### PR TITLE
Add kcal values in Nutriments

### DIFF
--- a/lib/model/Nutriments.dart
+++ b/lib/model/Nutriments.dart
@@ -43,6 +43,16 @@ class Nutriments extends JsonObject {
       fromJson: JsonObject.parseDouble)
   double energy;
   @JsonKey(
+      name: "energy-kcal",
+      includeIfNull: false,
+      fromJson: JsonObject.parseDouble)
+  double energyKcal;
+  @JsonKey(
+      name: "energy-kcal_100g",
+      includeIfNull: false,
+      fromJson: JsonObject.parseDouble)
+  double energyKcal100g;
+  @JsonKey(
       name: "carbohydrates_100g",
       includeIfNull: false,
       fromJson: JsonObject.parseDouble)
@@ -100,6 +110,12 @@ class Nutriments extends JsonObject {
       fromJson: UnitHelper.stringToUnit)
   Unit energyUnit;
 
+  @JsonKey(
+      name: "energy-kcal_unit",
+      includeIfNull: false,
+      fromJson: UnitHelper.stringToUnit)
+  Unit energyKcalUnit;
+
   Nutriments(
       {this.salt,
       this.fiber,
@@ -109,6 +125,8 @@ class Nutriments extends JsonObject {
       this.proteins,
       this.novaGroup,
       this.energy,
+      this.energyKcal,
+      this.energyKcal100g,
       this.carbohydrates,
       this.saltServing,
       this.fiberServing,
@@ -119,6 +137,7 @@ class Nutriments extends JsonObject {
       this.novaGroupServing,
       this.energyServing,
       this.carbohydratesServing,
+      this.energyKcalUnit,
       this.energyUnit});
 
   factory Nutriments.fromJson(Map<String, dynamic> json) =>

--- a/lib/model/Nutriments.g.dart
+++ b/lib/model/Nutriments.g.dart
@@ -16,6 +16,8 @@ Nutriments _$NutrimentsFromJson(Map<String, dynamic> json) {
     proteins: JsonObject.parseDouble(json['proteins_100g']),
     novaGroup: JsonObject.parseInt(json['nova-group_100g']),
     energy: JsonObject.parseDouble(json['energy_100g']),
+    energyKcal100g: JsonObject.parseDouble(json['energy-kcal_100g']),
+    energyKcal: JsonObject.parseDouble(json['energy-kcal']),
     carbohydrates: JsonObject.parseDouble(json['carbohydrates_100g']),
     saltServing: JsonObject.parseDouble(json['salt_serving']),
     fiberServing: JsonObject.parseDouble(json['fiber_serving']),
@@ -26,6 +28,7 @@ Nutriments _$NutrimentsFromJson(Map<String, dynamic> json) {
     novaGroupServing: JsonObject.parseInt(json['nova-group_serving']),
     energyServing: JsonObject.parseDouble(json['energy_serving']),
     carbohydratesServing: JsonObject.parseDouble(json['carbohydrates_serving']),
+    energyKcalUnit: UnitHelper.stringToUnit(json['energy-kcal_unit'] as String),
     energyUnit: UnitHelper.stringToUnit(json['energy_unit'] as String),
   );
 }
@@ -47,6 +50,7 @@ Map<String, dynamic> _$NutrimentsToJson(Nutriments instance) {
   writeNotNull('proteins_100g', instance.proteins);
   writeNotNull('nova-group_100g', instance.novaGroup);
   writeNotNull('energy_100g', instance.energy);
+  writeNotNull('energy-kcal_100g', instance.energyKcal100g);
   writeNotNull('carbohydrates_100g', instance.carbohydrates);
   writeNotNull('salt_serving', instance.saltServing);
   writeNotNull('fiber_serving', instance.fiberServing);
@@ -57,6 +61,7 @@ Map<String, dynamic> _$NutrimentsToJson(Nutriments instance) {
   writeNotNull('nova-group_serving', instance.novaGroupServing);
   writeNotNull('energy_serving', instance.energyServing);
   writeNotNull('carbohydrates_serving', instance.carbohydratesServing);
+  writeNotNull('energy-kcal_unit', _$UnitEnumMap[instance.energyKcalUnit]);
   writeNotNull('energy_unit', _$UnitEnumMap[instance.energyUnit]);
   return val;
 }


### PR DESCRIPTION
Hello,

I made the changes to include the `kcal` information into the Nutriment class.
It has been discussed in issue #44 

I am not familiar with OpenFoodFacts, so I am not sure if I used the good fields: `energy-kcal_100g` vs `energy-kcal`...

All tests passe, except for one:

```
00:02 +15 -1: ~/openfoodfacts-dart/test/api_getProductRaw_test.dart: OpenFoodAPIClient get raw products get product test 1 [E]                                                                                                                           
  Expected: <15>
    Actual: <18>
  
  package:test_api                                   expect
  package:flutter_test/src/widget_tester.dart 348:3  expect
  test/api_getProductRaw_test.dart 37:7              main.<fn>.<fn>
```

However, this one seems to be broken on master too.

Thank you,
Adrien

