### PR TITLE
fix_4/#90 - better space management and code readability for SearchResult

### DIFF
--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -199,8 +199,20 @@ class Product extends JsonObject {
       this.ecoscoreGrade,
       this.ecoscoreScore});
 
-  factory Product.fromJson(Map<String, dynamic> json) =>
-      _$ProductFromJson(json);
+  factory Product.fromJson(Map<String, dynamic> json) {
+    final Product result = _$ProductFromJson(json);
+    for (final String key in json.keys) {
+      if (key.startsWith('categories_tags_')) {
+        result.categoriesTagsTranslated =
+            (json[key] as List)?.map((e) => e as String)?.toList();
+      }
+      if (key.startsWith('labels_tags_')) {
+        result.labelsTagsTranslated =
+            (json[key] as List)?.map((e) => e as String)?.toList();
+      }
+    }
+    return result;
+  }
 
   @override
   Map<String, dynamic> toJson() => _$ProductToJson(this);

--- a/lib/model/SearchResult.dart
+++ b/lib/model/SearchResult.dart
@@ -18,33 +18,19 @@ class SearchResult extends JsonObject {
   @JsonKey(name: "skip", fromJson: JsonObject.parseInt)
   final int skip;
 
-  @JsonKey(name: "products_json", includeIfNull: false)
-  final List<dynamic> jsonProducts;
-
-  @JsonKey(includeIfNull: false)
+  @JsonKey(name: "products", includeIfNull: false)
   final List<Product> products;
 
-  const SearchResult(
-      {this.page,
-      this.pageSize,
-      this.count,
-      this.skip,
-      this.jsonProducts,
-      this.products});
+  const SearchResult({
+    this.page,
+    this.pageSize,
+    this.count,
+    this.skip,
+    this.products,
+  });
 
-  factory SearchResult.fromJson(Map<String, dynamic> json) {
-    return SearchResult(
-      page: JsonObject.parseInt(json['page']),
-      pageSize: JsonObject.parseInt(json['page_size']),
-      count: JsonObject.parseInt(json['count']),
-      skip: JsonObject.parseInt(json['skip']),
-      jsonProducts: json['products'],
-      products: (json['products'] as List)
-          ?.map((e) =>
-              e == null ? null : Product.fromJson(e as Map<String, dynamic>))
-          ?.toList(),
-    );
-  }
+  factory SearchResult.fromJson(Map<String, dynamic> json) =>
+      _$SearchResultFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$SearchResultToJson(this);

--- a/lib/model/SearchResult.g.dart
+++ b/lib/model/SearchResult.g.dart
@@ -12,7 +12,6 @@ SearchResult _$SearchResultFromJson(Map<String, dynamic> json) {
     pageSize: JsonObject.parseInt(json['page_size']),
     count: JsonObject.parseInt(json['count']),
     skip: JsonObject.parseInt(json['skip']),
-    jsonProducts: json['products_json'] as List,
     products: (json['products'] as List)
         ?.map((e) =>
             e == null ? null : Product.fromJson(e as Map<String, dynamic>))
@@ -34,7 +33,6 @@ Map<String, dynamic> _$SearchResultToJson(SearchResult instance) {
     }
   }
 
-  writeNotNull('products_json', instance.jsonProducts);
   writeNotNull('products', instance.products);
   return val;
 }

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -8,7 +8,6 @@ import 'package:openfoodfacts/model/OcrIngredientsResult.dart';
 import 'package:openfoodfacts/utils/OcrField.dart';
 import 'package:openfoodfacts/utils/PnnsGroupQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
-import 'package:openfoodfacts/utils/ProductFields.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 
 import 'model/Insight.dart';
@@ -161,13 +160,6 @@ class OpenFoodAPIClient {
     if (result.product != null) {
       ProductHelper.removeImages(result.product, configuration.language);
       ProductHelper.createImageUrls(result.product, queryType: queryType);
-      if (configuration.fields
-              .contains(ProductField.CATEGORIES_TAGS_TRANSLATED) ||
-          configuration.fields.contains(ProductField.LABELS_TAGS_TRANSLATED) ||
-          configuration.fields.contains(ProductField.ALL)) {
-        ProductHelper.addTranslatedFields(result.product,
-            json.decode(response.body)['product'], configuration.language);
-      }
     }
 
     return result;
@@ -194,20 +186,9 @@ class OpenFoodAPIClient {
         .doGetRequest(searchUri, user: user, queryType: queryType);
     var result = SearchResult.fromJson(json.decode(response.body));
 
-    if (configuration.fields
-            .contains(ProductField.CATEGORIES_TAGS_TRANSLATED) ||
-        configuration.fields.contains(ProductField.LABELS_TAGS_TRANSLATED) ||
-        configuration.fields.contains(ProductField.ALL)) {
-      result.products.asMap().forEach((index, product) {
-        ProductHelper.removeImages(product, configuration.language);
-        ProductHelper.addTranslatedFields(product,
-            result.jsonProducts.elementAt(index), configuration.language);
-      });
-    } else {
-      result.products.asMap().forEach((index, product) {
-        ProductHelper.removeImages(product, configuration.language);
-      });
-    }
+    result.products.asMap().forEach((index, product) {
+      ProductHelper.removeImages(product, configuration.language);
+    });
 
     return result;
   }
@@ -230,20 +211,9 @@ class OpenFoodAPIClient {
         .doGetRequest(searchUri, user: user, queryType: queryType);
     var result = SearchResult.fromJson(json.decode(response.body));
 
-    if (configuration.fields
-            .contains(ProductField.CATEGORIES_TAGS_TRANSLATED) ||
-        configuration.fields.contains(ProductField.LABELS_TAGS_TRANSLATED) ||
-        configuration.fields.contains(ProductField.ALL)) {
-      result.products.asMap().forEach((index, product) {
-        ProductHelper.removeImages(product, configuration.language);
-        ProductHelper.addTranslatedFields(product,
-            result.jsonProducts.elementAt(index), configuration.language);
-      });
-    } else {
-      result.products.asMap().forEach((index, product) {
-        ProductHelper.removeImages(product, configuration.language);
-      });
-    }
+    result.products.asMap().forEach((index, product) {
+      ProductHelper.removeImages(product, configuration.language);
+    });
 
     return result;
   }

--- a/lib/utils/ProductHelper.dart
+++ b/lib/utils/ProductHelper.dart
@@ -34,6 +34,7 @@ class ProductHelper {
     }
   }
 
+  @deprecated
   static void addTranslatedFields(Product product, Map<String, dynamic> source,
       OpenFoodFactsLanguage language) {
     product.categoriesTagsTranslated =


### PR DESCRIPTION
Impacted files:
* `openfoodfacts.dart`: removed any reference to translated fields, that are now automatically computed
* `Product.dart`: automatically computed the translated categories and labels
* `ProductHelper.dart`: deprecated the method to translate fields, which is automatic now
* `SearchResult.dart`: removed the confusing and space-consuming raw `jsonProducts` field; let the `fromJson` method point to the json annotation generated method
* `SearchResult.g.dart`: removed the confusing and space-consuming raw `jsonProducts` field