### PR TITLE
fix_5/#90 - added comments to Parameter-related classes

### DIFF
--- a/lib/interface/Parameter.dart
+++ b/lib/interface/Parameter.dart
@@ -1,4 +1,6 @@
 /// Abstract search API parameter, to be used in the search URI
+///
+/// Typical use will be 'name=value'
 abstract class Parameter {
   /// URI parameter name
   String getName();
@@ -10,19 +12,4 @@ abstract class Parameter {
   String toString() => '&${getName()}=${getValue()}';
 
   const Parameter();
-
-  /// Adds this parameter to [uriParameters] for the search API URI
-  ///
-  /// Only for [TagFilter]s it's not a simple 'X=Y' URI parameter;
-  /// int that case we need 3 URI parameters, linked by the same [index] value.
-  /// And then we return an incremented value of this index.
-  ///
-  /// But in most cases we don't use [index], and just return it untouched.
-  int addToMap(
-    final Map<String, String> uriParameters,
-    final int index,
-  ) {
-    uriParameters.putIfAbsent(getName(), () => getValue());
-    return index;
-  }
 }

--- a/lib/interface/Parameter.dart
+++ b/lib/interface/Parameter.dart
@@ -1,11 +1,28 @@
+/// Abstract search API parameter, to be used in the search URI
 abstract class Parameter {
+  /// URI parameter name
   String getName();
 
+  /// URI parameter value
   String getValue();
 
-  String toString() {
-    return '&' + getName() + '=' + getValue();
-  }
+  @override
+  String toString() => '&${getName()}=${getValue()}';
 
   const Parameter();
+
+  /// Adds this parameter to [uriParameters] for the search API URI
+  ///
+  /// Only for [TagFilter]s it's not a simple 'X=Y' URI parameter;
+  /// int that case we need 3 URI parameters, linked by the same [index] value.
+  /// And then we return an incremented value of this index.
+  ///
+  /// But in most cases we don't use [index], and just return it untouched.
+  int addToMap(
+    final Map<String, String> uriParameters,
+    final int index,
+  ) {
+    uriParameters.putIfAbsent(getName(), () => getValue());
+    return index;
+  }
 }

--- a/lib/model/parameter/ContainsAdditives.dart
+++ b/lib/model/parameter/ContainsAdditives.dart
@@ -1,17 +1,14 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
+/// "Contains additives?" search API parameter
 class ContainsAdditives extends Parameter {
   @override
-  String getName() {
-    return 'additives';
-  }
+  String getName() => 'additives';
 
   @override
-  String getValue() {
-    return filter! ? 'without' : '';
-  }
+  String getValue() => filter ? 'without' : '';
 
-  final bool? filter;
+  final bool filter;
 
-  const ContainsAdditives({this.filter});
+  const ContainsAdditives({required this.filter});
 }

--- a/lib/model/parameter/OutputFormat.dart
+++ b/lib/model/parameter/OutputFormat.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
+/// "Output format" search API parameter
 class OutputFormat extends Parameter {
   @override
   String getName() {
@@ -17,15 +18,14 @@ class OutputFormat extends Parameter {
   }
 
   @override
-  String getValue() {
-    return '1';
-  }
+  String getValue() => '1';
 
   final Format? format;
 
   const OutputFormat({this.format});
 }
 
+/// Possible output formats for search API
 enum Format {
   JSON,
   XML,

--- a/lib/model/parameter/Page.dart
+++ b/lib/model/parameter/Page.dart
@@ -1,17 +1,14 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
+/// "Page number" search API parameter
 class Page extends Parameter {
   @override
-  String getName() {
-    return 'page';
-  }
+  String getName() => 'page';
 
   @override
-  String getValue() {
-    return page.toString();
-  }
+  String getValue() => page.toString();
 
-  final int? page;
+  final int page;
 
-  const Page({this.page});
+  const Page({required this.page});
 }

--- a/lib/model/parameter/PageSize.dart
+++ b/lib/model/parameter/PageSize.dart
@@ -1,17 +1,14 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
+/// "Page size" search API parameter
 class PageSize extends Parameter {
   @override
-  String getName() {
-    return 'page_size';
-  }
+  String getName() => 'page_size';
 
   @override
-  String getValue() {
-    return size.toString();
-  }
+  String getValue() => size.toString();
 
-  final int? size;
+  final int size;
 
-  const PageSize({this.size});
+  const PageSize({required this.size});
 }

--- a/lib/model/parameter/SearchSimple.dart
+++ b/lib/model/parameter/SearchSimple.dart
@@ -1,15 +1,12 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
+// TODO(teolemon): find what this parameter is all about
 class SearchSimple extends Parameter {
   @override
-  String getName() {
-    return 'search_type';
-  }
+  String getName() => 'search_type';
 
   @override
-  String getValue() {
-    return active ? '1' : '0';
-  }
+  String getValue() => active ? '1' : '0';
 
   final bool active;
 

--- a/lib/model/parameter/SearchTerms.dart
+++ b/lib/model/parameter/SearchTerms.dart
@@ -1,17 +1,14 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
+/// Term list search API parameter
 class SearchTerms extends Parameter {
   @override
-  String getName() {
-    return 'search_terms';
-  }
+  String getName() => 'search_terms';
 
   @override
-  String getValue() {
-    return terms!.join('+');
-  }
+  String getValue() => terms.join('+');
 
-  final List<String>? terms;
+  final List<String> terms;
 
-  const SearchTerms({this.terms});
+  const SearchTerms({required this.terms});
 }

--- a/lib/model/parameter/SortBy.dart
+++ b/lib/model/parameter/SortBy.dart
@@ -1,10 +1,9 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
+/// Sort search API parameter
 class SortBy extends Parameter {
   @override
-  String getName() {
-    return 'sort_by';
-  }
+  String getName() => 'sort_by';
 
   @override
   String getValue() {
@@ -29,6 +28,7 @@ class SortBy extends Parameter {
   const SortBy({this.option});
 }
 
+/// Possible sort options for search API
 enum SortOption {
   POPULARITY,
   PRODUCT_NAME,

--- a/lib/model/parameter/TagFilter.dart
+++ b/lib/model/parameter/TagFilter.dart
@@ -8,10 +8,13 @@ class TagFilter extends Parameter {
   @override
   String getName() => '';
 
+  /// Tag type (e.g. 'nutrition_grades')
   String getTagType() => tagType;
 
+  /// "Contains - Yes/No?" parameter string
   String getContains() => contains ? 'contains' : 'without';
 
+  /// Tag value (e.g. 'A')
   String getTagName() => tagName;
 
   // actually not used
@@ -27,12 +30,4 @@ class TagFilter extends Parameter {
     required this.contains,
     required this.tagName,
   });
-
-  @override
-  int addToMap(final Map<String, String> result, final int currentIndex) {
-    result['tagtype_$currentIndex'] = getTagType();
-    result['tag_contains_$currentIndex'] = getContains();
-    result['tag_$currentIndex'] = getTagName();
-    return currentIndex + 1;
-  }
 }

--- a/lib/model/parameter/TagFilter.dart
+++ b/lib/model/parameter/TagFilter.dart
@@ -1,31 +1,38 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
+/// Tag filter ("LIST contains/without ITEM") search API parameter
+///
+/// Eg. 'nutrition_grades' contains 'A'
 class TagFilter extends Parameter {
+  // actually not used
   @override
-  String getName() {
-    return '';
-  }
+  String getName() => '';
 
-  String? getTagType() {
-    return tagType;
-  }
+  String getTagType() => tagType;
 
-  String getContains() {
-    return contains! ? 'contains' : 'without';
-  }
+  String getContains() => contains ? 'contains' : 'without';
 
-  String? getTagName() {
-    return tagName;
-  }
+  String getTagName() => tagName;
+
+  // actually not used
+  @override
+  String getValue() => '';
+
+  final String tagType;
+  final bool contains;
+  final String tagName;
+
+  const TagFilter({
+    required this.tagType,
+    required this.contains,
+    required this.tagName,
+  });
 
   @override
-  String getValue() {
-    return '';
+  int addToMap(final Map<String, String> result, final int currentIndex) {
+    result['tagtype_$currentIndex'] = getTagType();
+    result['tag_contains_$currentIndex'] = getContains();
+    result['tag_$currentIndex'] = getTagName();
+    return currentIndex + 1;
   }
-
-  final String? tagType;
-  final bool? contains;
-  final String? tagName;
-
-  const TagFilter({this.tagType, this.contains, this.tagName});
 }

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -1,4 +1,5 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
+import 'package:openfoodfacts/model/parameter/TagFilter.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
 
@@ -33,12 +34,19 @@ class ProductSearchQueryConfiguration {
   /// Returns the corresponding search API URI parameter map
   Map<String, String> getParametersMap() {
     var result = <String, String>{};
-
     int filterTagCount = 0;
     for (Parameter p in parametersList) {
-      filterTagCount = p.addToMap(result, filterTagCount);
+      if (p is TagFilter) {
+        TagFilter tf = p;
+        result.putIfAbsent('tagtype_$filterTagCount', () => tf.getTagType());
+        result.putIfAbsent(
+            'tag_contains_$filterTagCount', () => tf.getContains());
+        result.putIfAbsent('tag_$filterTagCount', () => tf.getTagName());
+        filterTagCount++;
+      } else {
+        result.putIfAbsent(p.getName(), () => p.getValue());
+      }
     }
-
     result.putIfAbsent('search_terms', () => '');
 
     if (language != null) {

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -1,8 +1,8 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
-import 'package:openfoodfacts/model/parameter/TagFilter.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
 
+/// Product Search Query Configuration, that helps building search API URI
 class ProductSearchQueryConfiguration {
   OpenFoodFactsLanguage? language;
   // Allow apps to directly provide the language code and country code without
@@ -10,10 +10,15 @@ class ProductSearchQueryConfiguration {
   String? lc;
   String? cc;
   List<ProductField>? fields;
-  List<Parameter>? parametersList;
+  List<Parameter> parametersList;
 
-  ProductSearchQueryConfiguration(
-      {this.language, this.lc, this.cc, this.fields, this.parametersList});
+  ProductSearchQueryConfiguration({
+    this.language,
+    this.lc,
+    this.cc,
+    this.fields,
+    required this.parametersList,
+  });
 
   List<String> getFieldsKeys() {
     List<String> result = [];
@@ -25,31 +30,25 @@ class ProductSearchQueryConfiguration {
     return result;
   }
 
-  Map<String, String?> getParametersMap() {
-    var result = <String, String?>{};
+  /// Returns the corresponding search API URI parameter map
+  Map<String, String> getParametersMap() {
+    var result = <String, String>{};
+
     int filterTagCount = 0;
-    for (Parameter p in parametersList!) {
-      if (p is TagFilter) {
-        TagFilter tf = p;
-        result.putIfAbsent('tagtype_$filterTagCount', () => tf.getTagType());
-        result.putIfAbsent(
-            'tag_contains_$filterTagCount', () => tf.getContains());
-        result.putIfAbsent('tag_$filterTagCount', () => tf.getTagName());
-        filterTagCount++;
-      } else {
-        result.putIfAbsent(p.getName(), () => p.getValue());
-      }
+    for (Parameter p in parametersList) {
+      filterTagCount = p.addToMap(result, filterTagCount);
     }
+
     result.putIfAbsent('search_terms', () => '');
 
     if (language != null) {
-      result.putIfAbsent('lc', () => language.code);
+      result.putIfAbsent('lc', () => language!.code);
     } else if (lc != null) {
-      result.putIfAbsent('lc', () => lc);
+      result.putIfAbsent('lc', () => lc!);
     }
 
     if (cc != null) {
-      result.putIfAbsent('cc', () => cc);
+      result.putIfAbsent('cc', () => cc!);
     }
 
     if (fields != null) {


### PR DESCRIPTION
On the way to a 130/130 pub.dev score...

By the way @teolemon @stephanegigandet: what's the purpose of `search_type=1` or `search_type=0` in the search API URI?

Impacted files:
* `ContainsAdditives.dart`: added a comment on class; refactored as non-nullable
* `OutputFormat.dart`: added a comment on class and enum; refactored
* `Page.dart`: added a comment on class; refactored as non-nullable
* `PageSize.dart`: added a comment on class; refactored as non-nullable
* `Parameter.dart`: added a comment on class; created method `addToMap`
* `ProductSearchQueryConfiguration.dart`: added a comment on class; refactored some fields as non-nullable
* `SearchSimple.dart`: not done much as the purpose of the class is unclear
* `SearchTerms.dart`: added a comment on class; refactored as non-nullable
* `SortBy.dart`: added a comment on class and enum; refactored
* `TagFilter.dart`: added a comment on class and enum; overridden new method `addToMap`; refactored