### PR TITLE
Make the example subproject to depend on the parent folder

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,12 +3,14 @@ description: example for this dart API
 version: 0.0.2
 author: Alexander Schacht <grumpf@gmx.de>
 homepage: https://github.com/Grumpf86/openfoodfacts-dart
+publish_to: none
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  openfoodfacts: ^1.0.2-beta
+  openfoodfacts:
+    path: ../
 
 dev_dependencies:
   test: any


### PR DESCRIPTION
The `example` subproject currently has `openfoodfacts: ^1.0.2-beta` as its dependency, which breaks its compilation since the latest openfoodfacts is `^1.1.0-beta`.

Seems that the example project should rather depend on the most up to date code, which is always stored in its parent folder.
This way no one will ever forget to change a version in its pubspec.yaml.