### PR TITLE
don't send NULL attributes via json 

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -215,7 +215,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.11+1"
+    version: "0.3.12+1"
   package_config:
     dependency: transitive
     description:

--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -27,7 +27,7 @@ class Product extends JsonObject {
   @JsonKey(name: 'product_name_fr', includeIfNull: false)
   String productNameFR;
   String brands;
-  @JsonKey(name: 'brands_tags')
+  @JsonKey(name: 'brands_tags', includeIfNull: false)
   List<String> brandsTags;
   @JsonKey(
       name: 'lang',
@@ -35,15 +35,16 @@ class Product extends JsonObject {
       fromJson: LanguageHelper.fromJson,
       includeIfNull: false)
   OpenFoodFactsLanguage lang;
+  @JsonKey(includeIfNull: false)
   String quantity;
-  @JsonKey(name: 'image_small_url')
+  @JsonKey(name: 'image_small_url', includeIfNull: false)
   String imgSmallUrl;
-  @JsonKey(name: 'serving_size')
+  @JsonKey(name: 'serving_size', includeIfNull: false)
   String servingSize;
   @JsonKey(
-      name: 'serving_quantity', fromJson: JsonHelper.servingQuantityFromJson)
+      name: 'serving_quantity', fromJson: JsonHelper.servingQuantityFromJson, includeIfNull: false)
   double servingQuantity;
-  @JsonKey(name: 'product_quantity')
+  @JsonKey(name: 'product_quantity', includeIfNull: false)
   dynamic packagingQuantity;
 
   /// cause nesting is sooo cool ;)

--- a/lib/model/Product.g.dart
+++ b/lib/model/Product.g.dart
@@ -87,13 +87,13 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('product_name_en', instance.productNameEN);
   writeNotNull('product_name_fr', instance.productNameFR);
   val['brands'] = instance.brands;
-  val['brands_tags'] = instance.brandsTags;
+  writeNotNull('brands_tags', instance.brandsTags);
   writeNotNull('lang', LanguageHelper.toJson(instance.lang));
-  val['quantity'] = instance.quantity;
-  val['image_small_url'] = instance.imgSmallUrl;
-  val['serving_size'] = instance.servingSize;
-  val['serving_quantity'] = instance.servingQuantity;
-  val['product_quantity'] = instance.packagingQuantity;
+  writeNotNull('quantity', instance.quantity);
+  writeNotNull('image_small_url', instance.imgSmallUrl);
+  writeNotNull('serving_size', instance.servingSize);
+  writeNotNull('serving_quantity', instance.servingQuantity);
+  writeNotNull('product_quantity', instance.packagingQuantity);
   writeNotNull('selected_images',
       JsonHelper.selectedImagesToJson(instance.selectedImages));
   writeNotNull('images', JsonHelper.imagesToJson(instance.images));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "7.0.0"
   analyzer:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.14"
+    version: "0.39.17"
   archive:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety"
   async_loader:
     dependency: "direct main"
     description:
@@ -49,7 +49,7 @@ packages:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety"
   build:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   build_runner_core:
     dependency: transitive
     description:
@@ -112,14 +112,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.2"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety"
   checked_yaml:
     dependency: transitive
     description:
@@ -133,28 +133,28 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.1"
+    version: "3.5.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.2"
   convert:
     dependency: transitive
     description:
@@ -189,7 +189,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.0-nullsafety"
   fixnum:
     dependency: transitive
     description:
@@ -227,7 +227,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0+3"
+    version: "0.14.0+4"
   http:
     dependency: "direct main"
     description:
@@ -297,14 +297,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.2"
   mime:
     dependency: transitive
     description:
@@ -339,21 +339,21 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.2"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
   pool:
     dependency: transitive
     description:
@@ -414,21 +414,21 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety"
   stream_transform:
     dependency: transitive
     description:
@@ -442,21 +442,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety"
   timing:
     dependency: transitive
     description:
@@ -470,14 +470,14 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.2"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.2"
   watcher:
     dependency: transitive
     description:
@@ -507,4 +507,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.10.0-0.0.dev <2.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   image: ^2.1.4
 
 dev_dependencies:
+  analyzer: ^0.39.17
   build_runner: ^1.10.1
   json_serializable: ^3.5.0
   flutter_test:

--- a/test/api_saveProduct_test.dart
+++ b/test/api_saveProduct_test.dart
@@ -13,11 +13,40 @@ void main() {
       HttpHelper().isTestMode = true;
     });
 
