### PR TITLE
allow setting the country code cc field, #76

### DIFF
--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -4,9 +4,14 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductQueryConfiguration {
   String barcode;
   OpenFoodFactsLanguage language;
+  // Allow apps to directly provide the language code and country code without
+  // having to use the OpenFoodFactsLanguage helper.
+  String lc;
+  String cc;
   List<ProductField> fields;
 
-  ProductQueryConfiguration(this.barcode, {this.language, this.fields});
+  ProductQueryConfiguration(this.barcode,
+      {this.language, this.lc, this.cc, this.fields});
 
   List<String> getFieldsKeys() {
     List<String> result = List<String>();
@@ -23,6 +28,12 @@ class ProductQueryConfiguration {
 
     if (this.language != null) {
       result.putIfAbsent("lc", () => language.code);
+    } else if (this.lc != null) {
+      result.putIfAbsent("lc", () => lc);
+    }
+
+    if (this.cc != null) {
+      result.putIfAbsent("cc", () => cc);
     }
 
     if (this.fields != null) {
@@ -35,20 +46,22 @@ class ProductQueryConfiguration {
       }
 
       if (!ignoreFieldsFilter) {
-
         String value = '';
 
-        if(fields.contains(ProductField.CATEGORIES_TAGS_TRANSLATED)) {
+        if (fields.contains(ProductField.CATEGORIES_TAGS_TRANSLATED)) {
           fields.remove(ProductField.CATEGORIES_TAGS_TRANSLATED);
-          value = "$value,${ProductField.CATEGORIES_TAGS_TRANSLATED.key}${language.code}";
+          value =
+              "$value,${ProductField.CATEGORIES_TAGS_TRANSLATED.key}${language.code}";
         }
 
-        if(fields.contains(ProductField.LABELS_TAGS_TRANSLATED)) {
+        if (fields.contains(ProductField.LABELS_TAGS_TRANSLATED)) {
           fields.remove(ProductField.LABELS_TAGS_TRANSLATED);
-          value = "$value,${ProductField.LABELS_TAGS_TRANSLATED.key}${language.code}";
+          value =
+              "$value,${ProductField.LABELS_TAGS_TRANSLATED.key}${language.code}";
         }
 
-        result.putIfAbsent('fields', () => "$value,${this.getFieldsKeys().join(',')}");
+        result.putIfAbsent(
+            'fields', () => "$value,${this.getFieldsKeys().join(',')}");
       }
     }
 


### PR DESCRIPTION
This is to allow app to pass directly the country code and language code parameters in the cc and lc fields.

It would probably be a good thing to add an OpenFoodFactsCountry helper, similar to the OpenFoodFactsLanguage helper.

I'd like to refactor the OpenFoodFactsLanguage with a map first, to replace the switch statement and the for loop to get the language corresponding to a code.