### PR TITLE
feat: add agribalyse score to EcoscoreData

### DIFF
--- a/lib/model/EcoscoreData.dart
+++ b/lib/model/EcoscoreData.dart
@@ -25,7 +25,13 @@ class EcoscoreData extends JsonObject {
   @JsonKey(includeIfNull: false)
   EcoscoreAdjustments? adjustments;
 
-  EcoscoreData({this.grade, this.score, this.status, this.agribalyse, this.adjustments});
+  EcoscoreData({
+    this.grade,
+    this.score,
+    this.status,
+    this.agribalyse,
+    this.adjustments,
+  });
 
   factory EcoscoreData.fromJson(Map<String, dynamic> json) =>
       _$EcoscoreDataFromJson(json);

--- a/lib/model/EcoscoreData.dart
+++ b/lib/model/EcoscoreData.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import '../interface/JsonObject.dart';
+import 'Agribalyse.dart';
 import 'EcoscoreAdjustments.dart';
 
 part 'EcoscoreData.g.dart';
@@ -20,9 +21,11 @@ class EcoscoreData extends JsonObject {
   @JsonKey(includeIfNull: false)
   EcoscoreStatus? status;
   @JsonKey(includeIfNull: false)
+  Agribalyse? agribalyse;
+  @JsonKey(includeIfNull: false)
   EcoscoreAdjustments? adjustments;
 
-  EcoscoreData({this.grade, this.score, this.status, this.adjustments});
+  EcoscoreData({this.grade, this.score, this.status, this.agribalyse, this.adjustments});
 
   factory EcoscoreData.fromJson(Map<String, dynamic> json) =>
       _$EcoscoreDataFromJson(json);

--- a/lib/model/EcoscoreData.g.dart
+++ b/lib/model/EcoscoreData.g.dart
@@ -11,6 +11,9 @@ EcoscoreData _$EcoscoreDataFromJson(Map<String, dynamic> json) {
     grade: json['grade'] as String?,
     score: JsonObject.parseDouble(json['score']),
     status: _$enumDecodeNullable(_$EcoscoreStatusEnumMap, json['status']),
+    agribalyse: json['agribalyse'] == null
+        ? null
+        : Agribalyse.fromJson(json['agribalyse'] as Map<String, dynamic>),
     adjustments: json['adjustments'] == null
         ? null
         : EcoscoreAdjustments.fromJson(
@@ -30,6 +33,7 @@ Map<String, dynamic> _$EcoscoreDataToJson(EcoscoreData instance) {
   writeNotNull('grade', instance.grade);
   writeNotNull('score', instance.score);
   writeNotNull('status', _$EcoscoreStatusEnumMap[instance.status]);
+  writeNotNull('agribalyse', instance.agribalyse?.toJson());
   writeNotNull('adjustments', instance.adjustments?.toJson());
   return val;
 }

--- a/test/api_getProductRaw_test.dart
+++ b/test/api_getProductRaw_test.dart
@@ -77,7 +77,7 @@ void main() {
       expect(
           result.product!.nutrientLevels!.levels[NutrientLevels.NUTRIENT_SALT],
           Level.MODERATE);
-          print(result.product!.countries);
+      print(result.product!.countries);
       expect(result.product!.countries,
           'Belgien,Deutschland,Niederlande,Spanien,Schweiz, en:france');
     });
@@ -115,8 +115,7 @@ void main() {
       expect(result.product != null, true);
       expect(result.product!.barcode, barcode);
 
-      expect(result.product!.productName,
-          'Elitess Still, Neutral');
+      expect(result.product!.productName, 'Elitess Still, Neutral');
 
       expect(result.product!.nutriments != null, true);
 

--- a/test/api_getProductRaw_test.dart
+++ b/test/api_getProductRaw_test.dart
@@ -77,7 +77,6 @@ void main() {
       expect(
           result.product!.nutrientLevels!.levels[NutrientLevels.NUTRIENT_SALT],
           Level.MODERATE);
-      print(result.product!.countries);
       expect(result.product!.countries,
           'Belgien,Deutschland,Niederlande,Spanien,Schweiz, en:france');
     });

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1,6 +1,5 @@
 import 'package:openfoodfacts/model/AttributeGroup.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
-import 'package:openfoodfacts/model/EcoscoreData.dart';
 import 'package:openfoodfacts/model/NutrientLevels.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/model/ProductResult.dart';
@@ -383,7 +382,7 @@ void main() {
     });
 
     test('product ecoscore', () async {
-      String barcode = '5000112548167';
+      String barcode = '3229820129488';
       ProductQueryConfiguration configurations = ProductQueryConfiguration(
           barcode,
           language: OpenFoodFactsLanguage.ENGLISH,
@@ -397,7 +396,9 @@ void main() {
 
       assert(result.product != null);
       assert(result.product!.ecoscoreGrade != null);
-      assert(result.product!.ecoscoreScore == null);
+      assert(result.product!.ecoscoreScore != null);
+      assert(result.product!.ecoscoreData!.agribalyse != null);
+      assert(result.product!.ecoscoreData!.adjustments != null);
     });
 
     test('product environment impact levels', () async {


### PR DESCRIPTION
I have added the agribalyse field to Product.ecoscoreData.
The Agribalyse class was already existing (but unused) and currently only include the score.