### PR TITLE
allow anonymous photo upload

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -86,7 +86,10 @@ class OpenFoodAPIClient {
     var dataMap = new Map<String, String>();
     var fileMap = new Map<String, Uri>();
 
-    dataMap.addAll(user.toData());
+    // Images can be sent anonymously
+    if (user != null) {
+      dataMap.addAll(user.toData());
+    }
     dataMap.addAll(image.toData());
     fileMap.putIfAbsent(image.getImageDataKey(), () => image.imageUrl);
 


### PR DESCRIPTION
Allows passing a null value for the user, to upload product photos without an OFF account.

fixes #72