### PR TITLE
fix image upload, fixes #134

### DIFF
--- a/lib/model/ProductImage.dart
+++ b/lib/model/ProductImage.dart
@@ -2,12 +2,12 @@ import 'package:openfoodfacts/utils/LanguageHelper.dart';
 
 enum ImageField { FRONT, INGREDIENTS, NUTRITION, PACKAGING, OTHER }
 
-extension ImageFieldExtension on ImageField? {
+extension ImageFieldExtension on ImageField {
   String get value {
     return getValue(this);
   }
 
-  static String getValue(ImageField? field) {
+  static String getValue(ImageField field) {
     switch (field) {
       case ImageField.FRONT:
         return 'front';
@@ -114,9 +114,10 @@ extension ImageSizeExtension on ImageSize? {
 /// The url to a specific product image.
 /// Categorized by content type, size and language
 class ProductImage {
-  ProductImage({this.field, this.size, this.language, this.url, this.rev});
+  ProductImage(
+      {required this.field, this.size, this.language, this.url, this.rev});
 
-  final ImageField? field;
+  final ImageField field;
   final ImageSize? size;
   final OpenFoodFactsLanguage? language;
   String? url;

--- a/lib/model/SendImage.dart
+++ b/lib/model/SendImage.dart
@@ -7,49 +7,32 @@ class SendImage extends JsonObject {
   OpenFoodFactsLanguage? lang;
 
   // ignored for json
-  Uri? imageUrl;
+  Uri imageUrl;
 
-  String? barcode;
+  String barcode;
 
   ImageField imageField;
 
   SendImage({
     this.lang,
-    this.barcode,
-    this.imageUrl,
+    required this.barcode,
+    required this.imageUrl,
     this.imageField = ImageField.OTHER,
   });
 
   /// the json key depending on the image field of this object.
-  String? getImageDataKey() {
-    switch (imageField) {
-      case ImageField.FRONT:
-        return 'imgupload_front';
-      case ImageField.INGREDIENTS:
-        return 'imgupload_ingredients';
-      case ImageField.NUTRITION:
-        return 'imgupload_nutrition';
-      case ImageField.OTHER:
-        return 'imgupload_other';
-      default:
-        return null;
+  String getImageDataKey() {
+    String imageDataKey = 'imgupload_' + imageField.value;
+    if (lang != null) {
+      imageDataKey += '_' + lang.code;
     }
-  }
-
-  factory SendImage.fromJson(Map<String, dynamic> json) {
-    ImageField imageField = ImageFieldExtension.getType(json['imagefield']);
-
-    return SendImage(
-      lang: LanguageHelper.fromJson(json['lang']),
-      barcode: json['code'] as String?,
-      imageField: imageField,
-    );
+    return imageDataKey;
   }
 
   @override
   Map<String, dynamic> toJson() {
     return <String, dynamic>{
-      'lang': lang,
+      'lc': lang.code,
       'code': barcode,
       'imagefield': imageField.value
     };

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -93,7 +93,7 @@ class OpenFoodAPIClient {
   static Future<Status> addProductImage(User user, SendImage image,
       {QueryType queryType = QueryType.PROD}) async {
     var dataMap = <String, String>{};
-    var fileMap = <String?, Uri?>{};
+    var fileMap = <String, Uri>{};
 
     // Images can be sent anonymously
     dataMap.addAll(user.toData());

--- a/lib/utils/HttpHelper.dart
+++ b/lib/utils/HttpHelper.dart
@@ -51,7 +51,7 @@ class HttpHelper {
   /// The files to send have to be provided as map containing the source file uri.
   /// As result a json object of the "type" Status is expected.
   Future<Status> doMultipartRequest(
-      Uri uri, Map<String, String> body, Map<String?, Uri?> files, User user,
+      Uri uri, Map<String, String> body, Map<String, Uri> files, User user,
       {QueryType queryType = QueryType.PROD}) async {
     var request = http.MultipartRequest('POST', uri);
     request.headers.addAll(_buildHeaders(user,
@@ -61,9 +61,9 @@ class HttpHelper {
     request.fields.addAll(body);
 
     // add all file entries to the request
-    for (MapEntry<String?, Uri?> entry in files.entries) {
-      List<int> fileBytes = await UriReader.instance!.readAsBytes(entry.value!);
-      var multipartFile = http.MultipartFile.fromBytes(entry.key!, fileBytes,
+    for (MapEntry<String, Uri> entry in files.entries) {
+      List<int> fileBytes = await UriReader.instance!.readAsBytes(entry.value);
+      var multipartFile = http.MultipartFile.fromBytes(entry.key, fileBytes,
           filename: basename(entry.value.toString()));
       request.files.add(multipartFile);
     }

--- a/test/api_addProductImage_test.dart
+++ b/test/api_addProductImage_test.dart
@@ -21,7 +21,7 @@ void main() {
           queryType: QueryType.TEST);
 
       expect(status.status, 'status not ok');
-      expect(status.error, 'This picture has already been sent.');
+      expect(status.error, 'Dieses Foto wurde schon hochgeladen.');
     });
 
     test('add ingredients image test', () async {


### PR DESCRIPTION
Fixes #134:

````
2021-03-14 21:58:10.234 3827-4274/org.openfoodfacts.app E/flutter: [ERROR:flutter/lib/ui/ui_dart_state.cc(186)] Unhandled Exception: Null check operator used on a null value
    #0      HttpHelper.doMultipartRequest (package:openfoodfacts/utils/HttpHelper.dart:66:65)
    <asynchronous suspension>
    #1      OpenFoodAPIClient.addProductImage (package:openfoodfacts/openfoodfacts.dart:108:12)
    <asynchronous suspension>
    #2      _ImageUploadCardState._getImage (package:smooth_app/cards/data_cards/image_upload_card.dart:77:13)
    <asynchronous suspension>
````

I think it's related to null safety, specifically it was this that was problematic:

`````
for (MapEntry<String?, Uri?> entry in files.entries) {
      List<int> fileBytes = await UriReader.instance!.readAsBytes(entry.value);
`````

I changed some types to indicate that they can't be null, and it solved that error.

There are also a few more changes:

- added the PACKAGING image type
- changed the way we construct the imagefield field, as it was missing the language, and images could not be uploaded.