### PR TITLE
Fix searching errors

### DIFF
--- a/lib/model/SearchResult.dart
+++ b/lib/model/SearchResult.dart
@@ -12,10 +12,10 @@ class SearchResult extends JsonObject {
   @JsonKey(name: "page_size", nullable: false, fromJson: JsonObject.parseInt)
   final int pageSize;
 
-  @JsonKey(name: "count", nullable: false)
+  @JsonKey(name: "count", nullable: false, fromJson: JsonObject.parseInt)
   final int count;
 
-  @JsonKey(name: "skip", nullable: false)
+  @JsonKey(name: "skip", nullable: false, fromJson: JsonObject.parseInt)
   final int skip;
 
   @JsonKey(includeIfNull: false)

--- a/lib/model/SearchResult.g.dart
+++ b/lib/model/SearchResult.g.dart
@@ -10,8 +10,8 @@ SearchResult _$SearchResultFromJson(Map<String, dynamic> json) {
   return SearchResult(
     page: JsonObject.parseInt(json['page']),
     pageSize: JsonObject.parseInt(json['page_size']),
-    count: json['count'] as int,
-    skip: json['skip'] as int,
+    count: JsonObject.parseInt(json['count']),
+    skip: JsonObject.parseInt(json['skip']),
     products: (json['products'] as List)
         ?.map((e) =>
             e == null ? null : Product.fromJson(e as Map<String, dynamic>))

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -18,6 +18,7 @@ import 'model/SearchResult.dart';
 import 'model/Status.dart';
 import 'model/User.dart';
 
+import 'model/parameter/OutputFormat.dart';
 import 'utils/HttpHelper.dart';
 import 'utils/ProductHelper.dart';
 
@@ -147,11 +148,15 @@ class OpenFoodAPIClient {
   /// Query the language specific host from OpenFoodFacts.
   static Future<SearchResult> searchProducts(
       User user, ProductSearchQueryConfiguration config) async {
+    const outputFormat = OutputFormat(format: Format.JSON);
+    var queryParameters = config.getParametersMap();
+    queryParameters[outputFormat.getName()] = outputFormat.getValue();
+
     var searchUri = Uri(
         scheme: URI_SCHEME,
         host: URI_HOST,
         path: '/cgi/search.pl',
-        queryParameters: config.getParametersMap());
+        queryParameters: queryParameters);
 
     print("URI: " + searchUri.toString());
 


### PR DESCRIPTION
Hi,

First of all: I really like this project 😄 

I was trying to perform a search using `OpenFoodAPIClient.searchProducts` and saw that I got several parsing errors. This PR aims to solve that.

I tried the modifications locally and it worked as expected:
- the API gives back JSON
- there's no parsing error anymore when parsing `{ ..., "count": "49", ... }`

