### PR TITLE
fix/#90_2 - +10 points - conditional imports for "not web" and "web" apps

### DIFF
--- a/lib/utils/HttpHelper.dart
+++ b/lib/utils/HttpHelper.dart
@@ -1,7 +1,7 @@
+import 'package:openfoodfacts/utils/UriReader.dart';
 import 'package:path/path.dart';
 import 'package:http/http.dart' as http;
 
-import 'dart:io';
 import 'dart:async';
 import 'dart:convert';
 
@@ -61,7 +61,7 @@ class HttpHelper {
 
     // add all file entries to the request
     for (MapEntry<String, Uri> entry in files.entries) {
-      List<int> fileBytes = await File.fromUri(entry.value).readAsBytes();
+      List<int> fileBytes = await UriReader.instance.readAsBytes(entry.value);
       var multipartFile = http.MultipartFile.fromBytes(entry.key, fileBytes,
           filename: basename(entry.value.toString()));
       request.files.add(multipartFile);

--- a/lib/utils/UriReader.dart
+++ b/lib/utils/UriReader.dart
@@ -1,0 +1,35 @@
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+import 'UriReader_stub.dart'
+    if (dart.library.io) 'UriReader_io.dart'
+    if (dart.library.js) 'UriReader_js.dart';
+
+/// Abstract reader of URI data, declined in "not web" and "web" versions
+abstract class UriReader {
+  static UriReader _instance;
+
+  static UriReader get instance {
+    _instance ??= getUriReaderInstance();
+    return _instance;
+  }
+
+  Future<List<int>> readAsBytes(final Uri uri) async {
+    final Uint8List content = uri.data?.contentAsBytes();
+    if (content != null) {
+      print('size=====${content.length}');
+      return content;
+    }
+    switch (uri.scheme) {
+      case 'file':
+        return await readFileAsBytes(uri);
+      case 'http':
+      case 'https':
+        http.Response response = await http.get(uri);
+        return response?.bodyBytes;
+    }
+    throw Exception('Unknown uri scheme for $uri');
+  }
+
+  Future<List<int>> readFileAsBytes(final Uri uri);
+}

--- a/lib/utils/UriReader.dart
+++ b/lib/utils/UriReader.dart
@@ -17,7 +17,6 @@ abstract class UriReader {
   Future<List<int>> readAsBytes(final Uri uri) async {
     final Uint8List content = uri.data?.contentAsBytes();
     if (content != null) {
-      print('size=====${content.length}');
       return content;
     }
     switch (uri.scheme) {

--- a/lib/utils/UriReader_io.dart
+++ b/lib/utils/UriReader_io.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+import 'UriReader.dart';
+
+UriReader getUriReaderInstance() => UriReaderIo();
+
+/// Reader of URI data, "not web" version (i.e. supports `File`)
+class UriReaderIo extends UriReader {
+  @override
+  Future<List<int>> readFileAsBytes(final Uri uri) async =>
+      await File.fromUri(uri).readAsBytes();
+}

--- a/lib/utils/UriReader_js.dart
+++ b/lib/utils/UriReader_js.dart
@@ -1,0 +1,10 @@
+import 'UriReader.dart';
+
+UriReader getUriReaderInstance() => UriReaderJs();
+
+/// Reader of URI data, "web" version
+class UriReaderJs extends UriReader {
+  @override
+  Future<List<int>> readFileAsBytes(final Uri uri) async =>
+      throw Exception('Cannot read files in web version');
+}

--- a/lib/utils/UriReader_stub.dart
+++ b/lib/utils/UriReader_stub.dart
@@ -1,0 +1,5 @@
+import 'UriReader.dart';
+
+/// Needed for conditional imports
+UriReader getUriReaderInstance() =>
+    throw UnsupportedError('Cannot create the URI reader!');


### PR DESCRIPTION
Web is now supported!

New files:
* `UriReader.dart`: Abstract reader of URI data, declined in "not web" and "web" versions
* `UriReader_io.dart`: Reader of URI data, "not web" version (i.e. supports `File`)
* `UriReader_js.dart`: Reader of URI data, "web" version
* `UriReader_stub.dart`: Needed for conditional imports

Impacted file:
* `HttpHelper.dart`: now using a UriReader