### PR TITLE
Fix test instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Regarding this package, we accept pull requests as well feature requests.
 Execute the following command from the root of the repository to run the tests:
 
 ```
-flutter test
+flutter test test/
 ```
 
 ## How to use ?


### PR DESCRIPTION
The "addProductImage" tests assume that the working directory is the `test` folder.