### PR TITLE
fix_3/#90 - support of relative files in UriReader

### DIFF
--- a/lib/utils/UriReader.dart
+++ b/lib/utils/UriReader.dart
@@ -20,11 +20,12 @@ abstract class UriReader {
       return content;
     }
     switch (uri.scheme) {
+      case '':
       case 'file':
         return await readFileAsBytes(uri);
       case 'http':
       case 'https':
-        http.Response response = await http.get(uri);
+        final http.Response response = await http.get(uri);
         return response?.bodyBytes;
     }
     throw Exception('Unknown uri scheme for $uri');

--- a/test/api_addProductImage_test.dart
+++ b/test/api_addProductImage_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/model/SendImage.dart';
@@ -16,7 +14,7 @@ void main() {
         lang: OpenFoodFactsLanguage.GERMAN,
         barcode: "4250752200784",
         imageField: ImageField.FRONT,
-        imageUrl: File("test/test_assets/front_de.jpg").absolute.uri,
+        imageUrl: Uri.file("test/test_assets/front_de.jpg"),
       );
       Status status = await OpenFoodAPIClient.addProductImage(
           TestConstants.PROD_USER, image,
@@ -32,7 +30,7 @@ void main() {
         lang: OpenFoodFactsLanguage.ENGLISH,
         barcode: "0048151623426",
         imageField: ImageField.INGREDIENTS,
-        imageUrl: File("test/test_assets/ingredients_en.jpg").absolute.uri,
+        imageUrl: Uri.file("test/test_assets/ingredients_en.jpg"),
       );
       Status status = await OpenFoodAPIClient.addProductImage(
           TestConstants.PROD_USER, image,
@@ -48,7 +46,7 @@ void main() {
         lang: OpenFoodFactsLanguage.DANISH,
         barcode: "5722970900207",
         imageField: ImageField.FRONT,
-        imageUrl: File("test/test_assets/corn_da.jpg").absolute.uri,
+        imageUrl: Uri.file("test/test_assets/corn_da.jpg"),
       );
       Status status = await OpenFoodAPIClient.addProductImage(
           TestConstants.PROD_USER, image,

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:openfoodfacts/model/AttributeGroup.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/EcoscoreData.dart';
@@ -42,7 +40,7 @@ void main() {
         lang: OpenFoodFactsLanguage.GERMAN,
         barcode: barcode,
         imageField: ImageField.FRONT,
-        imageUrl: File("test/test_assets/front_coca_light_de.jpg").absolute.uri,
+        imageUrl: Uri.file("test/test_assets/front_coca_light_de.jpg"),
       );
       await OpenFoodAPIClient.addProductImage(
           TestConstants.TEST_USER, fontImage,

--- a/test/api_ocrIngredients_test.dart
+++ b/test/api_ocrIngredients_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/model/OcrIngredientsResult.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -99,7 +97,7 @@ void main() {
         lang: OpenFoodFactsLanguage.FRENCH,
         barcode: "3613042717385",
         imageField: ImageField.INGREDIENTS,
-        imageUrl: File("test/test_assets/ingredient_3613042717385.jpg").absolute.uri,
+        imageUrl: Uri.file("test/test_assets/ingredient_3613042717385.jpg"),
       );
       await OpenFoodAPIClient.addProductImage(TestConstants.PROD_USER, image,
           queryType: QueryType.PROD);


### PR DESCRIPTION
Impacted files:
* `api_addProductImage_test.dart`: `File`s are now relative
* `api_getProduct_test.dart`: `File`s are now relative
* `api_ocrIngredients_test.dart`: `File`s are now relative
* `UriReader.dart`: now support relative `File`s