### PR TITLE
Web support for more Pub Points

### DIFF
--- a/lib/utils/UriReader_io.dart
+++ b/lib/utils/UriReader_io.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'package:universal_io/io.dart';
 import 'UriReader.dart';
 
 UriReader getUriReaderInstance() => UriReaderIo();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   http: ^0.12.0
   path: ^1.7.0
   image: ^2.1.4
+  universal_io: ^1.0.2
 
 dev_dependencies:
   analyzer: ^0.39.17


### PR DESCRIPTION
For #90
We used `dart:io` which is not compatible with web. I switched to a third party package [universal_io ](https://pub.dev/packages/universal_io) which works the same but supports web.


> Support multiple platforms
> 10/20 points: Supports 2 of 3 possible platforms (iOS, Android, Web)
> 
> Consider supporting multiple platforms:
> Package not compatible with runtime flutter-web on Web
> 
> Because:
> 
>     package:openfoodfacts/openfoodfacts.dart that imports:
>     package:openfoodfacts/utils/HttpHelper.dart that imports:
>     dart:io