-    test('add new product test 1', () async {
+    String barcode_1 = "0048151623426";
+    String quantity_1 = "230g";
+    String servingSize_1 = "100g";
+    double servingQuantity_1 = 100;
+
+    void testProductResult1(ProductResult result) {
+      print("test product result");
+      expect(result != null, true);
+      expect(result.status, 1);
+      print("barcode: " + result.barcode);
+      expect(result.barcode, barcode_1);
+      expect(result.product != null, true);
+      expect(result.product.barcode, barcode_1);
+
+      expect(result.product.quantity != null, true);
+      print("quantity: " + result.product.quantity);
+      expect(result.product.quantity, quantity_1);
+
+      expect(result.product.servingQuantity != null, true);
+      print("servingQuantity: " + result.product.servingQuantity.toString());
+      expect(result.product.servingQuantity, servingQuantity_1);
+
+      expect(result.product.servingSize != null, true);
+      print("servingSize: " + result.product.servingSize);
+      expect(result.product.servingSize, servingSize_1);
+    }
+
+    test('save product test, set serving-size', () async {
       Product product = Product(
-          barcode: "0048151623426",
+          barcode: barcode_1,
           productName: "Maryland Choc Chip",
-          quantity: "230g",
+          quantity: quantity_1,
+          servingSize: servingSize_1,
+          servingQuantity: servingQuantity_1,
           lang: OpenFoodFactsLanguage.ENGLISH,
           brands: "Golden Cookies",
           nutrimentEnergyUnit: "kJ",
@@ -32,7 +61,31 @@ void main() {
       expect(status != null, true);
       expect(status.status, 1);
       expect(status.statusVerbose, "fields saved");
+
+      ProductQueryConfiguration configurations = ProductQueryConfiguration(
+          barcode_1,
+          language: OpenFoodFactsLanguage.ENGLISH,
+          fields: [ProductField.ALL]);
+      ProductResult result = await OpenFoodAPIClient.getProduct(configurations,
+          user: TestConstants.TEST_USER);
+
+      testProductResult1(result);
+
+      // save and get the existing product to test, if no attributes get lost
+      Product product2 = Product(
+          barcode: barcode_1,
+          productName: "Maryland Choc Chip");
+      Status status2 = await OpenFoodAPIClient.saveProduct(TestConstants.TEST_USER, product2);
+      expect(status2 != null, true);
+      expect(status2.status, 1);
+      expect(status2.statusVerbose, "fields saved");
+
+      ProductResult result2 = await OpenFoodAPIClient.getProduct(configurations,
+          user: TestConstants.TEST_USER);
+
+      testProductResult1(result2);
     });
+
 
     test('add new product test 2', () async {
       Product product = Product(


### PR DESCRIPTION
Hey guys :)

Christoph(cjk) reported yesterday via #general in slack the following issue:

> a few products I participated in were edited today by user grumpf ((app)Dart API - TIOLI), however it appears the app or API does put invalid data into the Serving size attribute (they are all "null" now)

I can confirm the issue. 
a null value or string "null" will be written, if no serving size attibute has been set.

I dismissed the idea to load ALL attributes before saving the product.
Instead I changed the json mapping to remove the attribute "serving_size" if it is null. This is the common way, we process other attributes, too.

`@JsonKey(name: 'serving_size', includeIfNull: false)
  String servingSize;`

I extended the test case in _api_saveProduct_test.dart_ to check if the servingSize attribute won't be overwritten anymore, while saving.