### PR TITLE
API should not require a user being passed when searching products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.0.1-beta] - 08.03.2021
+- API method for searching products does not require a user being passed
+
 ## [1.0.0-beta] - 07.03.2021
 - Migrated SDK to null safety
 - Updated test instructions in README.md

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -160,7 +160,7 @@ class OpenFoodAPIClient {
   /// Query the language specific host from OpenFoodFacts.
   /// By default the query will hit the PROD DB
   static Future<SearchResult> searchProducts(
-      User user, ProductSearchQueryConfiguration configuration,
+      User? user, ProductSearchQueryConfiguration configuration,
       {QueryType queryType = QueryType.PROD}) async {
     const outputFormat = OutputFormat(format: Format.JSON);
     var queryParameters = configuration.getParametersMap();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openfoodfacts
 description: Dart package for the Open Food Facts API, a food products database made by everyone, for everyone.
-version: 1.0.0-beta
+version: 1.0.1-beta
 #authors:
 #- Alexander Schacht <grumpf@gmx.de>
 #- Primaël Quémerais <primael@reefind.com>


### PR DESCRIPTION
Post null safety migration fix.