### PR TITLE
added field ecoscore_grade to product

### DIFF
--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -153,6 +153,9 @@ class Product extends JsonObject {
     toJson: JsonHelper.dateToTimestamp)
   DateTime lastModified;
 
+  @JsonKey(name: 'ecoscore_grade', includeIfNull: false)
+  String ecoscoreGrade;
+
   Product(
       {this.barcode,
       this.productName,
@@ -173,7 +176,8 @@ class Product extends JsonObject {
       this.additives,
       this.nutrientLevels,
       this.servingSize,
-      this.servingQuantity});
+      this.servingQuantity,
+      this.ecoscoreGrade});
 
   factory Product.fromJson(Map<String, dynamic> json) =>
       _$ProductFromJson(json);

--- a/lib/model/Product.g.dart
+++ b/lib/model/Product.g.dart
@@ -32,6 +32,7 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
     servingSize: json['serving_size'] as String,
     servingQuantity:
         JsonHelper.servingQuantityFromJson(json['serving_quantity']),
+    ecoscoreGrade: json['ecoscore_grade'] as String,
   )
     ..productNameFR = json['product_name_fr'] as String
     ..brandsTags =
@@ -69,7 +70,7 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
         (json['stores_tags'] as List)?.map((e) => e as String)?.toList()
     ..attributeGroups =
         AttributeGroups.fromJson(json['attribute_groups'] as List)
-    ..lastModified = JsonHelper.timestampToDate(json['last_modified_t'] as int);
+    ..lastModified = JsonHelper.timestampToDate(json['last_modified_t']);
 }
 
 Map<String, dynamic> _$ProductToJson(Product instance) {
@@ -129,5 +130,6 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
       'attribute_groups', AttributeGroups.toJson(instance.attributeGroups));
   writeNotNull(
       'last_modified_t', JsonHelper.dateToTimestamp(instance.lastModified));
+  writeNotNull('ecoscore_grade', instance.ecoscoreGrade);
   return val;
 }

--- a/lib/utils/ProductFields.dart
+++ b/lib/utils/ProductFields.dart
@@ -31,6 +31,8 @@ enum ProductField {
   ALLERGENS,
   ENVIRONMENT_IMPACT_LEVELS,
   ATTRIBUTE_GROUPS,
+  ECOSCORE_GRADE,
+  ECOSCORE_ALPHA,
   ALL
 }
 
@@ -132,6 +134,12 @@ extension ProductFieldExtension on ProductField {
         break;
       case ProductField.ATTRIBUTE_GROUPS:
         return "attribute_groups";
+        break;
+      case ProductField.ECOSCORE_GRADE:
+        return "ecoscore_grade";
+        break;
+      case ProductField.ECOSCORE_ALPHA:
+        return "ecoscore_alpha";
         break;
       default:
         return "";

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -379,6 +379,20 @@ void main() {
           result.product.ingredients.length.toString());
       assert(result.product.ingredientsText != null);
     });
+    
+    test('product ecoscore grade', () async {
+      String barcode = "5000112548167";
+      ProductQueryConfiguration configurations = ProductQueryConfiguration(
+          barcode,
+          language: OpenFoodFactsLanguage.ENGLISH,
+          fields: [ProductField.ECOSCORE_GRADE, ProductField.ECOSCORE_ALPHA]);
+      ProductResult result = await OpenFoodAPIClient.getProduct(configurations,
+          user: TestConstants.TEST_USER);
+
+      assert(result != null);
+      assert(result.product != null);
+      assert(result.product.ecoscoreGrade != null);
+    });
 
     test('product environment impact levels', () async {
       String barcode = "7613331814562";


### PR DESCRIPTION
Hi,

I have added the ecoscore_grade field to Product, which is currently only available when we query with ecoscore_alpha.
Adding this will allows apps (like the smooth app) to prepare the arrival of the ecoscore (which I'm really excited about).

If this is accepted, I will try to add ecoscore_data handling later.