### PR TITLE
Add 'vegan', 'vegetarian' and 'fromPalmOil' fields to the Ingredient class

### DIFF
--- a/lib/model/Ingredient.dart
+++ b/lib/model/Ingredient.dart
@@ -3,6 +3,8 @@ import '../interface/JsonObject.dart';
 
 part 'Ingredient.g.dart';
 
+enum IngredientSpecialPropertyStatus { POSITIVE, NEGATIVE, MAYBE, IGNORE }
+
 @JsonSerializable()
 class Ingredient extends JsonObject {
   @JsonKey(includeIfNull: false, fromJson: JsonObject.parseInt)
@@ -14,13 +16,78 @@ class Ingredient extends JsonObject {
   @JsonKey(includeIfNull: false, fromJson: JsonObject.parseDouble)
   double? percent;
 
+  @JsonKey(
+      includeIfNull: false,
+      fromJson: ingredientSpecialPropertyStatusFromJson,
+      toJson: ingredientSpecialPropertyStatusToJson)
+  IngredientSpecialPropertyStatus? vegan;
+
+  @JsonKey(
+      includeIfNull: false,
+      fromJson: ingredientSpecialPropertyStatusFromJson,
+      toJson: ingredientSpecialPropertyStatusToJson)
+  IngredientSpecialPropertyStatus? vegetarian;
+
+  @JsonKey(
+      name: 'from_palm_oil',
+      includeIfNull: false,
+      fromJson: ingredientSpecialPropertyStatusFromJson,
+      toJson: ingredientSpecialPropertyStatusToJson)
+  IngredientSpecialPropertyStatus? fromPalmOil;
+
   bool? bold;
 
-  Ingredient({this.rank, this.id, this.text, this.percent, this.bold = false});
+  Ingredient(
+      {this.rank,
+      this.id,
+      this.text,
+      this.percent,
+      this.vegan,
+      this.vegetarian,
+      this.fromPalmOil,
+      this.bold = false});
 
   factory Ingredient.fromJson(Map<String, dynamic> json) =>
       _$IngredientFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$IngredientToJson(this);
+}
+
+IngredientSpecialPropertyStatus? ingredientSpecialPropertyStatusFromJson(
+    dynamic json) {
+  if (json == null || json is! String) {
+    return null;
+  }
+  switch (json) {
+    case 'yes':
+      return IngredientSpecialPropertyStatus.POSITIVE;
+    case 'no':
+      return IngredientSpecialPropertyStatus.NEGATIVE;
+    case 'maybe':
+      return IngredientSpecialPropertyStatus.MAYBE;
+    case 'ignore':
+      return IngredientSpecialPropertyStatus.IGNORE;
+    default:
+      return null;
+  }
+}
+
+String? ingredientSpecialPropertyStatusToJson(
+    IngredientSpecialPropertyStatus? status) {
+  if (status == null) {
+    return null;
+  }
+  switch (status) {
+    case IngredientSpecialPropertyStatus.POSITIVE:
+      return 'yes';
+    case IngredientSpecialPropertyStatus.NEGATIVE:
+      return 'no';
+    case IngredientSpecialPropertyStatus.MAYBE:
+      return 'maybe';
+    case IngredientSpecialPropertyStatus.IGNORE:
+      return 'ignore';
+    default:
+      throw Exception('New enum type is not handled: $status');
+  }
 }

--- a/lib/model/Ingredient.g.dart
+++ b/lib/model/Ingredient.g.dart
@@ -12,6 +12,9 @@ Ingredient _$IngredientFromJson(Map<String, dynamic> json) {
     id: json['id'] as String?,
     text: json['text'] as String?,
     percent: JsonObject.parseDouble(json['percent']),
+    vegan: ingredientSpecialPropertyStatusFromJson(json['vegan']),
+    vegetarian: ingredientSpecialPropertyStatusFromJson(json['vegetarian']),
+    fromPalmOil: ingredientSpecialPropertyStatusFromJson(json['from_palm_oil']),
     bold: json['bold'] as bool?,
   );
 }
@@ -29,6 +32,11 @@ Map<String, dynamic> _$IngredientToJson(Ingredient instance) {
   writeNotNull('id', instance.id);
   val['text'] = instance.text;
   writeNotNull('percent', instance.percent);
+  writeNotNull('vegan', ingredientSpecialPropertyStatusToJson(instance.vegan));
+  writeNotNull(
+      'vegetarian', ingredientSpecialPropertyStatusToJson(instance.vegetarian));
+  writeNotNull('from_palm_oil',
+      ingredientSpecialPropertyStatusToJson(instance.fromPalmOil));
   val['bold'] = instance.bold;
   return val;
 }

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -739,5 +739,29 @@ void main() {
               .url,
           'https://static.openfoodfacts.net/images/products/500/011/254/8167/ingredients_de.7.400.jpg');
     });
+
+    test(
+        'vegan, vegetarian and palm oil ingredients of Danish Butter Cookies & Chocolate Chip Cookies',
+        () async {
+      String barcode = '5701184005007';
+      ProductQueryConfiguration configurations = ProductQueryConfiguration(
+          barcode,
+          language: OpenFoodFactsLanguage.GERMAN,
+          fields: [ProductField.ALL]);
+      ProductResult result = await OpenFoodAPIClient.getProduct(configurations,
+          user: TestConstants.TEST_USER, queryType: QueryType.TEST);
+
+      final lecithin = result.product!.ingredients!
+          .firstWhere((ingredient) => ingredient.text == 'Lecithin');
+      expect(lecithin.vegan, IngredientSpecialPropertyStatus.MAYBE);
+      expect(lecithin.vegetarian, IngredientSpecialPropertyStatus.MAYBE);
+      expect(lecithin.fromPalmOil, null);
+
+      final vegetableFat = result.product!.ingredients!
+          .firstWhere((ingredient) => ingredient.text == 'Pflanzenfett');
+      expect(vegetableFat.vegan, IngredientSpecialPropertyStatus.POSITIVE);
+      expect(vegetableFat.vegetarian, IngredientSpecialPropertyStatus.POSITIVE);
+      expect(vegetableFat.fromPalmOil, IngredientSpecialPropertyStatus.MAYBE);
+    });
   });
 }


### PR DESCRIPTION
Adding 'vegan', 'vegetarian' and 'fromPalmOil' fields to the Ingredient class (for #125).

At first I wanted to use existing enums in `IngredientsAnalysisTags`, but they seem to be not very suitable for the purpose:
- They don't have an `ignore` value and it doesn't make sense for them to have such a value (e.g. a product cannot have an "ignore" vegan status).
- I would have to create 6 distinct `toJson` and `fromJson` functions for 3 distinct enums, which is a lot of boilerplate code.