### PR TITLE
Fix parsing of imageId

### DIFF
--- a/lib/model/Status.dart
+++ b/lib/model/Status.dart
@@ -12,7 +12,7 @@ class Status extends JsonObject {
 
   final String error;
 
-  @JsonKey(name: 'imgid')
+  @JsonKey(name: 'imgid', fromJson: JsonObject.parseInt)
   final int imageId;
 
   Status({

--- a/lib/model/Status.g.dart
+++ b/lib/model/Status.g.dart
@@ -11,7 +11,7 @@ Status _$StatusFromJson(Map<String, dynamic> json) {
     status: json['status'],
     statusVerbose: json['status_verbose'] as String,
     error: json['error'] as String,
-    imageId: json['imgid'] as int,
+    imageId: JsonObject.parseInt(json['imgid']),
   );
 }
 


### PR DESCRIPTION
Apparently the `imageId` is sometimes returned as a `String` so it's safer to parse it rather than casting it.