### PR TITLE
Upgraded dependencies

### DIFF
--- a/lib/utils/HttpHelper.dart
+++ b/lib/utils/HttpHelper.dart
@@ -24,7 +24,7 @@ class HttpHelper {
   /// By default the query will hit the PROD DB
   Future<http.Response> doGetRequest(Uri uri,
       {User user, QueryType queryType = QueryType.PROD}) async {
-    http.Response response = await http.get(uri.toString(),
+    http.Response response = await http.get(uri,
         headers: _buildHeaders(user,
             isTestModeActive: queryType == QueryType.PROD ? false : true));
 
@@ -38,7 +38,7 @@ class HttpHelper {
       Uri uri, Map<String, String> body, User user,
       {QueryType queryType = QueryType.PROD}) async {
     http.Response response = await http.post(
-      uri.toString(),
+      uri,
       headers: _buildHeaders(user,
           isTestModeActive: queryType == QueryType.PROD ? false : true),
       body: body,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,16 +18,16 @@ environment:
   sdk: '>=2.10.5 <3.0.0'
 
 dependencies:
-  json_annotation: ^3.1.1
-  http: ^0.12.2
-  path: ^1.7.0
-  image: ^2.1.19
+  json_annotation: ^4.0.0
+  http: ^0.13.0
+  path: ^1.8.0
+  image: ^3.0.1
 
 dev_dependencies:
-  analyzer: ^0.41.2
-  build_runner: ^1.11.1
-  json_serializable: ^3.5.1
-  pedantic: ^1.9.2
+  analyzer: ^1.1.0
+  build_runner: ^1.11.5
+  json_serializable: ^4.0.2
+  pedantic: ^1.11.0
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Upgraded all the dependencies. The only one not supporting null safety is `build_runner `(dev_dependencies)

We have 7x `'nullable' is deprecated and shouldn't be used. Has no effect. (deprecated_member_use at [openfoodfacts] lib\model\Ingredient.dart:12` in the `@JsonKey()`. I left them in, for clearity when switching to null safety