### PR TITLE
switched to dart

### DIFF
--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -6,19 +6,21 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
+    
     - name: Chekout code
       uses: actions/checkout@v2
 
-    - name: Setup flutter
-      uses: subosito/flutter-action@v1
-      with:
-        channel: 'stable'
+    - name: Setup Dart
+      uses: dart-lang/setup-dart@v1
 
-    - run: flutter pub get
+    - name: Install dependencies
+      run: dart pub get
 
     - name: Check for formatting issues (run "flutter format . ")
-      run: flutter format --set-exit-if-changed .
+      run: dart format --set-exit-if-changed .
 
-    - run: flutter analyze
+    - name: Analyze project
+      run: dart analyze
 
-    - run: flutter test test/
+    - name: Run tests
+      run: dart test test/

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Regarding this package, we accept pull requests as well feature requests.
 Execute the following command from the root of the repository to run the tests:
 
 ```
-flutter test
+dart test
 ```
 
 ## How to use ?

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:openfoodfacts/model/OcrIngredientsResult.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 
 /// request a product from the OpenFoodFacts database
-Future<Product> getProduct() async {
+Future<Product?> getProduct() async {
   var barcode = '0048151623426';
 
   ProductQueryConfiguration configuration = ProductQueryConfiguration(barcode,
@@ -34,7 +34,7 @@ void addNewProduct() async {
   Status result = await OpenFoodAPIClient.saveProduct(myUser, myProduct);
 
   if (result.status != 1) {
-    throw Exception('product could not be added: ' + result.error);
+    throw Exception('product could not be added: ${result.error}');
   }
 }
 
@@ -57,17 +57,15 @@ void addProductImage() async {
   Status result = await OpenFoodAPIClient.addProductImage(myUser, image);
 
   if (result.status != 'status ok') {
-    throw Exception('image could not be uploaded: ' +
-        result.error +
-        ' ' +
-        result.imageId.toString());
+    throw Exception(
+        'image could not be uploaded: ${result.error} ${result.imageId.toString()}');
   }
 }
 
 /// Extract the ingredients of an existing product of the OpenFoodFacts database
 /// That has already ingredient image
 /// Otherwise it should be added first to the server and then this can be called
-Future<String> extractIngredient() async {
+Future<String?> extractIngredient() async {
   // a registered user login for https://world.openfoodfacts.org/ is required
   User myUser = User(userId: 'max@off.com', password: 'password');
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,10 +5,10 @@ author: Alexander Schacht <grumpf@gmx.de>
 homepage: https://github.com/Grumpf86/openfoodfacts-dart
 
 environment:
-  sdk: '>=2.0.0-dev.54.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  openfoodfacts: 0.3.15+2
+  openfoodfacts: ^1.0.2-beta
 
 dev_dependencies:
   test: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,8 +28,7 @@ dev_dependencies:
   build_runner: ^1.11.5
   json_serializable: ^4.0.2
   pedantic: ^1.11.0
-  flutter_test:
-    sdk: flutter
+  test: ^1.16.8
 
 # https://www.dartlang.org/tools/pub/pubspec
 

--- a/test/api_addProductImage_test.dart
+++ b/test/api_addProductImage_test.dart
@@ -1,10 +1,10 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/model/SendImage.dart';
 import 'package:openfoodfacts/model/ProductImage.dart';
 import 'package:openfoodfacts/model/Status.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
 import 'test_constants.dart';
 
 void main() {

--- a/test/api_getProductRaw_test.dart
+++ b/test/api_getProductRaw_test.dart
@@ -1,5 +1,4 @@
 import 'package:openfoodfacts/model/NutrientLevels.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/model/ProductResult.dart';
 import 'package:openfoodfacts/model/ProductImage.dart';
@@ -7,6 +6,7 @@ import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
 import 'package:openfoodfacts/utils/ProductQueryConfigurations.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
 
 import 'test_constants.dart';
 

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -2,7 +2,6 @@ import 'package:openfoodfacts/model/AttributeGroup.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/EcoscoreData.dart';
 import 'package:openfoodfacts/model/NutrientLevels.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/model/ProductResult.dart';
 import 'package:openfoodfacts/model/ProductImage.dart';
@@ -11,6 +10,7 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 import 'package:openfoodfacts/utils/ProductQueryConfigurations.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:openfoodfacts/utils/UnitHelper.dart';
+import 'package:test/test.dart';
 
 import 'test_constants.dart';
 

--- a/test/api_getRobotoff_test.dart
+++ b/test/api_getRobotoff_test.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/model/Insight.dart';
 import 'package:openfoodfacts/model/RobotoffQuestion.dart';
 import 'package:openfoodfacts/model/SpellingCorrections.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
 import 'test_constants.dart';
 
 void main() {

--- a/test/api_ocrIngredients_test.dart
+++ b/test/api_ocrIngredients_test.dart
@@ -1,8 +1,8 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/model/OcrIngredientsResult.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/OcrField.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
 import 'test_constants.dart';
 
 void main() {

--- a/test/api_pnnsGroup2Query_test.dart
+++ b/test/api_pnnsGroup2Query_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/model/SearchResult.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
@@ -6,6 +5,7 @@ import 'package:openfoodfacts/utils/PnnsGroupQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
 
 import 'test_constants.dart';
 

--- a/test/api_postRobotoff_test.dart
+++ b/test/api_postRobotoff_test.dart
@@ -1,8 +1,8 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/model/Insight.dart';
 import 'package:openfoodfacts/model/RobotoffQuestion.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
 import 'test_constants.dart';
 
 void main() {

--- a/test/api_saveProduct_test.dart
+++ b/test/api_saveProduct_test.dart
@@ -1,10 +1,10 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/model/Additives.dart';
 import 'package:openfoodfacts/model/Nutriments.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/model/Status.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
 import 'test_constants.dart';
 
 void main() {

--- a/test/api_searchProducts_test.dart
+++ b/test/api_searchProducts_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/interface/Parameter.dart';
 import 'package:openfoodfacts/model/parameter/ContainsAdditives.dart';
 import 'package:openfoodfacts/model/parameter/SearchTerms.dart';
@@ -9,6 +8,7 @@ import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
 import 'package:openfoodfacts/utils/ProductSearchQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
 
 import 'test_constants.dart';
 

--- a/test/json_product_generation_test.dart
+++ b/test/json_product_generation_test.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/model/EcoscoreAdjustments.dart';
 import 'package:openfoodfacts/model/EcoscoreData.dart';
 import 'package:openfoodfacts/model/OriginsOfIngredients.dart';
@@ -11,6 +10,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
 import 'package:openfoodfacts/utils/ProductQueryConfigurations.dart';
+import 'package:test/test.dart';
 
 import 'test_constants.dart';
 

--- a/test/recommended_daily_intake_test.dart
+++ b/test/recommended_daily_intake_test.dart
@@ -1,10 +1,8 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:openfoodfacts/model/RecommendedDailyIntake.dart';
 import 'package:openfoodfacts/utils/UnitHelper.dart';
+import 'package:test/test.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
   group('Get Recommendations', () {
     test('Get', () {
       RecommendedDailyIntake rdi =


### PR DESCRIPTION
@teolemon mentioned on [slack](https://openfoodfacts.slack.com/archives/CC668J8AC/p1617001176000200) that a official Dart setup action got release. 

Because we used `flutter_test` for testing, this packages was a flutter package. I switched to the official [dart test package](https://pub.dev/packages/test) and updated the ci workflow. This should now be a flutter + dart package.