### PR TITLE
feat: add EcoscoreData.missingDataWarning field support

### DIFF
--- a/lib/interface/JsonObject.dart
+++ b/lib/interface/JsonObject.dart
@@ -33,6 +33,18 @@ abstract class JsonObject {
     }
   }
 
+  static bool parseBool(dynamic json) {
+    if (json is String) {
+      return json == '1';
+    } else if (json is int) {
+      return json == 1;
+    } else if (json is bool) {
+      return json;
+    } else {
+      return false;
+    }
+  }
+
   static Map<String, dynamic> removeNullEntries(
       final Map<String, dynamic> input) {
     final Map<String, dynamic> result = {};

--- a/lib/model/EcoscoreData.dart
+++ b/lib/model/EcoscoreData.dart
@@ -24,6 +24,11 @@ class EcoscoreData extends JsonObject {
   Agribalyse? agribalyse;
   @JsonKey(includeIfNull: false)
   EcoscoreAdjustments? adjustments;
+  @JsonKey(
+    name: 'missing_data_warning',
+    fromJson: JsonObject.parseBool,
+  )
+  bool missingDataWarning;
 
   EcoscoreData({
     this.grade,
@@ -31,6 +36,7 @@ class EcoscoreData extends JsonObject {
     this.status,
     this.agribalyse,
     this.adjustments,
+    this.missingDataWarning = false,
   });
 
   factory EcoscoreData.fromJson(Map<String, dynamic> json) =>

--- a/lib/model/EcoscoreData.g.dart
+++ b/lib/model/EcoscoreData.g.dart
@@ -18,6 +18,7 @@ EcoscoreData _$EcoscoreDataFromJson(Map<String, dynamic> json) {
         ? null
         : EcoscoreAdjustments.fromJson(
             json['adjustments'] as Map<String, dynamic>),
+    missingDataWarning: JsonObject.parseBool(json['missing_data_warning']),
   );
 }
 
@@ -35,6 +36,7 @@ Map<String, dynamic> _$EcoscoreDataToJson(EcoscoreData instance) {
   writeNotNull('status', _$EcoscoreStatusEnumMap[instance.status]);
   writeNotNull('agribalyse', instance.agribalyse?.toJson());
   writeNotNull('adjustments', instance.adjustments?.toJson());
+  val['missing_data_warning'] = instance.missingDataWarning;
   return val;
 }
 

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -399,6 +399,7 @@ void main() {
       assert(result.product!.ecoscoreScore != null);
       assert(result.product!.ecoscoreData!.agribalyse != null);
       assert(result.product!.ecoscoreData!.adjustments != null);
+      assert(result.product!.ecoscoreData!.missingDataWarning == false);
     });
 
     test('product environment impact levels', () async {


### PR DESCRIPTION
I have added the support for the `missing_data_warning` field, which allows the user to know the ecoscore may be improved.

However, I have decided to use a non-nullable boolean field, while the returned json use a `1` or empty value. I'm not sure why the server does not use boolean values but I believe it should be simplified here.