### PR TITLE
feature/#107 - deprecated useless parameters OutputFormat and SearchSimple

### DIFF
--- a/lib/model/parameter/OutputFormat.dart
+++ b/lib/model/parameter/OutputFormat.dart
@@ -1,21 +1,10 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
-/// "Output format" search API parameter
+// TODO(monsieurtanuki): deprecated from 2021-07-13 (#107) because in fact always JSON; remove when old enough
+@deprecated
 class OutputFormat extends Parameter {
   @override
-  String getName() {
-    switch (format) {
-      case Format.XML:
-        return 'xml';
-
-      case Format.JQM:
-        return 'jqm';
-
-      case Format.JSON:
-      default:
-        return 'json';
-    }
-  }
+  String getName() => 'json';
 
   @override
   String getValue() => '1';
@@ -25,7 +14,8 @@ class OutputFormat extends Parameter {
   const OutputFormat({this.format});
 }
 
-/// Possible output formats for search API
+// TODO(monsieurtanuki): deprecated from 2021-07-13 (#107) because in fact always JSON; remove when old enough
+@deprecated
 enum Format {
   JSON,
   XML,

--- a/lib/model/parameter/SearchSimple.dart
+++ b/lib/model/parameter/SearchSimple.dart
@@ -1,6 +1,7 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
-// TODO(teolemon): find what this parameter is all about
+// TODO(monsieurtanuki): deprecated from 2021-07-13 (#107) because useless; remove when old enough
+@deprecated
 class SearchSimple extends Parameter {
   @override
   String getName() => 'search_type';

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -21,7 +21,6 @@ import 'model/SpellingCorrections.dart';
 import 'model/Status.dart';
 import 'model/User.dart';
 
-import 'model/parameter/OutputFormat.dart';
 import 'utils/HttpHelper.dart';
 import 'utils/LanguageHelper.dart';
 import 'utils/ProductHelper.dart';
@@ -171,9 +170,7 @@ class OpenFoodAPIClient {
   static Future<SearchResult> searchProducts(
       User? user, ProductSearchQueryConfiguration configuration,
       {QueryType queryType = QueryType.PROD}) async {
-    const outputFormat = OutputFormat(format: Format.JSON);
     var queryParameters = configuration.getParametersMap();
-    queryParameters[outputFormat.getName()] = outputFormat.getValue();
 
     var searchUri = Uri(
         scheme: URI_SCHEME,
@@ -197,9 +194,7 @@ class OpenFoodAPIClient {
   static Future<SearchResult> queryPnnsGroup(
       User user, PnnsGroupQueryConfiguration configuration,
       {QueryType queryType = QueryType.PROD}) async {
-    const outputFormat = OutputFormat(format: Format.JSON);
     var queryParameters = configuration.getParametersMap();
-    queryParameters[outputFormat.getName()] = outputFormat.getValue();
 
     var searchUri = Uri(
         scheme: URI_SCHEME,

--- a/lib/utils/PnnsGroupQueryConfiguration.dart
+++ b/lib/utils/PnnsGroupQueryConfiguration.dart
@@ -41,6 +41,9 @@ class PnnsGroupQueryConfiguration {
       }
     }
 
+    // explicit json output
+    result.putIfAbsent('json', () => '1');
+
     return result;
   }
 }

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -73,6 +73,9 @@ class ProductSearchQueryConfiguration {
       }
     }
 
+    // explicit json output
+    result.putIfAbsent('json', () => '1');
+
     return result;
   }
 }

--- a/test/api_searchProducts_test.dart
+++ b/test/api_searchProducts_test.dart
@@ -16,10 +16,8 @@ void main() {
   group('$OpenFoodAPIClient search products', () {
     test('search favorite products', () async {
       var parameters = <Parameter>[
-        const OutputFormat(format: Format.JSON),
         const Page(page: 1),
         const PageSize(size: 10),
-        const SearchSimple(active: true),
         const SortBy(option: SortOption.POPULARITY)
       ];
 
@@ -43,10 +41,8 @@ void main() {
 
     test('search favorite products EN', () async {
       var parameters = <Parameter>[
-        const OutputFormat(format: Format.JSON),
         const Page(page: 14),
         const PageSize(size: 3),
-        const SearchSimple(active: true),
         const SortBy(option: SortOption.EDIT)
       ];
 
@@ -70,10 +66,8 @@ void main() {
 
     test('type bug : ingredient percent int vs String ', () async {
       var parameters = <Parameter>[
-        const OutputFormat(format: Format.JSON),
         const Page(page: 16),
         const PageSize(size: 5),
-        const SearchSimple(active: true),
         const SortBy(option: SortOption.POPULARITY)
       ];
 
@@ -128,10 +122,8 @@ void main() {
 
     test('search products filter additives', () async {
       var parameters = <Parameter>[
-        const OutputFormat(format: Format.JSON),
         const Page(page: 5),
         const PageSize(size: 10),
-        const SearchSimple(active: true),
         const SortBy(option: SortOption.PRODUCT_NAME),
         const SearchTerms(terms: ['Fruit à coques']),
         const ContainsAdditives(filter: false)
@@ -150,10 +142,8 @@ void main() {
       int totalCount = result.count!;
 
       parameters = <Parameter>[
-        const OutputFormat(format: Format.JSON),
         const Page(page: 5),
         const PageSize(size: 10),
-        const SearchSimple(active: true),
         const SortBy(option: SortOption.PRODUCT_NAME),
         const SearchTerms(terms: ['Fruit à coques']),
         const ContainsAdditives(filter: true)
@@ -173,10 +163,8 @@ void main() {
 
     test('search products with filter on tags', () async {
       var parameters = <Parameter>[
-        const OutputFormat(format: Format.JSON),
         const Page(page: 5),
         const PageSize(size: 10),
-        const SearchSimple(active: true),
         const SortBy(option: SortOption.PRODUCT_NAME),
         const TagFilter(
             tagType: 'categories',
@@ -219,7 +207,6 @@ void main() {
           queryType: QueryType.TEST);
 
       var parameters = <Parameter>[
-        const OutputFormat(format: Format.JSON),
         const Page(page: 1),
         const SearchTerms(terms: ['Quoted Coca "Cola"']),
       ];


### PR DESCRIPTION
Impacted files:
* `api_searchProducts_test.dart`: removed all references to `OutputFormat` and `SearchSimple`
* `OutputFormat.dart`: deprecated because in fact always JSON
* `ProductSearchQueryConfiguration.dart`: explicit JSON output
* `SearchSimple.dart`: deprecated because useless