### PR TITLE
Add multiple '_translated' fields to Product

### DIFF
--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -20,33 +20,52 @@ part 'Product.g.dart';
 class Product extends JsonObject {
   @JsonKey(name: 'code')
   String? barcode;
+
   @JsonKey(name: 'product_name', includeIfNull: false)
   String? productName;
+  @JsonKey(name: 'product_name_translated', includeIfNull: false)
+  String? productNameTranslated;
+
+  /// Deprecated: please use productNameTranslated
   @JsonKey(name: 'product_name_de', includeIfNull: false)
+  @deprecated
   String? productNameDE;
+
+  /// Deprecated: please use productNameTranslated
   @JsonKey(name: 'product_name_en', includeIfNull: false)
+  @deprecated
   String? productNameEN;
+
+  /// Deprecated: please use productNameTranslated
   @JsonKey(name: 'product_name_fr', includeIfNull: false)
+  @deprecated
   String? productNameFR;
+
+  @JsonKey(name: 'brands', includeIfNull: false)
   String? brands;
   @JsonKey(name: 'brands_tags', includeIfNull: false)
   List<String>? brandsTags;
+
   @JsonKey(name: 'countries', includeIfNull: false)
   String? countries;
   @JsonKey(name: 'countries_tags', includeIfNull: false)
   List<String>? countriesTags;
+  @JsonKey(name: 'countries_tags_translated', includeIfNull: false)
+  List<String>? countriesTagsTranslated;
+
   @JsonKey(
       name: 'lang',
       toJson: LanguageHelper.toJson,
       fromJson: LanguageHelper.fromJson,
       includeIfNull: false)
   OpenFoodFactsLanguage? lang;
-  @JsonKey(includeIfNull: false)
+
+  @JsonKey(name: 'quantity', includeIfNull: false)
   String? quantity;
 
   // Images
 
-  // imgSmallUrl is deprecated, use imageFrontSmallUrl instead
+  /// imgSmallUrl is deprecated, use imageFrontSmallUrl instead
   @JsonKey(name: 'image_small_url', includeIfNull: false)
   @deprecated
   String? imgSmallUrl;
@@ -96,10 +115,46 @@ class Product extends JsonObject {
       toJson: JsonHelper.imagesToJson)
   List<ProductImage>? images;
 
-  @JsonKey(includeIfNull: false, toJson: JsonHelper.ingredientsToJson)
+  @JsonKey(
+      name: 'ingredients',
+      includeIfNull: false,
+      toJson: JsonHelper.ingredientsToJson)
   List<Ingredient>? ingredients;
 
-  @JsonKey(includeIfNull: false, toJson: Nutriments.toJsonHelper)
+  @JsonKey(name: 'ingredients_text', includeIfNull: false)
+  String? ingredientsText;
+  @JsonKey(name: 'ingredients_text_translated', includeIfNull: false)
+  String? ingredientsTextTranslated;
+
+  @JsonKey(name: 'ingredients_tags', includeIfNull: false)
+  List<String>? ingredientsTags;
+  @JsonKey(name: 'ingredients_tags_translated', includeIfNull: false)
+  List<String>? ingredientsTagsTranslated;
+
+  /// Deprecated: please use ingredientsTextTranslated
+  @JsonKey(name: 'ingredients_text_de', includeIfNull: false)
+  @deprecated
+  String? ingredientsTextDE;
+
+  /// Deprecated: please use ingredientsTextTranslated
+  @JsonKey(name: 'ingredients_text_en', includeIfNull: false)
+  @deprecated
+  String? ingredientsTextEN;
+
+  /// Deprecated: please use ingredientsTextTranslated
+  @JsonKey(name: 'ingredients_text_fr', includeIfNull: false)
+  @deprecated
+  String? ingredientsTextFR;
+
+  @JsonKey(
+      name: 'ingredients_analysis_tags',
+      includeIfNull: false,
+      fromJson: IngredientsAnalysisTags.fromJson,
+      toJson: IngredientsAnalysisTags.toJson)
+  IngredientsAnalysisTags? ingredientsAnalysisTags;
+
+  @JsonKey(
+      name: 'nutriments', includeIfNull: false, toJson: Nutriments.toJsonHelper)
   Nutriments? nutriments;
 
   @JsonKey(
@@ -130,22 +185,6 @@ class Product extends JsonObject {
       toJson: NutrientLevels.toJson)
   NutrientLevels? nutrientLevels;
 
-  @JsonKey(name: 'ingredients_text', includeIfNull: false)
-  String? ingredientsText;
-  @JsonKey(name: 'ingredients_text_de', includeIfNull: false)
-  String? ingredientsTextDE;
-  @JsonKey(name: 'ingredients_text_en', includeIfNull: false)
-  String? ingredientsTextEN;
-  @JsonKey(name: 'ingredients_text_fr', includeIfNull: false)
-  String? ingredientsTextFR;
-
-  @JsonKey(
-      name: 'ingredients_analysis_tags',
-      includeIfNull: false,
-      fromJson: IngredientsAnalysisTags.fromJson,
-      toJson: IngredientsAnalysisTags.toJson)
-  IngredientsAnalysisTags? ingredientsAnalysisTags;
-
   @JsonKey(name: 'nutriment_energy_unit', includeIfNull: false)
   String? nutrimentEnergyUnit;
   @JsonKey(name: 'nutrition_data_per', includeIfNull: false)
@@ -155,21 +194,23 @@ class Product extends JsonObject {
 
   @JsonKey(name: 'categories', includeIfNull: false)
   String? categories;
-
   @JsonKey(name: 'categories_tags', includeIfNull: false)
   List<String>? categoriesTags;
   @JsonKey(name: 'categories_tags_translated', includeIfNull: false)
   List<String>? categoriesTagsTranslated;
-  @JsonKey(name: 'labels_tags', includeIfNull: false)
-  List<String>? labelsTags;
+
   @JsonKey(name: 'labels', includeIfNull: false)
   String? labels;
+  @JsonKey(name: 'labels_tags', includeIfNull: false)
+  List<String>? labelsTags;
+  @JsonKey(name: 'labels_tags_translated', includeIfNull: false)
+  List<String>? labelsTagsTranslated;
+
   @JsonKey(name: 'packaging', includeIfNull: false)
   String? packaging;
   @JsonKey(name: 'packaging_tags', includeIfNull: false)
   List<String>? packagingTags;
-  @JsonKey(name: 'labels_tags_translated', includeIfNull: false)
-  List<String>? labelsTagsTranslated;
+
   @JsonKey(name: 'misc', includeIfNull: false)
   List<String>? miscTags;
   @JsonKey(name: 'states_tags', includeIfNull: false)
@@ -208,16 +249,15 @@ class Product extends JsonObject {
   Product(
       {this.barcode,
       this.productName,
+      this.productNameTranslated,
       this.productNameDE,
       this.productNameEN,
       this.productNameFR,
       this.brands,
+      this.brandsTags,
       this.countries,
       this.countriesTags,
-      this.labels,
-      this.labelsTags,
-      this.packaging,
-      this.packagingTags,
+      this.countriesTagsTranslated,
       this.lang,
       this.quantity,
       this.imgSmallUrl,
@@ -229,39 +269,113 @@ class Product extends JsonObject {
       this.imageNutritionSmallUrl,
       this.imagePackagingUrl,
       this.imagePackagingSmallUrl,
+      this.servingSize,
+      this.servingQuantity,
+      this.packagingQuantity,
+      this.selectedImages,
+      this.images,
+      this.ingredients,
       this.ingredientsText,
+      this.ingredientsTextTranslated,
+      this.ingredientsTags,
+      this.ingredientsTagsTranslated,
       this.ingredientsTextDE,
       this.ingredientsTextEN,
-      this.categories,
-      this.categoriesTags,
+      this.ingredientsTextFR,
+      this.ingredientsAnalysisTags,
+      this.nutriments,
+      this.additives,
+      this.environmentImpactLevels,
+      this.allergens,
+      this.nutrientLevels,
       this.nutrimentEnergyUnit,
       this.nutrimentDataPer,
       this.nutriscore,
-      this.nutriments,
-      this.additives,
-      this.nutrientLevels,
-      this.servingSize,
-      this.servingQuantity,
+      this.categories,
+      this.categoriesTags,
+      this.categoriesTagsTranslated,
+      this.labels,
+      this.labelsTags,
+      this.labelsTagsTranslated,
+      this.packaging,
+      this.packagingTags,
+      this.miscTags,
+      this.statesTags,
+      this.tracesTags,
+      this.storesTags,
+      this.attributeGroups,
+      this.lastModified,
       this.ecoscoreGrade,
-      this.ecoscoreScore});
+      this.ecoscoreScore,
+      this.ecoscoreData});
 
   factory Product.fromJson(Map<String, dynamic> json) {
     final Product result = _$ProductFromJson(json);
     for (final String key in json.keys) {
-      if (key.startsWith('categories_tags_')) {
-        result.categoriesTagsTranslated =
-            (json[key] as List?)?.map((e) => e as String).toList();
+      if (key.contains('debug')) {
+        continue;
+      } else if (key.startsWith('product_name_')) {
+        result.productNameTranslated = json[key];
+      } else if (key.startsWith('categories_tags_')) {
+        result.categoriesTagsTranslated = _jsonValueToList(json[key]);
+      } else if (key.startsWith('ingredients_tags_')) {
+        result.ingredientsTagsTranslated = _jsonValueToList(json[key]);
+      } else if (key.startsWith('labels_tags_')) {
+        result.labelsTagsTranslated = _jsonValueToList(json[key]);
+      } else if (key.startsWith('countries_tags_')) {
+        result.countriesTagsTranslated = _jsonValueToList(json[key]);
+      } else if (key.startsWith('ingredients_text_')) {
+        result.ingredientsTextTranslated = json[key];
       }
-      if (key.startsWith('labels_tags_')) {
-        result.labelsTagsTranslated =
-            (json[key] as List?)?.map((e) => e as String).toList();
+    }
+    return result;
+  }
+
+  static List<String>? _jsonValueToList(dynamic value) {
+    return (value as List?)?.map((e) => e as String).toList();
+  }
+
+  Map<String, String> toValidatedData() {
+    final result = super.toData();
+    for (final key in result.keys) {
+      if (key.endsWith('_translated') && lang == null) {
+        throw StateError('Cannot send translated field without language');
+      }
+      if (key.endsWith('_tags_translated')) {
+        throw StateError(
+            'Fields "SOMENAME_tags_translated" cannot be sent to backend. '
+            'Please send translated values either by "SOMENAME_translated" field '
+            'if it exists, or by "SOMENAME" field and '
+            'prepending language code to values, e.g.: '
+            '{"categories": "en:nuts, en:peanut"}');
       }
     }
     return result;
   }
 
   @override
-  Map<String, dynamic> toJson() => _$ProductToJson(this);
+  Map<String, dynamic> toJson() {
+    final json = _$ProductToJson(this);
+    if (lang == null) {
+      return json;
+    }
+
+    // Defensive keys copy to modify map while iterating
+    final keys = json.keys.toList();
+
+    for (final key in keys) {
+      // NOTE: '_tags_translated' are not supported because tags translation
+      // is done automatically on the server.
+      if (key.endsWith('_translated') && !key.endsWith('_tags_translated')) {
+        final value = json[key];
+        json.remove(key);
+        final keyUntranslated = key.substring(0, key.indexOf('_translated'));
+        final realKey = '${keyUntranslated}_${lang.code}';
+        json[realKey] = value;
+      }
+    }
+    return json;
+  }
 
   /// Returns all existing product attributes matching a list of attribute ids
   Map<String, Attribute> getAttributes(

--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -18,6 +18,9 @@ part 'Product.g.dart';
 
 @JsonSerializable()
 class Product extends JsonObject {
+  @JsonKey(ignore: true)
+  OpenFoodFactsLanguage? translatedLang;
+
   @JsonKey(name: 'code')
   String? barcode;
 
@@ -247,7 +250,8 @@ class Product extends JsonObject {
   EcoscoreData? ecoscoreData;
 
   Product(
-      {this.barcode,
+      {this.translatedLang,
+      this.barcode,
       this.productName,
       this.productNameTranslated,
       this.productNameDE,
@@ -335,10 +339,10 @@ class Product extends JsonObject {
     return (value as List?)?.map((e) => e as String).toList();
   }
 
-  Map<String, String> toServerData(String? lc) {
+  Map<String, String> toServerData() {
     final data = super.toData();
 
-    lc ??= lang?.code;
+    final lc = translatedLang?.code ?? lang?.code;
 
     // Defensive keys copy to modify map while iterating
     final keys = data.keys.toList();

--- a/lib/model/Product.g.dart
+++ b/lib/model/Product.g.dart
@@ -10,22 +10,22 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
   return Product(
     barcode: json['code'] as String?,
     productName: json['product_name'] as String?,
+    productNameTranslated: json['product_name_translated'] as String?,
     productNameDE: json['product_name_de'] as String?,
     productNameEN: json['product_name_en'] as String?,
     productNameFR: json['product_name_fr'] as String?,
     brands: json['brands'] as String?,
+    brandsTags: (json['brands_tags'] as List<dynamic>?)
+        ?.map((e) => e as String)
+        .toList(),
     countries: json['countries'] as String?,
     countriesTags: (json['countries_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    labels: json['labels'] as String?,
-    labelsTags: (json['labels_tags'] as List<dynamic>?)
-        ?.map((e) => e as String)
-        .toList(),
-    packaging: json['packaging'] as String?,
-    packagingTags: (json['packaging_tags'] as List<dynamic>?)
-        ?.map((e) => e as String)
-        .toList(),
+    countriesTagsTranslated:
+        (json['countries_tags_translated'] as List<dynamic>?)
+            ?.map((e) => e as String)
+            .toList(),
     lang: LanguageHelper.fromJson(json['lang'] as String?),
     quantity: json['quantity'] as String?,
     imgSmallUrl: json['image_small_url'] as String?,
@@ -37,68 +37,81 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
     imageNutritionSmallUrl: json['image_nutrition_small_url'] as String?,
     imagePackagingUrl: json['image_packaging_url'] as String?,
     imagePackagingSmallUrl: json['image_packaging_small_url'] as String?,
+    servingSize: json['serving_size'] as String?,
+    servingQuantity:
+        JsonHelper.servingQuantityFromJson(json['serving_quantity']),
+    packagingQuantity: json['product_quantity'],
+    selectedImages:
+        JsonHelper.selectedImagesFromJson(json['selected_images'] as Map?),
+    images: JsonHelper.imagesFromJson(json['images'] as Map?),
+    ingredients: (json['ingredients'] as List<dynamic>?)
+        ?.map((e) => Ingredient.fromJson(e as Map<String, dynamic>))
+        .toList(),
     ingredientsText: json['ingredients_text'] as String?,
-    ingredientsTextDE: json['ingredients_text_de'] as String?,
-    ingredientsTextEN: json['ingredients_text_en'] as String?,
-    categories: json['categories'] as String?,
-    categoriesTags: (json['categories_tags'] as List<dynamic>?)
+    ingredientsTextTranslated: json['ingredients_text_translated'] as String?,
+    ingredientsTags: (json['ingredients_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    nutrimentEnergyUnit: json['nutriment_energy_unit'] as String?,
-    nutrimentDataPer: json['nutrition_data_per'] as String?,
-    nutriscore: json['nutrition_grade_fr'] as String?,
+    ingredientsTagsTranslated:
+        (json['ingredients_tags_translated'] as List<dynamic>?)
+            ?.map((e) => e as String)
+            .toList(),
+    ingredientsTextDE: json['ingredients_text_de'] as String?,
+    ingredientsTextEN: json['ingredients_text_en'] as String?,
+    ingredientsTextFR: json['ingredients_text_fr'] as String?,
+    ingredientsAnalysisTags: IngredientsAnalysisTags.fromJson(
+        json['ingredients_analysis_tags'] as List?),
     nutriments: json['nutriments'] == null
         ? null
         : Nutriments.fromJson(json['nutriments'] as Map<String, dynamic>),
     additives: Additives.additivesFromJson(json['additives_tags'] as List?),
+    environmentImpactLevels: EnvironmentImpactLevels.fromJson(
+        json['environment_impact_level_tags'] as List?),
+    allergens: Allergens.allergensFromJson(json['allergens_tags'] as List?),
     nutrientLevels: NutrientLevels.fromJson(json['nutrient_levels'] as Map?),
-    servingSize: json['serving_size'] as String?,
-    servingQuantity:
-        JsonHelper.servingQuantityFromJson(json['serving_quantity']),
-    ecoscoreGrade: json['ecoscore_grade'] as String?,
-    ecoscoreScore: JsonObject.parseDouble(json['ecoscore_score']),
-  )
-    ..brandsTags = (json['brands_tags'] as List<dynamic>?)
+    nutrimentEnergyUnit: json['nutriment_energy_unit'] as String?,
+    nutrimentDataPer: json['nutrition_data_per'] as String?,
+    nutriscore: json['nutrition_grade_fr'] as String?,
+    categories: json['categories'] as String?,
+    categoriesTags: (json['categories_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
-        .toList()
-    ..packagingQuantity = json['product_quantity']
-    ..selectedImages =
-        JsonHelper.selectedImagesFromJson(json['selected_images'] as Map?)
-    ..images = JsonHelper.imagesFromJson(json['images'] as Map?)
-    ..ingredients = (json['ingredients'] as List<dynamic>?)
-        ?.map((e) => Ingredient.fromJson(e as Map<String, dynamic>))
-        .toList()
-    ..environmentImpactLevels = EnvironmentImpactLevels.fromJson(
-        json['environment_impact_level_tags'] as List?)
-    ..allergens = Allergens.allergensFromJson(json['allergens_tags'] as List?)
-    ..ingredientsTextFR = json['ingredients_text_fr'] as String?
-    ..ingredientsAnalysisTags = IngredientsAnalysisTags.fromJson(
-        json['ingredients_analysis_tags'] as List?)
-    ..categoriesTagsTranslated =
+        .toList(),
+    categoriesTagsTranslated:
         (json['categories_tags_translated'] as List<dynamic>?)
             ?.map((e) => e as String)
-            .toList()
-    ..labelsTagsTranslated = (json['labels_tags_translated'] as List<dynamic>?)
+            .toList(),
+    labels: json['labels'] as String?,
+    labelsTags: (json['labels_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
-        .toList()
-    ..miscTags =
-        (json['misc'] as List<dynamic>?)?.map((e) => e as String).toList()
-    ..statesTags = (json['states_tags'] as List<dynamic>?)
+        .toList(),
+    labelsTagsTranslated: (json['labels_tags_translated'] as List<dynamic>?)
         ?.map((e) => e as String)
-        .toList()
-    ..tracesTags = (json['traces_tags'] as List<dynamic>?)
+        .toList(),
+    packaging: json['packaging'] as String?,
+    packagingTags: (json['packaging_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
-        .toList()
-    ..storesTags = (json['stores_tags'] as List<dynamic>?)
+        .toList(),
+    miscTags:
+        (json['misc'] as List<dynamic>?)?.map((e) => e as String).toList(),
+    statesTags: (json['states_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
-        .toList()
-    ..attributeGroups = (json['attribute_groups'] as List<dynamic>?)
+        .toList(),
+    tracesTags: (json['traces_tags'] as List<dynamic>?)
+        ?.map((e) => e as String)
+        .toList(),
+    storesTags: (json['stores_tags'] as List<dynamic>?)
+        ?.map((e) => e as String)
+        .toList(),
+    attributeGroups: (json['attribute_groups'] as List<dynamic>?)
         ?.map((e) => AttributeGroup.fromJson(e))
-        .toList()
-    ..lastModified = JsonHelper.timestampToDate(json['last_modified_t'])
-    ..ecoscoreData = json['ecoscore_data'] == null
+        .toList(),
+    lastModified: JsonHelper.timestampToDate(json['last_modified_t']),
+    ecoscoreGrade: json['ecoscore_grade'] as String?,
+    ecoscoreScore: JsonObject.parseDouble(json['ecoscore_score']),
+    ecoscoreData: json['ecoscore_data'] == null
         ? null
-        : EcoscoreData.fromJson(json['ecoscore_data'] as Map<String, dynamic>);
+        : EcoscoreData.fromJson(json['ecoscore_data'] as Map<String, dynamic>),
+  );
 }
 
 Map<String, dynamic> _$ProductToJson(Product instance) {
@@ -113,13 +126,15 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   }
 
   writeNotNull('product_name', instance.productName);
+  writeNotNull('product_name_translated', instance.productNameTranslated);
   writeNotNull('product_name_de', instance.productNameDE);
   writeNotNull('product_name_en', instance.productNameEN);
   writeNotNull('product_name_fr', instance.productNameFR);
-  val['brands'] = instance.brands;
+  writeNotNull('brands', instance.brands);
   writeNotNull('brands_tags', instance.brandsTags);
   writeNotNull('countries', instance.countries);
   writeNotNull('countries_tags', instance.countriesTags);
+  writeNotNull('countries_tags_translated', instance.countriesTagsTranslated);
   writeNotNull('lang', LanguageHelper.toJson(instance.lang));
   writeNotNull('quantity', instance.quantity);
   writeNotNull('image_small_url', instance.imgSmallUrl);
@@ -140,6 +155,17 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('images', JsonHelper.imagesToJson(instance.images));
   writeNotNull(
       'ingredients', JsonHelper.ingredientsToJson(instance.ingredients));
+  writeNotNull('ingredients_text', instance.ingredientsText);
+  writeNotNull(
+      'ingredients_text_translated', instance.ingredientsTextTranslated);
+  writeNotNull('ingredients_tags', instance.ingredientsTags);
+  writeNotNull(
+      'ingredients_tags_translated', instance.ingredientsTagsTranslated);
+  writeNotNull('ingredients_text_de', instance.ingredientsTextDE);
+  writeNotNull('ingredients_text_en', instance.ingredientsTextEN);
+  writeNotNull('ingredients_text_fr', instance.ingredientsTextFR);
+  writeNotNull('ingredients_analysis_tags',
+      IngredientsAnalysisTags.toJson(instance.ingredientsAnalysisTags));
   writeNotNull('nutriments', Nutriments.toJsonHelper(instance.nutriments));
   writeNotNull('additives_tags', Additives.additivesToJson(instance.additives));
   writeNotNull('environment_impact_level_tags',
@@ -147,23 +173,17 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('allergens_tags', Allergens.allergensToJson(instance.allergens));
   writeNotNull(
       'nutrient_levels', NutrientLevels.toJson(instance.nutrientLevels));
-  writeNotNull('ingredients_text', instance.ingredientsText);
-  writeNotNull('ingredients_text_de', instance.ingredientsTextDE);
-  writeNotNull('ingredients_text_en', instance.ingredientsTextEN);
-  writeNotNull('ingredients_text_fr', instance.ingredientsTextFR);
-  writeNotNull('ingredients_analysis_tags',
-      IngredientsAnalysisTags.toJson(instance.ingredientsAnalysisTags));
   writeNotNull('nutriment_energy_unit', instance.nutrimentEnergyUnit);
   writeNotNull('nutrition_data_per', instance.nutrimentDataPer);
   writeNotNull('nutrition_grade_fr', instance.nutriscore);
   writeNotNull('categories', instance.categories);
   writeNotNull('categories_tags', instance.categoriesTags);
   writeNotNull('categories_tags_translated', instance.categoriesTagsTranslated);
-  writeNotNull('labels_tags', instance.labelsTags);
   writeNotNull('labels', instance.labels);
+  writeNotNull('labels_tags', instance.labelsTags);
+  writeNotNull('labels_tags_translated', instance.labelsTagsTranslated);
   writeNotNull('packaging', instance.packaging);
   writeNotNull('packaging_tags', instance.packagingTags);
-  writeNotNull('labels_tags_translated', instance.labelsTagsTranslated);
   writeNotNull('misc', instance.miscTags);
   writeNotNull('states_tags', instance.statesTags);
   writeNotNull('traces_tags', instance.tracesTags);

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -70,10 +70,10 @@ class OpenFoodAPIClient {
   /// By default the query will hit the PROD DB
   /// Returns a Status object as result.
   static Future<Status> saveProduct(User user, Product product,
-      {QueryType queryType = QueryType.PROD}) async {
+      {String? lc, QueryType queryType = QueryType.PROD}) async {
     var parameterMap = <String, String>{};
     parameterMap.addAll(user.toData());
-    parameterMap.addAll(product.toValidatedData());
+    parameterMap.addAll(product.toServerData(lc));
 
     var productUri = Uri(
         scheme: URI_SCHEME,

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -70,10 +70,10 @@ class OpenFoodAPIClient {
   /// By default the query will hit the PROD DB
   /// Returns a Status object as result.
   static Future<Status> saveProduct(User user, Product product,
-      {String? lc, QueryType queryType = QueryType.PROD}) async {
+      {QueryType queryType = QueryType.PROD}) async {
     var parameterMap = <String, String>{};
     parameterMap.addAll(user.toData());
-    parameterMap.addAll(product.toServerData(lc));
+    parameterMap.addAll(product.toServerData());
 
     var productUri = Uri(
         scheme: URI_SCHEME,
@@ -151,6 +151,8 @@ class OpenFoodAPIClient {
     if (result.product != null) {
       ProductHelper.removeImages(result.product!, configuration.language);
       ProductHelper.createImageUrls(result.product!, queryType: queryType);
+      final translatedLang = configuration.lc ?? configuration.language?.code;
+      result.product!.translatedLang = LanguageHelper.fromJson(translatedLang);
     }
 
     return result;

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -73,7 +73,7 @@ class OpenFoodAPIClient {
       {QueryType queryType = QueryType.PROD}) async {
     var parameterMap = <String, String>{};
     parameterMap.addAll(user.toData());
-    parameterMap.addAll(product.toData());
+    parameterMap.addAll(product.toValidatedData());
 
     var productUri = Uri(
         scheme: URI_SCHEME,

--- a/lib/utils/ProductFields.dart
+++ b/lib/utils/ProductFields.dart
@@ -1,11 +1,15 @@
+import 'package:openfoodfacts/utils/LanguageHelper.dart';
+
 enum ProductField {
   BARCODE,
   NAME,
+  NAME_TRANSLATED,
   GENERIC_NAME,
   BRANDS,
   BRANDS_TAGS,
   COUNTRIES,
   COUNTRIES_TAGS,
+  COUNTRIES_TAGS_TRANSLATED,
   LANGUAGE,
   QUANTITY,
   SERVING_SIZE,
@@ -22,10 +26,13 @@ enum ProductField {
   IMAGE_PACKAGING_SMALL_URL,
   IMAGES,
   INGREDIENTS,
+  INGREDIENTS_TAGS,
+  INGREDIENTS_TAGS_TRANSLATED,
   NUTRIMENTS,
   ADDITIVES,
   NUTRIENT_LEVELS,
   INGREDIENTS_TEXT,
+  INGREDIENTS_TEXT_TRANSLATED,
   NUTRIMENT_ENERGY_UNIT,
   NUTRIMENT_DATA_PER,
   NUTRISCORE,
@@ -54,6 +61,8 @@ extension ProductFieldExtension on ProductField {
         return 'code';
       case ProductField.NAME:
         return 'product_name';
+      case ProductField.NAME_TRANSLATED:
+        return 'product_name_';
       case ProductField.GENERIC_NAME:
         return 'generic_name';
       case ProductField.BRANDS:
@@ -64,6 +73,8 @@ extension ProductFieldExtension on ProductField {
         return 'countries';
       case ProductField.COUNTRIES_TAGS:
         return 'countries_tags';
+      case ProductField.COUNTRIES_TAGS_TRANSLATED:
+        return 'countries_tags_';
       case ProductField.LANGUAGE:
         return 'lang';
       case ProductField.QUANTITY:
@@ -96,6 +107,10 @@ extension ProductFieldExtension on ProductField {
         return 'images';
       case ProductField.INGREDIENTS:
         return 'ingredients';
+      case ProductField.INGREDIENTS_TAGS:
+        return 'ingredients_tags';
+      case ProductField.INGREDIENTS_TAGS_TRANSLATED:
+        return 'ingredients_tags_';
       case ProductField.NUTRIMENTS:
         return 'nutriments';
       case ProductField.ADDITIVES:
@@ -104,6 +119,8 @@ extension ProductFieldExtension on ProductField {
         return 'nutrient_levels';
       case ProductField.INGREDIENTS_TEXT:
         return 'ingredients_text';
+      case ProductField.INGREDIENTS_TEXT_TRANSLATED:
+        return 'ingredients_text_';
       case ProductField.NUTRIMENT_ENERGY_UNIT:
         return 'nutriment_energy_unit';
       case ProductField.NUTRIMENT_DATA_PER:
@@ -144,4 +161,33 @@ extension ProductFieldExtension on ProductField {
         return '';
     }
   }
+}
+
+/// NOTE: if one of the fields is TRANSLATED and language is null -
+/// the function will throw.
+List<String> convertFieldsToStrings(
+    List<ProductField> fields, OpenFoodFactsLanguage? language) {
+  final fieldsStrings = <String>[];
+
+  const translatedFields = [
+    ProductField.CATEGORIES_TAGS_TRANSLATED,
+    ProductField.LABELS_TAGS_TRANSLATED,
+    ProductField.NAME_TRANSLATED,
+    ProductField.COUNTRIES_TAGS_TRANSLATED,
+    ProductField.INGREDIENTS_TEXT_TRANSLATED,
+    ProductField.INGREDIENTS_TAGS_TRANSLATED,
+  ];
+
+  for (final field in fields) {
+    if (translatedFields.contains(field)) {
+      if (language == null) {
+        throw ArgumentError('Cannot request translated field without language');
+      }
+      fieldsStrings.add('${field.key}${language.code}');
+    } else {
+      fieldsStrings.add(field.key);
+    }
+  }
+
+  return fieldsStrings;
 }

--- a/lib/utils/ProductHelper.dart
+++ b/lib/utils/ProductHelper.dart
@@ -40,5 +40,11 @@ class ProductHelper {
     product.categoriesTagsTranslated =
         source['categories_tags_${language.code}'];
     product.labelsTagsTranslated = source['labels_tags_${language.code}'];
+    product.ingredientsTagsTranslated =
+        source['ingredients_tags_${language.code}'];
+    product.ingredientsTextTranslated =
+        source['ingredients_text_${language.code}'];
+    product.productNameTranslated = source['product_name_${language.code}'];
+    product.countriesTagsTranslated = source['countries_tags_${language.code}'];
   }
 }

--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -15,16 +15,6 @@ class ProductQueryConfiguration {
     fields ??= [ProductField.ALL];
   }
 
-  List<String> getFieldsKeys() {
-    List<String> result = [];
-
-    for (ProductField field in fields!) {
-      result.add(field.key);
-    }
-
-    return result;
-  }
-
   Map<String, String?> getParametersMap() {
     Map<String, String?> result = {};
 
@@ -46,24 +36,9 @@ class ProductQueryConfiguration {
           break;
         }
       }
-
       if (!ignoreFieldsFilter) {
-        String value = '';
-
-        if (fields!.contains(ProductField.CATEGORIES_TAGS_TRANSLATED)) {
-          fields!.remove(ProductField.CATEGORIES_TAGS_TRANSLATED);
-          value =
-              '$value,${ProductField.CATEGORIES_TAGS_TRANSLATED.key}${language.code}';
-        }
-
-        if (fields!.contains(ProductField.LABELS_TAGS_TRANSLATED)) {
-          fields!.remove(ProductField.LABELS_TAGS_TRANSLATED);
-          value =
-              '$value,${ProductField.LABELS_TAGS_TRANSLATED.key}${language.code}';
-        }
-
-        result.putIfAbsent(
-            'fields', () => "$value,${getFieldsKeys().join(',')}");
+        final fieldsStrings = convertFieldsToStrings(fields!, language);
+        result.putIfAbsent('fields', () => fieldsStrings.join(','));
       }
     }
 

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -60,24 +60,9 @@ class ProductSearchQueryConfiguration {
           break;
         }
       }
-
       if (!ignoreFieldsFilter) {
-        String value = '';
-
-        if (fields!.contains(ProductField.CATEGORIES_TAGS_TRANSLATED)) {
-          fields!.remove(ProductField.CATEGORIES_TAGS_TRANSLATED);
-          value =
-              '$value,${ProductField.CATEGORIES_TAGS_TRANSLATED.key}${language.code}';
-        }
-
-        if (fields!.contains(ProductField.LABELS_TAGS_TRANSLATED)) {
-          fields!.remove(ProductField.LABELS_TAGS_TRANSLATED);
-          value =
-              '$value,${ProductField.LABELS_TAGS_TRANSLATED.key}${language.code}';
-        }
-
-        result.putIfAbsent(
-            'fields', () => "$value,${getFieldsKeys().join(',')}");
+        final fieldsStrings = convertFieldsToStrings(fields!, language);
+        result.putIfAbsent('fields', () => fieldsStrings.join(','));
       }
     }
 

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -864,7 +864,7 @@ void main() {
     });
 
     test(
-        'translated fields when product is not translated into second language',
+        'translated fields when product is not translated into a second language',
         () async {
       String barcode = '3333333333333';
 
@@ -948,7 +948,7 @@ void main() {
       expect(russianProduct.countriesTagsTranslated, equals(['Россия']));
     });
 
-    test('translated fields when product is translated into second language',
+    test('translated fields when product is translated into a second language',
         () async {
       String barcode = '2222222222222';
 

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -862,5 +862,184 @@ void main() {
       expect(matchedProduct.score, 0.0);
       expect(matchedProduct.status, MatchedProductStatus.YES);
     });
+
+    test(
+        'translated fields when product is not translated into second language',
+        () async {
+      String barcode = '3333333333333';
+
+      Product englishInputProduct = Product(
+        barcode: barcode,
+        lang: OpenFoodFactsLanguage.ENGLISH,
+        productNameTranslated: 'Pancakes',
+        ingredientsTextTranslated: 'Flour, water',
+        categories: 'Beverages',
+        countries: 'Russia',
+      );
+
+      await OpenFoodAPIClient.saveProduct(
+          TestConstants.TEST_USER, englishInputProduct,
+          queryType: QueryType.TEST);
+
+      final fields = [
+        ProductField.NAME,
+        ProductField.NAME_TRANSLATED,
+        ProductField.INGREDIENTS_TEXT,
+        ProductField.INGREDIENTS_TEXT_TRANSLATED,
+        ProductField.INGREDIENTS_TAGS,
+        ProductField.INGREDIENTS_TAGS_TRANSLATED,
+        ProductField.CATEGORIES_TAGS,
+        ProductField.CATEGORIES_TAGS_TRANSLATED,
+        ProductField.COUNTRIES_TAGS,
+        ProductField.COUNTRIES_TAGS_TRANSLATED,
+      ];
+
+      ProductQueryConfiguration englishConf = ProductQueryConfiguration(barcode,
+          language: OpenFoodFactsLanguage.ENGLISH, fields: fields);
+      ProductQueryConfiguration russianConf = ProductQueryConfiguration(barcode,
+          language: OpenFoodFactsLanguage.RUSSIAN, fields: fields);
+
+      // English!
+
+      ProductResult englishResult = await OpenFoodAPIClient.getProduct(
+          englishConf,
+          user: TestConstants.TEST_USER,
+          queryType: QueryType.TEST);
+      Product englishProduct = englishResult.product!;
+
+      expect(englishProduct.productName, equals('Pancakes'));
+      expect(englishProduct.productNameTranslated, equals('Pancakes'));
+
+      expect(englishProduct.ingredientsText, equals('Flour, water'));
+      expect(englishProduct.ingredientsTextTranslated, equals('Flour, water'));
+
+      expect(englishProduct.ingredientsTags, equals(['en:flour', 'en:water']));
+      expect(
+          englishProduct.ingredientsTagsTranslated, equals(['Flour', 'Water']));
+
+      expect(englishProduct.categoriesTags, equals(['en:beverages']));
+      expect(englishProduct.categoriesTagsTranslated, equals(['Beverages']));
+
+      expect(englishProduct.countriesTags, equals(['en:russia']));
+      expect(englishProduct.countriesTagsTranslated, equals(['Russia']));
+
+      // Russian!
+
+      ProductResult russianResult = await OpenFoodAPIClient.getProduct(
+          russianConf,
+          user: TestConstants.TEST_USER,
+          queryType: QueryType.TEST);
+      Product russianProduct = russianResult.product!;
+
+      expect(russianProduct.productName, equals('Pancakes'));
+      expect(russianProduct.productNameTranslated, isNull);
+
+      expect(russianProduct.ingredientsText, equals('Flour, water'));
+      expect(russianProduct.ingredientsTextTranslated, isNull);
+
+      expect(russianProduct.ingredientsTags, equals(['en:flour', 'en:water']));
+      expect(
+          russianProduct.ingredientsTagsTranslated, equals(['Мука', 'Вода']));
+
+      expect(russianProduct.categoriesTags, equals(['en:beverages']));
+      expect(russianProduct.categoriesTagsTranslated, equals(['Напитки']));
+
+      expect(russianProduct.countriesTags, equals(['en:russia']));
+      expect(russianProduct.countriesTagsTranslated, equals(['Россия']));
+    });
+
+    test('translated fields when product is translated into second language',
+        () async {
+      String barcode = '2222222222222';
+
+      Product englishInputProduct = Product(
+        barcode: barcode,
+        lang: OpenFoodFactsLanguage.ENGLISH,
+        productNameTranslated: 'Pancakes',
+        ingredientsTextTranslated: 'Flour, water',
+        categories: 'Beverages',
+        countries: 'Russia',
+      );
+
+      Product russianInputProduct = Product(
+        barcode: barcode,
+        lang: OpenFoodFactsLanguage.RUSSIAN,
+        productNameTranslated: 'Блинчики',
+        ingredientsTextTranslated: 'Мука, вода',
+      );
+
+      await OpenFoodAPIClient.saveProduct(
+          TestConstants.TEST_USER, englishInputProduct,
+          queryType: QueryType.TEST);
+      await OpenFoodAPIClient.saveProduct(
+          TestConstants.TEST_USER, russianInputProduct,
+          queryType: QueryType.TEST);
+
+      final fields = [
+        ProductField.NAME,
+        ProductField.NAME_TRANSLATED,
+        ProductField.INGREDIENTS_TEXT,
+        ProductField.INGREDIENTS_TEXT_TRANSLATED,
+        ProductField.INGREDIENTS_TAGS,
+        ProductField.INGREDIENTS_TAGS_TRANSLATED,
+        ProductField.CATEGORIES_TAGS,
+        ProductField.CATEGORIES_TAGS_TRANSLATED,
+        ProductField.COUNTRIES_TAGS,
+        ProductField.COUNTRIES_TAGS_TRANSLATED,
+      ];
+
+      ProductQueryConfiguration englishConf = ProductQueryConfiguration(barcode,
+          language: OpenFoodFactsLanguage.ENGLISH, fields: fields);
+      ProductQueryConfiguration russianConf = ProductQueryConfiguration(barcode,
+          language: OpenFoodFactsLanguage.RUSSIAN, fields: fields);
+
+      // English!
+
+      ProductResult englishResult = await OpenFoodAPIClient.getProduct(
+          englishConf,
+          user: TestConstants.TEST_USER,
+          queryType: QueryType.TEST);
+      Product englishProduct = englishResult.product!;
+
+      expect(englishProduct.productName, equals('Pancakes'));
+      expect(englishProduct.productNameTranslated, equals('Pancakes'));
+
+      expect(englishProduct.ingredientsText, equals('Flour, water'));
+      expect(englishProduct.ingredientsTextTranslated, equals('Flour, water'));
+
+      expect(englishProduct.ingredientsTags, equals(['en:flour', 'en:water']));
+      expect(
+          englishProduct.ingredientsTagsTranslated, equals(['Flour', 'Water']));
+
+      expect(englishProduct.categoriesTags, equals(['en:beverages']));
+      expect(englishProduct.categoriesTagsTranslated, equals(['Beverages']));
+
+      expect(englishProduct.countriesTags, equals(['en:russia']));
+      expect(englishProduct.countriesTagsTranslated, equals(['Russia']));
+
+      // Russian!
+
+      ProductResult russianResult = await OpenFoodAPIClient.getProduct(
+          russianConf,
+          user: TestConstants.TEST_USER,
+          queryType: QueryType.TEST);
+      Product russianProduct = russianResult.product!;
+
+      expect(russianProduct.productName, equals('Блинчики'));
+      expect(russianProduct.productNameTranslated, equals('Блинчики'));
+
+      expect(russianProduct.ingredientsText, equals('Мука, вода'));
+      expect(russianProduct.ingredientsTextTranslated, equals('Мука, вода'));
+
+      expect(russianProduct.ingredientsTags, equals(['en:flour', 'en:water']));
+      expect(
+          russianProduct.ingredientsTagsTranslated, equals(['Мука', 'Вода']));
+
+      expect(russianProduct.categoriesTags, equals(['en:beverages']));
+      expect(russianProduct.categoriesTagsTranslated, equals(['Напитки']));
+
+      expect(russianProduct.countriesTags, equals(['en:russia']));
+      expect(russianProduct.countriesTagsTranslated, equals(['Россия']));
+    });
   });
 }

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -477,7 +477,7 @@ void main() {
       assert(result.product!.brandsTags != null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameDE == null);
+      assert(result.product!.productNameTranslated == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -494,7 +494,7 @@ void main() {
       assert(result.product!.brandsTags == null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameDE == null);
+      assert(result.product!.productNameTranslated == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -511,7 +511,7 @@ void main() {
       assert(result.product!.brandsTags == null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameDE == null);
+      assert(result.product!.productNameTranslated == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -529,7 +529,7 @@ void main() {
       assert(result.product!.brandsTags == null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameDE == null);
+      assert(result.product!.productNameTranslated == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -923,6 +923,9 @@ void main() {
       expect(englishProduct.countriesTags, equals(['en:russia']));
       expect(englishProduct.countriesTagsTranslated, equals(['Russia']));
 
+      expect(
+          englishProduct.translatedLang, equals(OpenFoodFactsLanguage.ENGLISH));
+
       // Russian!
 
       ProductResult russianResult = await OpenFoodAPIClient.getProduct(
@@ -946,6 +949,9 @@ void main() {
 
       expect(russianProduct.countriesTags, equals(['en:russia']));
       expect(russianProduct.countriesTagsTranslated, equals(['Россия']));
+
+      expect(
+          russianProduct.translatedLang, equals(OpenFoodFactsLanguage.RUSSIAN));
     });
 
     test('translated fields when product is translated into a second language',
@@ -963,7 +969,7 @@ void main() {
 
       Product russianInputProduct = Product(
         barcode: barcode,
-        lang: OpenFoodFactsLanguage.RUSSIAN,
+        translatedLang: OpenFoodFactsLanguage.RUSSIAN,
         productNameTranslated: 'Блинчики',
         ingredientsTextTranslated: 'Мука, вода',
       );
@@ -1017,6 +1023,9 @@ void main() {
       expect(englishProduct.countriesTags, equals(['en:russia']));
       expect(englishProduct.countriesTagsTranslated, equals(['Russia']));
 
+      expect(
+          englishProduct.translatedLang, equals(OpenFoodFactsLanguage.ENGLISH));
+
       // Russian!
 
       ProductResult russianResult = await OpenFoodAPIClient.getProduct(
@@ -1040,6 +1049,9 @@ void main() {
 
       expect(russianProduct.countriesTags, equals(['en:russia']));
       expect(russianProduct.countriesTagsTranslated, equals(['Россия']));
+
+      expect(
+          russianProduct.translatedLang, equals(OpenFoodFactsLanguage.RUSSIAN));
     });
   });
 }


### PR DESCRIPTION
Adding more translated product fields for #151

- Added several `Translated`-fields to Product.
- Marked the `de`, `en` and `fr` fields as deprecated because now (almost`*`) same functionality is available by the `translated` fields.
    `*` - "almost" - because now to get a product name in 3 those language the SDK user has to make 3 requests. If that's an issue - the `deprecated` annotation can of course be removed.
- Many fields of Product are reordered so that related fields would be declared close to each other.
- Product's constructor received new arguments it didn't have before for some reason.
- `Product.toJson` now fills translated fields when they're specified
- Product got a new method - `toValidatedData`, it's used instead of `toData` when a product is sent to the server, and it validates the product state before returning a result. This function would allow SDK users to find errors quicker.
- Extracted common logic from `ProductQueryConfigurations` and `ProductSearchQueryConfiguration` into a function in `ProductFields`. Also removed modification of the Configuration objects from this common logic - seemed strange that a `get`-function made significant state mutation.