### PR TITLE
Prepare release of v1.1.0-beta (include breaking changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [1.1.0-beta] - 30.03.2021
+- Renamed SendImage imageUrl parameter to imageUri as it is an Uri (breaking change)
 - New product preferences and matching classes for personalized search (thanks to monsieurtanuki)
 - Added missing values for IngredientsAnalysisTags, and renamed some values to match API names (breaking change)
 - Fixed image upload and added PACKAGING image type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.0-beta] - 30.03.2021
+- New product preferences and matching classes for personalized search (thanks to monsieurtanuki)
+- Added missing values for IngredientsAnalysisTags, and renamed some values to match API names (breaking change)
+- Fixed image upload and added PACKAGING image type
+
 ## [1.0.2-beta] - 11.03.2021
 - Added support for new fields (images URLs, vegan/vegetarian/from palm oil ingredients, categories, labels and packaging)
 - Fixed test mode for addProductImage

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openfoodfacts
 description: Dart package for the Open Food Facts API, a food products database made by everyone, for everyone.
-version: 1.0.2-beta
+version: 1.1.0-beta
 #authors:
 #- Alexander Schacht <grumpf@gmx.de>
 #- Primaël Quémerais <primael@reefind.com>


### PR DESCRIPTION
The enum values for IngredientsAnalysisTags have changed, so it is a breaking change, this is why I bumped the middle version number.

While we are doing breaking changes, I think we should include a fix for #144 as well.