### PR TITLE
Add ability to request and set multiple translated product fields at once

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -76,15 +76,6 @@ List<String> miscTags
 List<String> stateTags
 List<String> tracesTags
 
-
----- Available for RAW products ----
-String productNameDE
-String productNameEN
-String productNameFR
-
-String ingredientsTextDE
-String ingredientsTextEN
-String ingredientsTextFR
 ```
 
 #### ProductImage
@@ -525,3 +516,143 @@ if(result.status != 1) {
 print("Upload was successful");
 ```
 
+## Notes on languages mechanics.
+
+TL;DR: use the "..InLangs" fields if you intend to display products data in
+specific language(s). You __must__ use the "..InLangs" fields if you intend
+to update products. Otherwise you might accidentally corrupt products by
+overwriting proper-language data with improper-language data.
+
+See detailed explanation and examples below.
+
+### Detailed explanation of languages mechanics.
+
+Most of end-user facing apps want to display products data to a user in
+the language(s) the user understands.
+In order for a developer to properly implement multilingual Open Food Facts
+usage, the developer might want to understand how Open Food Facts works with
+languages.
+
+Here are main concepts.
+
+Products in Open Food Facts can have some of their fields in multiple
+languages. Such fields are of 2 types:
+1. Fields with info taken directly from product packaging
+   (like product name and ingredients list). Such fields generally are
+   not touched by the backend and are stored in the DB exactly as they
+   were sent.
+2. Fields with meta-information (like list countries where the product is
+   being sold, or like product's categories). Such fields are processed
+   by the backend in different ways and often shouldn't be displayed to
+   the user as-is.
+
+In addition to that, fields of the [Product] class with multilingual
+support also are of 2 types:
+1. Fields with simple value (e.g. [Product.productName]).
+2. Fields with multilingual values (e.g. [Product.productNameInLangs]).
+
+Lastly, products in Open Food Facts have a main language. That's the
+language which will be used to fill fields of [Product] when no specific
+language settings were provided.
+Most likely you don't want to show the data to your users in the product's
+main language. Most likely you want to prefer data in some specific
+language.
+
+Let's say you want a product to be displayed in German and
+so you've set the value of [AbstractQueryConfiguration.language] to German.
+Here's how the described above types of fields work in combinations:
+1. 1-1 (packaging info + simple value).
+   Fields like [Product.productName] will be in German if the German
+   versions of them are available in OFF.
+   If the German version is not available, the fields will be in the main
+   product's language.
+2. 1-2 (packaging info + multilingual value).
+   Fields like [Product.productNameInLangs] will have the German value
+   inside if it's available.
+   If it's not available, `product.productNameInLangs[GERMAN]`
+   will be `null`.
+3. 2-1 (meta info + simple value).
+   Fields like [Product.countriesTags] __will not be in German__, ever.
+   They will have values like `["en:austria", "en:belgium", "en:canada"]`.
+4. 2-2 (meta info + multilingual value).
+   Fields like [Product.countriesTagsInLangs] will have German values
+   when available, if some of the values is not available in German it
+   will have a language prefix: `["Österreich ", "Belgien", "en:canada"]`.
+
+Those 4 combinations can be observed "in the wild" by
+executing next request:
+https://world.openfoodfacts.org/api/v2/product/3017620422003?lc=de&fields=product_name,product_name_de,countries_tags,countries_tags_de
+
+As you can see, the multilingual values should be prefered in most cases
+when product's data is displayed to a user.
+
+#### Example: display a product in German language or rollback to default.
+
+```dart
+final conf = ProductQueryConfiguration(
+          barcode,
+          language: OpenFoodFactsLanguage.GERMAN,
+          fields: [ProductField.NAME]);
+final product = await OpenFoodAPIClient.getProduct(conf);
+var name = product.productName ?? 'No name';
+_displayProductName(name);
+```
+
+#### Example: display a product in German language, or in Russian,
+#### or rollback to default.
+
+```dart
+final conf = ProductQueryConfiguration(
+          barcode,
+          language: OpenFoodFactsLanguage.GERMAN,
+          secondaryLanguages: [OpenFoodFactsLanguage.RUSSIAN],
+          fields: [ProductField.NAME, ProductField.NAME_IN_LANGS]);
+final product = await OpenFoodAPIClient.getProduct(conf);
+var name = product.productNameInLangs[OpenFoodFactsLanguage.GERMAN];
+name ??= product.productNameInLangs[OpenFoodFactsLanguage.RUSSIAN];
+name ??= product.productName;
+name ??= 'No name';
+_displayProductName(name);
+```
+
+#### Example: display product categories in German language.
+
+```dart
+final conf = ProductQueryConfiguration(
+          barcode,
+          language: OpenFoodFactsLanguage.GERMAN,
+          fields: [ProductField.CATEGORIES_TAGS_IN_LANGS]);
+final product = await OpenFoodAPIClient.getProduct(conf);
+var categories = product.categoriesTagsInLangs[OpenFoodFactsLanguage.GERMAN];
+
+// Erase not translated categories (e.g. "en:cake").
+categories = categories.where((c) => !c.startsWith(RegExp('\w+:')));
+
+_displayProductCategories(categories);
+```
+
+#### Example: update German product categories.
+
+```dart
+final conf = ProductQueryConfiguration(
+          barcode,
+          language: OpenFoodFactsLanguage.GERMAN,
+          fields: [ProductField.CATEGORIES_TAGS_IN_LANGS]);
+final product = await OpenFoodAPIClient.getProduct(conf);
+var categories = product.categoriesTagsInLangs[OpenFoodFactsLanguage.GERMAN];
+
+// Will have only categories which start with
+// lang prefixes (e.g. "en:cake").
+final notTranslatedCategories = categories.where((c) => c.startsWith(RegExp('\w+:')));
+// Translated categories only.
+final translatedCategories = categories.where((c) => !c.startsWith(RegExp('\w+:')));
+
+final updatedCategories = await _askUserToUpdateCategories(
+  translatedCategories);
+// Set updated German categories AND avoid
+// erasure of the not translated ones.
+product.categoriesTagsInLangs[OpenFoodFactsLanguage.GERMAN] =
+  updatedCategories + notTranslatedCategories;
+
+await OpenFoodAPIClient.saveProduct(_user, product);
+```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -518,8 +518,8 @@ print("Upload was successful");
 
 ## Notes on languages mechanics.
 
-TL;DR: use the "..InLangs" fields if you intend to display products data in
-specific language(s). You __must__ use the "..InLangs" fields if you intend
+TL;DR: use the "..InLanguages" fields if you intend to display products data in
+specific language(s). You __must__ use the "..InLanguages" fields if you intend
 to update products. Otherwise you might accidentally corrupt products by
 overwriting proper-language data with improper-language data.
 
@@ -549,7 +549,7 @@ languages. Such fields are of 2 types:
 In addition to that, fields of the [Product] class with multilingual
 support also are of 2 types:
 1. Fields with simple value (e.g. [Product.productName]).
-2. Fields with multilingual values (e.g. [Product.productNameInLangs]).
+2. Fields with multilingual values (e.g. [Product.productNameInLanguages]).
 
 Lastly, products in Open Food Facts have a main language. That's the
 language which will be used to fill fields of [Product] when no specific
@@ -567,15 +567,15 @@ Here's how the described above types of fields work in combinations:
    If the German version is not available, the fields will be in the main
    product's language.
 2. 1-2 (packaging info + multilingual value).
-   Fields like [Product.productNameInLangs] will have the German value
+   Fields like [Product.productNameInLanguages] will have the German value
    inside if it's available.
-   If it's not available, `product.productNameInLangs[GERMAN]`
+   If it's not available, `product.productNameInLanguages[GERMAN]`
    will be `null`.
 3. 2-1 (meta info + simple value).
    Fields like [Product.countriesTags] __will not be in German__, ever.
    They will have values like `["en:austria", "en:belgium", "en:canada"]`.
 4. 2-2 (meta info + multilingual value).
-   Fields like [Product.countriesTagsInLangs] will have German values
+   Fields like [Product.countriesTagsInLanguages] will have German values
    when available, if some of the values is not available in German it
    will have a language prefix: `["Österreich ", "Belgien", "en:canada"]`.
 
@@ -606,11 +606,11 @@ _displayProductName(name);
 final conf = ProductQueryConfiguration(
           barcode,
           language: OpenFoodFactsLanguage.GERMAN,
-          extraLanguages: [OpenFoodFactsLanguage.RUSSIAN],
-          fields: [ProductField.NAME, ProductField.NAME_IN_LANGS]);
+          languages: [OpenFoodFactsLanguage.RUSSIAN],
+          fields: [ProductField.NAME, ProductField.NAME_IN_LANGUAGES]);
 final product = await OpenFoodAPIClient.getProduct(conf);
-var name = product.productNameInLangs[OpenFoodFactsLanguage.GERMAN];
-name ??= product.productNameInLangs[OpenFoodFactsLanguage.RUSSIAN];
+var name = product.productNameInLanguages[OpenFoodFactsLanguage.GERMAN];
+name ??= product.productNameInLanguages[OpenFoodFactsLanguage.RUSSIAN];
 name ??= product.productName;
 name ??= 'No name';
 _displayProductName(name);
@@ -622,9 +622,9 @@ _displayProductName(name);
 final conf = ProductQueryConfiguration(
           barcode,
           language: OpenFoodFactsLanguage.GERMAN,
-          fields: [ProductField.CATEGORIES_TAGS_IN_LANGS]);
+          fields: [ProductField.CATEGORIES_TAGS_IN_LANGUAGES]);
 final product = await OpenFoodAPIClient.getProduct(conf);
-var categories = product.categoriesTagsInLangs[OpenFoodFactsLanguage.GERMAN];
+var categories = product.categoriesTagsInLanguages[OpenFoodFactsLanguage.GERMAN];
 
 // Erase not translated categories (e.g. "en:cake").
 categories = categories.where((c) => !c.startsWith(RegExp('\w+:')));
@@ -638,9 +638,9 @@ _displayProductCategories(categories);
 final conf = ProductQueryConfiguration(
           barcode,
           language: OpenFoodFactsLanguage.GERMAN,
-          fields: [ProductField.CATEGORIES_TAGS_IN_LANGS]);
+          fields: [ProductField.CATEGORIES_TAGS_IN_LANGUAGES]);
 final product = await OpenFoodAPIClient.getProduct(conf);
-var categories = product.categoriesTagsInLangs[OpenFoodFactsLanguage.GERMAN];
+var categories = product.categoriesTagsInLanguages[OpenFoodFactsLanguage.GERMAN];
 
 // Will have only categories which start with
 // lang prefixes (e.g. "en:cake").
@@ -652,7 +652,7 @@ final updatedCategories = await _askUserToUpdateCategories(
   translatedCategories);
 // Set updated German categories AND avoid
 // erasure of the not translated ones.
-product.categoriesTagsInLangs[OpenFoodFactsLanguage.GERMAN] =
+product.categoriesTagsInLanguages[OpenFoodFactsLanguage.GERMAN] =
   updatedCategories + notTranslatedCategories;
 
 await OpenFoodAPIClient.saveProduct(_user, product);

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -537,11 +537,11 @@ Here are main concepts.
 
 Products in Open Food Facts can have some of their fields in multiple
 languages. Such fields are of 2 types:
-1. Fields with info taken directly from product packaging
+1. Text fields with info taken directly from product packaging
    (like product name and ingredients list). Such fields generally are
    not touched by the backend and are stored in the DB exactly as they
    were sent.
-2. Fields with meta-information (like list countries where the product is
+2. Lists of tags with meta-information (like list countries where the product is
    being sold, or like product's categories). Such fields are processed
    by the backend in different ways and often shouldn't be displayed to
    the user as-is.
@@ -594,18 +594,19 @@ final conf = ProductQueryConfiguration(
           language: OpenFoodFactsLanguage.GERMAN,
           fields: [ProductField.NAME]);
 final product = await OpenFoodAPIClient.getProduct(conf);
+// The requested language is German, so `product.productName`
+// either is in German, or in main product's language, or null.
 var name = product.productName ?? 'No name';
 _displayProductName(name);
 ```
 
-#### Example: display a product in German language, or in Russian,
-#### or rollback to default.
+#### Example: display a product in German language, or in Russian, or rollback to default.
 
 ```dart
 final conf = ProductQueryConfiguration(
           barcode,
           language: OpenFoodFactsLanguage.GERMAN,
-          secondaryLanguages: [OpenFoodFactsLanguage.RUSSIAN],
+          languages: [OpenFoodFactsLanguage.RUSSIAN],
           fields: [ProductField.NAME, ProductField.NAME_IN_LANGS]);
 final product = await OpenFoodAPIClient.getProduct(conf);
 var name = product.productNameInLangs[OpenFoodFactsLanguage.GERMAN];

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -606,7 +606,7 @@ _displayProductName(name);
 final conf = ProductQueryConfiguration(
           barcode,
           language: OpenFoodFactsLanguage.GERMAN,
-          languages: [OpenFoodFactsLanguage.RUSSIAN],
+          extraLanguages: [OpenFoodFactsLanguage.RUSSIAN],
           fields: [ProductField.NAME, ProductField.NAME_IN_LANGS]);
 final product = await OpenFoodAPIClient.getProduct(conf);
 var name = product.productNameInLangs[OpenFoodFactsLanguage.GERMAN];

--- a/lib/interface/JsonObject.dart
+++ b/lib/interface/JsonObject.dart
@@ -3,8 +3,12 @@ abstract class JsonObject {
   Map<String, dynamic> toJson();
 
   Map<String, String> toData() {
+    return toDataStatic(toJson());
+  }
+
+  static Map<String, String> toDataStatic(Map<String, dynamic> json) {
     var result = <String, String>{};
-    for (MapEntry<String, dynamic> entry in toJson().entries) {
+    for (MapEntry<String, dynamic> entry in json.entries) {
       result.putIfAbsent(entry.key, () => entry.value.toString());
     }
 

--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -28,11 +28,11 @@ class Product extends JsonObject {
   @JsonKey(name: 'product_name', includeIfNull: false)
   String? productName;
   @JsonKey(
-      name: 'product_name_in_langs',
+      name: 'product_name_in_languages',
       fromJson: LanguageHelper.fromJsonStringMap,
       toJson: LanguageHelper.toJsonStringMap,
       includeIfNull: false)
-  Map<OpenFoodFactsLanguage, String>? productNameInLangs;
+  Map<OpenFoodFactsLanguage, String>? productNameInLanguages;
 
   @JsonKey(name: 'brands', includeIfNull: false)
   String? brands;
@@ -44,11 +44,11 @@ class Product extends JsonObject {
   @JsonKey(name: 'countries_tags', includeIfNull: false)
   List<String>? countriesTags;
   @JsonKey(
-      name: 'countries_tags_in_langs',
+      name: 'countries_tags_in_languages',
       toJson: LanguageHelper.toJsonStringsListMap,
       fromJson: LanguageHelper.fromJsonStringsListMap,
       includeIfNull: false)
-  Map<OpenFoodFactsLanguage, List<String>>? countriesTagsInLangs;
+  Map<OpenFoodFactsLanguage, List<String>>? countriesTagsInLanguages;
 
   @JsonKey(
       name: 'lang',
@@ -119,20 +119,20 @@ class Product extends JsonObject {
   @JsonKey(name: 'ingredients_text', includeIfNull: false)
   String? ingredientsText;
   @JsonKey(
-      name: 'ingredients_text_in_langs',
+      name: 'ingredients_text_in_languages',
       fromJson: LanguageHelper.fromJsonStringMap,
       toJson: LanguageHelper.toJsonStringMap,
       includeIfNull: false)
-  Map<OpenFoodFactsLanguage, String>? ingredientsTextInLangs;
+  Map<OpenFoodFactsLanguage, String>? ingredientsTextInLanguages;
 
   @JsonKey(name: 'ingredients_tags', includeIfNull: false)
   List<String>? ingredientsTags;
   @JsonKey(
-      name: 'ingredients_tags_in_langs',
+      name: 'ingredients_tags_in_languages',
       toJson: LanguageHelper.toJsonStringsListMap,
       fromJson: LanguageHelper.fromJsonStringsListMap,
       includeIfNull: false)
-  Map<OpenFoodFactsLanguage, List<String>>? ingredientsTagsInLangs;
+  Map<OpenFoodFactsLanguage, List<String>>? ingredientsTagsInLanguages;
 
   @JsonKey(
       name: 'ingredients_analysis_tags',
@@ -185,22 +185,22 @@ class Product extends JsonObject {
   @JsonKey(name: 'categories_tags', includeIfNull: false)
   List<String>? categoriesTags;
   @JsonKey(
-      name: 'categories_tags_in_langs',
+      name: 'categories_tags_in_languages',
       toJson: LanguageHelper.toJsonStringsListMap,
       fromJson: LanguageHelper.fromJsonStringsListMap,
       includeIfNull: false)
-  Map<OpenFoodFactsLanguage, List<String>>? categoriesTagsInLangs;
+  Map<OpenFoodFactsLanguage, List<String>>? categoriesTagsInLanguages;
 
   @JsonKey(name: 'labels', includeIfNull: false)
   String? labels;
   @JsonKey(name: 'labels_tags', includeIfNull: false)
   List<String>? labelsTags;
   @JsonKey(
-      name: 'labels_tags_in_langs',
+      name: 'labels_tags_in_languages',
       toJson: LanguageHelper.toJsonStringsListMap,
       fromJson: LanguageHelper.fromJsonStringsListMap,
       includeIfNull: false)
-  Map<OpenFoodFactsLanguage, List<String>>? labelsTagsInLangs;
+  Map<OpenFoodFactsLanguage, List<String>>? labelsTagsInLanguages;
 
   @JsonKey(name: 'packaging', includeIfNull: false)
   String? packaging;
@@ -245,12 +245,12 @@ class Product extends JsonObject {
   Product(
       {this.barcode,
       this.productName,
-      this.productNameInLangs,
+      this.productNameInLanguages,
       this.brands,
       this.brandsTags,
       this.countries,
       this.countriesTags,
-      this.countriesTagsInLangs,
+      this.countriesTagsInLanguages,
       this.lang,
       this.quantity,
       this.imgSmallUrl,
@@ -269,9 +269,9 @@ class Product extends JsonObject {
       this.images,
       this.ingredients,
       this.ingredientsText,
-      this.ingredientsTextInLangs,
+      this.ingredientsTextInLanguages,
       this.ingredientsTags,
-      this.ingredientsTagsInLangs,
+      this.ingredientsTagsInLanguages,
       this.ingredientsAnalysisTags,
       this.nutriments,
       this.additives,
@@ -283,10 +283,10 @@ class Product extends JsonObject {
       this.nutriscore,
       this.categories,
       this.categoriesTags,
-      this.categoriesTagsInLangs,
+      this.categoriesTagsInLanguages,
       this.labels,
       this.labelsTags,
-      this.labelsTagsInLangs,
+      this.labelsTagsInLanguages,
       this.packaging,
       this.packagingTags,
       this.miscTags,
@@ -307,42 +307,42 @@ class Product extends JsonObject {
       } else if (key.startsWith('product_name_')) {
         OpenFoodFactsLanguage lang = _langFrom(key, 'product_name_');
         if (lang != OpenFoodFactsLanguage.UNDEFINED) {
-          result.productNameInLangs ??= {};
-          result.productNameInLangs![lang] = json[key];
+          result.productNameInLanguages ??= {};
+          result.productNameInLanguages![lang] = json[key];
         }
       } else if (key.startsWith('categories_tags_')) {
         OpenFoodFactsLanguage lang = _langFrom(key, 'categories_tags_');
         final values = _jsonValueToList(json[key]);
         if (lang != OpenFoodFactsLanguage.UNDEFINED && values != null) {
-          result.categoriesTagsInLangs ??= {};
-          result.categoriesTagsInLangs![lang] = values;
+          result.categoriesTagsInLanguages ??= {};
+          result.categoriesTagsInLanguages![lang] = values;
         }
       } else if (key.startsWith('ingredients_tags_')) {
         OpenFoodFactsLanguage lang = _langFrom(key, 'ingredients_tags_');
         final values = _jsonValueToList(json[key]);
         if (lang != OpenFoodFactsLanguage.UNDEFINED && values != null) {
-          result.ingredientsTagsInLangs ??= {};
-          result.ingredientsTagsInLangs![lang] = values;
+          result.ingredientsTagsInLanguages ??= {};
+          result.ingredientsTagsInLanguages![lang] = values;
         }
       } else if (key.startsWith('labels_tags_')) {
         OpenFoodFactsLanguage lang = _langFrom(key, 'labels_tags_');
         final values = _jsonValueToList(json[key]);
         if (lang != OpenFoodFactsLanguage.UNDEFINED && values != null) {
-          result.labelsTagsInLangs ??= {};
-          result.labelsTagsInLangs![lang] = values;
+          result.labelsTagsInLanguages ??= {};
+          result.labelsTagsInLanguages![lang] = values;
         }
       } else if (key.startsWith('countries_tags_')) {
         OpenFoodFactsLanguage lang = _langFrom(key, 'countries_tags_');
         final values = _jsonValueToList(json[key]);
         if (lang != OpenFoodFactsLanguage.UNDEFINED && values != null) {
-          result.countriesTagsInLangs ??= {};
-          result.countriesTagsInLangs![lang] = values;
+          result.countriesTagsInLanguages ??= {};
+          result.countriesTagsInLanguages![lang] = values;
         }
       } else if (key.startsWith('ingredients_text_')) {
         OpenFoodFactsLanguage lang = _langFrom(key, 'ingredients_text_');
         if (lang != OpenFoodFactsLanguage.UNDEFINED) {
-          result.ingredientsTextInLangs ??= {};
-          result.ingredientsTextInLangs![lang] = json[key];
+          result.ingredientsTextInLanguages ??= {};
+          result.ingredientsTextInLanguages![lang] = json[key];
         }
       }
     }
@@ -364,13 +364,13 @@ class Product extends JsonObject {
     final keys = json.keys.toList();
 
     for (final key in keys) {
-      // NOTE: '_tags_in_langs' are not supported because tags translation
+      // NOTE: '_tags_in_languages' are not supported because tags translation
       // is done automatically on the server.
-      if (key.endsWith('_in_langs')) {
-        if (key.endsWith('_tags_in_langs')) {
+      if (key.endsWith('_in_languages')) {
+        if (key.endsWith('_tags_in_languages')) {
           throw StateError(
-              'Fields "SOMENAME_tags_in_langs" cannot be sent to the server. '
-              'Please send localized values either by "SOMENAME_in_langs" '
+              'Fields "SOMENAME_tags_in_languages" cannot be sent to the server. '
+              'Please send localized values either by "SOMENAME_in_languages" '
               'field if it exists, or by "SOMENAME" field and '
               'prepending language code to values, e.g.: '
               '{"categories": "en:nuts, en:peanut"}');
@@ -383,7 +383,7 @@ class Product extends JsonObject {
             throw StateError('Cannot send localized field without '
                 'a proper language. Received: $langKey');
           }
-          final keyNoLangs = key.substring(0, key.indexOf('_in_langs'));
+          final keyNoLangs = key.substring(0, key.indexOf('_in_languages'));
           final realKey = '${keyNoLangs}_${lang.code}';
           json[realKey] = entry.value;
         }

--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -16,33 +16,23 @@ import 'Nutriments.dart';
 
 part 'Product.g.dart';
 
+/// This class contains most of the data about a specific product.
+///
+/// Please read the language mechanics explanation if you intend to display
+/// or update data in specific language: https://github.com/openfoodfacts/openfoodfacts-dart/blob/master/DOCUMENTATION.md#about-languages-mechanics
 @JsonSerializable()
 class Product extends JsonObject {
-  @JsonKey(ignore: true)
-  OpenFoodFactsLanguage? translatedLang;
-
   @JsonKey(name: 'code')
   String? barcode;
 
   @JsonKey(name: 'product_name', includeIfNull: false)
   String? productName;
-  @JsonKey(name: 'product_name_translated', includeIfNull: false)
-  String? productNameTranslated;
-
-  /// Deprecated: please use productNameTranslated
-  @JsonKey(name: 'product_name_de', includeIfNull: false)
-  @deprecated
-  String? productNameDE;
-
-  /// Deprecated: please use productNameTranslated
-  @JsonKey(name: 'product_name_en', includeIfNull: false)
-  @deprecated
-  String? productNameEN;
-
-  /// Deprecated: please use productNameTranslated
-  @JsonKey(name: 'product_name_fr', includeIfNull: false)
-  @deprecated
-  String? productNameFR;
+  @JsonKey(
+      name: 'product_name_in_langs',
+      fromJson: LanguageHelper.fromJsonStringMap,
+      toJson: LanguageHelper.toJsonStringMap,
+      includeIfNull: false)
+  Map<OpenFoodFactsLanguage, String>? productNameInLangs;
 
   @JsonKey(name: 'brands', includeIfNull: false)
   String? brands;
@@ -53,8 +43,12 @@ class Product extends JsonObject {
   String? countries;
   @JsonKey(name: 'countries_tags', includeIfNull: false)
   List<String>? countriesTags;
-  @JsonKey(name: 'countries_tags_translated', includeIfNull: false)
-  List<String>? countriesTagsTranslated;
+  @JsonKey(
+      name: 'countries_tags_in_langs',
+      toJson: LanguageHelper.toJsonStringsListMap,
+      fromJson: LanguageHelper.fromJsonStringsListMap,
+      includeIfNull: false)
+  Map<OpenFoodFactsLanguage, List<String>>? countriesTagsInLangs;
 
   @JsonKey(
       name: 'lang',
@@ -124,28 +118,21 @@ class Product extends JsonObject {
 
   @JsonKey(name: 'ingredients_text', includeIfNull: false)
   String? ingredientsText;
-  @JsonKey(name: 'ingredients_text_translated', includeIfNull: false)
-  String? ingredientsTextTranslated;
+  @JsonKey(
+      name: 'ingredients_text_in_langs',
+      fromJson: LanguageHelper.fromJsonStringMap,
+      toJson: LanguageHelper.toJsonStringMap,
+      includeIfNull: false)
+  Map<OpenFoodFactsLanguage, String>? ingredientsTextInLangs;
 
   @JsonKey(name: 'ingredients_tags', includeIfNull: false)
   List<String>? ingredientsTags;
-  @JsonKey(name: 'ingredients_tags_translated', includeIfNull: false)
-  List<String>? ingredientsTagsTranslated;
-
-  /// Deprecated: please use ingredientsTextTranslated
-  @JsonKey(name: 'ingredients_text_de', includeIfNull: false)
-  @deprecated
-  String? ingredientsTextDE;
-
-  /// Deprecated: please use ingredientsTextTranslated
-  @JsonKey(name: 'ingredients_text_en', includeIfNull: false)
-  @deprecated
-  String? ingredientsTextEN;
-
-  /// Deprecated: please use ingredientsTextTranslated
-  @JsonKey(name: 'ingredients_text_fr', includeIfNull: false)
-  @deprecated
-  String? ingredientsTextFR;
+  @JsonKey(
+      name: 'ingredients_tags_in_langs',
+      toJson: LanguageHelper.toJsonStringsListMap,
+      fromJson: LanguageHelper.fromJsonStringsListMap,
+      includeIfNull: false)
+  Map<OpenFoodFactsLanguage, List<String>>? ingredientsTagsInLangs;
 
   @JsonKey(
       name: 'ingredients_analysis_tags',
@@ -197,15 +184,23 @@ class Product extends JsonObject {
   String? categories;
   @JsonKey(name: 'categories_tags', includeIfNull: false)
   List<String>? categoriesTags;
-  @JsonKey(name: 'categories_tags_translated', includeIfNull: false)
-  List<String>? categoriesTagsTranslated;
+  @JsonKey(
+      name: 'categories_tags_in_langs',
+      toJson: LanguageHelper.toJsonStringsListMap,
+      fromJson: LanguageHelper.fromJsonStringsListMap,
+      includeIfNull: false)
+  Map<OpenFoodFactsLanguage, List<String>>? categoriesTagsInLangs;
 
   @JsonKey(name: 'labels', includeIfNull: false)
   String? labels;
   @JsonKey(name: 'labels_tags', includeIfNull: false)
   List<String>? labelsTags;
-  @JsonKey(name: 'labels_tags_translated', includeIfNull: false)
-  List<String>? labelsTagsTranslated;
+  @JsonKey(
+      name: 'labels_tags_in_langs',
+      toJson: LanguageHelper.toJsonStringsListMap,
+      fromJson: LanguageHelper.fromJsonStringsListMap,
+      includeIfNull: false)
+  Map<OpenFoodFactsLanguage, List<String>>? labelsTagsInLangs;
 
   @JsonKey(name: 'packaging', includeIfNull: false)
   String? packaging;
@@ -248,18 +243,14 @@ class Product extends JsonObject {
   EcoscoreData? ecoscoreData;
 
   Product(
-      {this.translatedLang,
-      this.barcode,
+      {this.barcode,
       this.productName,
-      this.productNameTranslated,
-      this.productNameDE,
-      this.productNameEN,
-      this.productNameFR,
+      this.productNameInLangs,
       this.brands,
       this.brandsTags,
       this.countries,
       this.countriesTags,
-      this.countriesTagsTranslated,
+      this.countriesTagsInLangs,
       this.lang,
       this.quantity,
       this.imgSmallUrl,
@@ -278,12 +269,9 @@ class Product extends JsonObject {
       this.images,
       this.ingredients,
       this.ingredientsText,
-      this.ingredientsTextTranslated,
+      this.ingredientsTextInLangs,
       this.ingredientsTags,
-      this.ingredientsTagsTranslated,
-      this.ingredientsTextDE,
-      this.ingredientsTextEN,
-      this.ingredientsTextFR,
+      this.ingredientsTagsInLangs,
       this.ingredientsAnalysisTags,
       this.nutriments,
       this.additives,
@@ -295,10 +283,10 @@ class Product extends JsonObject {
       this.nutriscore,
       this.categories,
       this.categoriesTags,
-      this.categoriesTagsTranslated,
+      this.categoriesTagsInLangs,
       this.labels,
       this.labelsTags,
-      this.labelsTagsTranslated,
+      this.labelsTagsInLangs,
       this.packaging,
       this.packagingTags,
       this.miscTags,
@@ -317,20 +305,52 @@ class Product extends JsonObject {
       if (key.contains('debug')) {
         continue;
       } else if (key.startsWith('product_name_')) {
-        result.productNameTranslated = json[key];
+        OpenFoodFactsLanguage lang = _langFrom(key, 'product_name_');
+        if (lang != OpenFoodFactsLanguage.UNDEFINED) {
+          result.productNameInLangs ??= {};
+          result.productNameInLangs![lang] = json[key];
+        }
       } else if (key.startsWith('categories_tags_')) {
-        result.categoriesTagsTranslated = _jsonValueToList(json[key]);
+        OpenFoodFactsLanguage lang = _langFrom(key, 'categories_tags_');
+        final values = _jsonValueToList(json[key]);
+        if (lang != OpenFoodFactsLanguage.UNDEFINED && values != null) {
+          result.categoriesTagsInLangs ??= {};
+          result.categoriesTagsInLangs![lang] = values;
+        }
       } else if (key.startsWith('ingredients_tags_')) {
-        result.ingredientsTagsTranslated = _jsonValueToList(json[key]);
+        OpenFoodFactsLanguage lang = _langFrom(key, 'ingredients_tags_');
+        final values = _jsonValueToList(json[key]);
+        if (lang != OpenFoodFactsLanguage.UNDEFINED && values != null) {
+          result.ingredientsTagsInLangs ??= {};
+          result.ingredientsTagsInLangs![lang] = values;
+        }
       } else if (key.startsWith('labels_tags_')) {
-        result.labelsTagsTranslated = _jsonValueToList(json[key]);
+        OpenFoodFactsLanguage lang = _langFrom(key, 'labels_tags_');
+        final values = _jsonValueToList(json[key]);
+        if (lang != OpenFoodFactsLanguage.UNDEFINED && values != null) {
+          result.labelsTagsInLangs ??= {};
+          result.labelsTagsInLangs![lang] = values;
+        }
       } else if (key.startsWith('countries_tags_')) {
-        result.countriesTagsTranslated = _jsonValueToList(json[key]);
+        OpenFoodFactsLanguage lang = _langFrom(key, 'countries_tags_');
+        final values = _jsonValueToList(json[key]);
+        if (lang != OpenFoodFactsLanguage.UNDEFINED && values != null) {
+          result.countriesTagsInLangs ??= {};
+          result.countriesTagsInLangs![lang] = values;
+        }
       } else if (key.startsWith('ingredients_text_')) {
-        result.ingredientsTextTranslated = json[key];
+        OpenFoodFactsLanguage lang = _langFrom(key, 'ingredients_text_');
+        if (lang != OpenFoodFactsLanguage.UNDEFINED) {
+          result.ingredientsTextInLangs ??= {};
+          result.ingredientsTextInLangs![lang] = json[key];
+        }
       }
     }
     return result;
+  }
+
+  static OpenFoodFactsLanguage _langFrom(String key, String prefix) {
+    return LanguageHelper.fromJson(key.substring(prefix.length));
   }
 
   static List<String>? _jsonValueToList(dynamic value) {
@@ -338,36 +358,38 @@ class Product extends JsonObject {
   }
 
   Map<String, String> toServerData() {
-    final data = super.toData();
-
-    final lc = translatedLang?.code ?? lang?.code;
+    final json = toJson();
 
     // Defensive keys copy to modify map while iterating
-    final keys = data.keys.toList();
+    final keys = json.keys.toList();
 
     for (final key in keys) {
-      // NOTE: '_tags_translated' are not supported because tags translation
+      // NOTE: '_tags_in_langs' are not supported because tags translation
       // is done automatically on the server.
-      if (key.endsWith('_translated')) {
-        if (lc == null) {
-          throw StateError('Cannot send translated field without language');
-        }
-        if (key.endsWith('_tags_translated')) {
+      if (key.endsWith('_in_langs')) {
+        if (key.endsWith('_tags_in_langs')) {
           throw StateError(
-              'Fields "SOMENAME_tags_translated" cannot be sent to the server. '
-              'Please send translated values either by "SOMENAME_translated" field '
-              'if it exists, or by "SOMENAME" field and '
+              'Fields "SOMENAME_tags_in_langs" cannot be sent to the server. '
+              'Please send localized values either by "SOMENAME_in_langs" '
+              'field if it exists, or by "SOMENAME" field and '
               'prepending language code to values, e.g.: '
               '{"categories": "en:nuts, en:peanut"}');
         }
-        final value = data[key];
-        data.remove(key);
-        final keyUntranslated = key.substring(0, key.indexOf('_translated'));
-        final realKey = '${keyUntranslated}_$lc';
-        data[realKey] = value!;
+        final value = json.remove(key) as Map<String, dynamic>;
+        for (final entry in value.entries) {
+          final langKey = entry.key;
+          final lang = LanguageHelper.fromJson(langKey);
+          if (lang == OpenFoodFactsLanguage.UNDEFINED) {
+            throw StateError('Cannot send localized field without '
+                'a proper language. Received: $langKey');
+          }
+          final keyNoLangs = key.substring(0, key.indexOf('_in_langs'));
+          final realKey = '${keyNoLangs}_${lang.code}';
+          json[realKey] = entry.value;
+        }
       }
     }
-    return data;
+    return JsonObject.toDataStatic(json);
   }
 
   @override

--- a/lib/model/Product.g.dart
+++ b/lib/model/Product.g.dart
@@ -10,10 +10,8 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
   return Product(
     barcode: json['code'] as String?,
     productName: json['product_name'] as String?,
-    productNameTranslated: json['product_name_translated'] as String?,
-    productNameDE: json['product_name_de'] as String?,
-    productNameEN: json['product_name_en'] as String?,
-    productNameFR: json['product_name_fr'] as String?,
+    productNameInLangs: LanguageHelper.fromJsonStringMap(
+        json['product_name_in_langs'] as Map<String, String>?),
     brands: json['brands'] as String?,
     brandsTags: (json['brands_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
@@ -22,10 +20,8 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
     countriesTags: (json['countries_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    countriesTagsTranslated:
-        (json['countries_tags_translated'] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
+    countriesTagsInLangs: LanguageHelper.fromJsonStringsListMap(
+        json['countries_tags_in_langs'] as Map<String, List<String>>?),
     lang: LanguageHelper.fromJson(json['lang'] as String?),
     quantity: json['quantity'] as String?,
     imgSmallUrl: json['image_small_url'] as String?,
@@ -48,17 +44,13 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
         ?.map((e) => Ingredient.fromJson(e as Map<String, dynamic>))
         .toList(),
     ingredientsText: json['ingredients_text'] as String?,
-    ingredientsTextTranslated: json['ingredients_text_translated'] as String?,
+    ingredientsTextInLangs: LanguageHelper.fromJsonStringMap(
+        json['ingredients_text_in_langs'] as Map<String, String>?),
     ingredientsTags: (json['ingredients_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    ingredientsTagsTranslated:
-        (json['ingredients_tags_translated'] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
-    ingredientsTextDE: json['ingredients_text_de'] as String?,
-    ingredientsTextEN: json['ingredients_text_en'] as String?,
-    ingredientsTextFR: json['ingredients_text_fr'] as String?,
+    ingredientsTagsInLangs: LanguageHelper.fromJsonStringsListMap(
+        json['ingredients_tags_in_langs'] as Map<String, List<String>>?),
     ingredientsAnalysisTags: IngredientsAnalysisTags.fromJson(
         json['ingredients_analysis_tags'] as List?),
     nutriments: json['nutriments'] == null
@@ -76,17 +68,14 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
     categoriesTags: (json['categories_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    categoriesTagsTranslated:
-        (json['categories_tags_translated'] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
+    categoriesTagsInLangs: LanguageHelper.fromJsonStringsListMap(
+        json['categories_tags_in_langs'] as Map<String, List<String>>?),
     labels: json['labels'] as String?,
     labelsTags: (json['labels_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    labelsTagsTranslated: (json['labels_tags_translated'] as List<dynamic>?)
-        ?.map((e) => e as String)
-        .toList(),
+    labelsTagsInLangs: LanguageHelper.fromJsonStringsListMap(
+        json['labels_tags_in_langs'] as Map<String, List<String>>?),
     packaging: json['packaging'] as String?,
     packagingTags: (json['packaging_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
@@ -126,15 +115,14 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   }
 
   writeNotNull('product_name', instance.productName);
-  writeNotNull('product_name_translated', instance.productNameTranslated);
-  writeNotNull('product_name_de', instance.productNameDE);
-  writeNotNull('product_name_en', instance.productNameEN);
-  writeNotNull('product_name_fr', instance.productNameFR);
+  writeNotNull('product_name_in_langs',
+      LanguageHelper.toJsonStringMap(instance.productNameInLangs));
   writeNotNull('brands', instance.brands);
   writeNotNull('brands_tags', instance.brandsTags);
   writeNotNull('countries', instance.countries);
   writeNotNull('countries_tags', instance.countriesTags);
-  writeNotNull('countries_tags_translated', instance.countriesTagsTranslated);
+  writeNotNull('countries_tags_in_langs',
+      LanguageHelper.toJsonStringsListMap(instance.countriesTagsInLangs));
   writeNotNull('lang', LanguageHelper.toJson(instance.lang));
   writeNotNull('quantity', instance.quantity);
   writeNotNull('image_small_url', instance.imgSmallUrl);
@@ -156,14 +144,11 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull(
       'ingredients', JsonHelper.ingredientsToJson(instance.ingredients));
   writeNotNull('ingredients_text', instance.ingredientsText);
-  writeNotNull(
-      'ingredients_text_translated', instance.ingredientsTextTranslated);
+  writeNotNull('ingredients_text_in_langs',
+      LanguageHelper.toJsonStringMap(instance.ingredientsTextInLangs));
   writeNotNull('ingredients_tags', instance.ingredientsTags);
-  writeNotNull(
-      'ingredients_tags_translated', instance.ingredientsTagsTranslated);
-  writeNotNull('ingredients_text_de', instance.ingredientsTextDE);
-  writeNotNull('ingredients_text_en', instance.ingredientsTextEN);
-  writeNotNull('ingredients_text_fr', instance.ingredientsTextFR);
+  writeNotNull('ingredients_tags_in_langs',
+      LanguageHelper.toJsonStringsListMap(instance.ingredientsTagsInLangs));
   writeNotNull('ingredients_analysis_tags',
       IngredientsAnalysisTags.toJson(instance.ingredientsAnalysisTags));
   writeNotNull('nutriments', Nutriments.toJsonHelper(instance.nutriments));
@@ -178,10 +163,12 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('nutrition_grade_fr', instance.nutriscore);
   writeNotNull('categories', instance.categories);
   writeNotNull('categories_tags', instance.categoriesTags);
-  writeNotNull('categories_tags_translated', instance.categoriesTagsTranslated);
+  writeNotNull('categories_tags_in_langs',
+      LanguageHelper.toJsonStringsListMap(instance.categoriesTagsInLangs));
   writeNotNull('labels', instance.labels);
   writeNotNull('labels_tags', instance.labelsTags);
-  writeNotNull('labels_tags_translated', instance.labelsTagsTranslated);
+  writeNotNull('labels_tags_in_langs',
+      LanguageHelper.toJsonStringsListMap(instance.labelsTagsInLangs));
   writeNotNull('packaging', instance.packaging);
   writeNotNull('packaging_tags', instance.packagingTags);
   writeNotNull('misc', instance.miscTags);

--- a/lib/model/Product.g.dart
+++ b/lib/model/Product.g.dart
@@ -10,8 +10,8 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
   return Product(
     barcode: json['code'] as String?,
     productName: json['product_name'] as String?,
-    productNameInLangs: LanguageHelper.fromJsonStringMap(
-        json['product_name_in_langs'] as Map<String, String>?),
+    productNameInLanguages: LanguageHelper.fromJsonStringMap(
+        json['product_name_in_languages'] as Map<String, String>?),
     brands: json['brands'] as String?,
     brandsTags: (json['brands_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
@@ -20,8 +20,8 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
     countriesTags: (json['countries_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    countriesTagsInLangs: LanguageHelper.fromJsonStringsListMap(
-        json['countries_tags_in_langs'] as Map<String, List<String>>?),
+    countriesTagsInLanguages: LanguageHelper.fromJsonStringsListMap(
+        json['countries_tags_in_languages'] as Map<String, List<String>>?),
     lang: LanguageHelper.fromJson(json['lang'] as String?),
     quantity: json['quantity'] as String?,
     imgSmallUrl: json['image_small_url'] as String?,
@@ -44,13 +44,13 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
         ?.map((e) => Ingredient.fromJson(e as Map<String, dynamic>))
         .toList(),
     ingredientsText: json['ingredients_text'] as String?,
-    ingredientsTextInLangs: LanguageHelper.fromJsonStringMap(
-        json['ingredients_text_in_langs'] as Map<String, String>?),
+    ingredientsTextInLanguages: LanguageHelper.fromJsonStringMap(
+        json['ingredients_text_in_languages'] as Map<String, String>?),
     ingredientsTags: (json['ingredients_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    ingredientsTagsInLangs: LanguageHelper.fromJsonStringsListMap(
-        json['ingredients_tags_in_langs'] as Map<String, List<String>>?),
+    ingredientsTagsInLanguages: LanguageHelper.fromJsonStringsListMap(
+        json['ingredients_tags_in_languages'] as Map<String, List<String>>?),
     ingredientsAnalysisTags: IngredientsAnalysisTags.fromJson(
         json['ingredients_analysis_tags'] as List?),
     nutriments: json['nutriments'] == null
@@ -68,14 +68,14 @@ Product _$ProductFromJson(Map<String, dynamic> json) {
     categoriesTags: (json['categories_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    categoriesTagsInLangs: LanguageHelper.fromJsonStringsListMap(
-        json['categories_tags_in_langs'] as Map<String, List<String>>?),
+    categoriesTagsInLanguages: LanguageHelper.fromJsonStringsListMap(
+        json['categories_tags_in_languages'] as Map<String, List<String>>?),
     labels: json['labels'] as String?,
     labelsTags: (json['labels_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    labelsTagsInLangs: LanguageHelper.fromJsonStringsListMap(
-        json['labels_tags_in_langs'] as Map<String, List<String>>?),
+    labelsTagsInLanguages: LanguageHelper.fromJsonStringsListMap(
+        json['labels_tags_in_languages'] as Map<String, List<String>>?),
     packaging: json['packaging'] as String?,
     packagingTags: (json['packaging_tags'] as List<dynamic>?)
         ?.map((e) => e as String)
@@ -115,14 +115,14 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   }
 
   writeNotNull('product_name', instance.productName);
-  writeNotNull('product_name_in_langs',
-      LanguageHelper.toJsonStringMap(instance.productNameInLangs));
+  writeNotNull('product_name_in_languages',
+      LanguageHelper.toJsonStringMap(instance.productNameInLanguages));
   writeNotNull('brands', instance.brands);
   writeNotNull('brands_tags', instance.brandsTags);
   writeNotNull('countries', instance.countries);
   writeNotNull('countries_tags', instance.countriesTags);
-  writeNotNull('countries_tags_in_langs',
-      LanguageHelper.toJsonStringsListMap(instance.countriesTagsInLangs));
+  writeNotNull('countries_tags_in_languages',
+      LanguageHelper.toJsonStringsListMap(instance.countriesTagsInLanguages));
   writeNotNull('lang', LanguageHelper.toJson(instance.lang));
   writeNotNull('quantity', instance.quantity);
   writeNotNull('image_small_url', instance.imgSmallUrl);
@@ -144,11 +144,11 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull(
       'ingredients', JsonHelper.ingredientsToJson(instance.ingredients));
   writeNotNull('ingredients_text', instance.ingredientsText);
-  writeNotNull('ingredients_text_in_langs',
-      LanguageHelper.toJsonStringMap(instance.ingredientsTextInLangs));
+  writeNotNull('ingredients_text_in_languages',
+      LanguageHelper.toJsonStringMap(instance.ingredientsTextInLanguages));
   writeNotNull('ingredients_tags', instance.ingredientsTags);
-  writeNotNull('ingredients_tags_in_langs',
-      LanguageHelper.toJsonStringsListMap(instance.ingredientsTagsInLangs));
+  writeNotNull('ingredients_tags_in_languages',
+      LanguageHelper.toJsonStringsListMap(instance.ingredientsTagsInLanguages));
   writeNotNull('ingredients_analysis_tags',
       IngredientsAnalysisTags.toJson(instance.ingredientsAnalysisTags));
   writeNotNull('nutriments', Nutriments.toJsonHelper(instance.nutriments));
@@ -163,12 +163,12 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('nutrition_grade_fr', instance.nutriscore);
   writeNotNull('categories', instance.categories);
   writeNotNull('categories_tags', instance.categoriesTags);
-  writeNotNull('categories_tags_in_langs',
-      LanguageHelper.toJsonStringsListMap(instance.categoriesTagsInLangs));
+  writeNotNull('categories_tags_in_languages',
+      LanguageHelper.toJsonStringsListMap(instance.categoriesTagsInLanguages));
   writeNotNull('labels', instance.labels);
   writeNotNull('labels_tags', instance.labelsTags);
-  writeNotNull('labels_tags_in_langs',
-      LanguageHelper.toJsonStringsListMap(instance.labelsTagsInLangs));
+  writeNotNull('labels_tags_in_languages',
+      LanguageHelper.toJsonStringsListMap(instance.labelsTagsInLanguages));
   writeNotNull('packaging', instance.packaging);
   writeNotNull('packaging_tags', instance.packagingTags);
   writeNotNull('misc', instance.miscTags);

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -71,6 +71,9 @@ class OpenFoodAPIClient {
   /// Add the given product to the database.
   /// By default the query will hit the PROD DB
   /// Returns a Status object as result.
+  ///
+  /// Please read the language mechanics explanation if you intend to display
+  /// or update data in specific language: https://github.com/openfoodfacts/openfoodfacts-dart/blob/master/DOCUMENTATION.md#about-languages-mechanics
   static Future<Status> saveProduct(User user, Product product,
       {QueryType queryType = QueryType.PROD}) async {
     var parameterMap = <String, String>{};
@@ -147,6 +150,9 @@ class OpenFoodAPIClient {
   /// The ProductResult does not contain a product, if the product is not available.
   /// ingredients, images and product name will be prepared for the given language.
   /// By default the query will hit the PROD DB
+  ///
+  /// Please read the language mechanics explanation if you intend to show
+  /// or update data in specific language: https://github.com/openfoodfacts/openfoodfacts-dart/blob/master/DOCUMENTATION.md#about-languages-mechanics
   static Future<ProductResult> getProduct(
       ProductQueryConfiguration configuration,
       {User? user,
@@ -165,8 +171,6 @@ class OpenFoodAPIClient {
     if (result.product != null) {
       ProductHelper.removeImages(result.product!, configuration.language);
       ProductHelper.createImageUrls(result.product!, queryType: queryType);
-      final translatedLang = configuration.lc ?? configuration.language?.code;
-      result.product!.translatedLang = LanguageHelper.fromJson(translatedLang);
     }
 
     return result;

--- a/lib/utils/AbstractQueryConfiguration.dart
+++ b/lib/utils/AbstractQueryConfiguration.dart
@@ -3,38 +3,53 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 
 /// Abstract Query Configuration, that helps build API URI
 abstract class AbstractQueryConfiguration {
+  /// Use to set the desired product language. Cannot be used together with
+  /// the [languages] field.
+  /// See also the comment to the [languages] field.
   OpenFoodFactsLanguage? language;
 
-  /// The [extraLanguages] field should be used when a product is requested
-  /// with fields in multiple languages. I.e. when some of the
-  /// `IN_LANGS` fields are used (e.g. [ProductField.NAME_IN_LANGS]).
+  /// The [languages] field should be used when a product is requested
+  /// with fields in multiple languages. I.e.:
+  /// - when some of the `IN_LANGUAGES` fields are used
+  ///   (e.g. [ProductField.NAME_IN_LANGUAGES]).
+  /// - when Product's text fields are wanted to be filled with either
+  ///   of several languages in prioritized manner
   ///
-  /// However, the `IN_LANGS` fields are also compatible with the [language]
-  /// and [lc] fields - if only 1 language is needed, [extraLanguages] can
-  /// be omitted.
-  List<OpenFoodFactsLanguage> extraLanguages;
-  // Allow apps to directly provide the language code and country code without
-  // having to use the OpenFoodFactsLanguage helper.
+  /// However, the `IN_LANGUAGES` fields are also compatible with the [language]
+  /// field - if only 1 language is needed, [language] can be used.
+  ///
+  /// Please see https://github.com/openfoodfacts/openfoodfacts-dart/blob/master/DOCUMENTATION.md#about-languages-mechanics
+  /// for detailed explanation on how to work with multiple languages.
+  List<OpenFoodFactsLanguage> languages;
+
+  /// Deprecated: please use [language] or [languages]
+  @deprecated
   String? lc;
+
   String? cc;
   List<ProductField>? fields;
 
   AbstractQueryConfiguration({
     this.language,
-    this.extraLanguages = const [],
+    this.languages = const [],
     this.lc,
     this.cc,
     this.fields,
   }) {
     fields ??= [ProductField.ALL];
+    if ((language != null || lc != null) && languages.isNotEmpty) {
+      throw ArgumentError(
+          '[languages] cannot be used together with [language]/[lc]');
+    }
   }
 
   /// Returns the corresponding API URI parameter map
   Map<String, String> getParametersMap() {
     final Map<String, String> result = {};
 
-    if (language != null) {
-      result.putIfAbsent('lc', () => language.code);
+    final languages = language != null ? [language!] : this.languages.toList();
+    if (languages.isNotEmpty) {
+      result.putIfAbsent('lc', () => languages.map((e) => e.code).join(','));
     } else if (lc != null) {
       result.putIfAbsent('lc', () => lc!);
     }
@@ -48,15 +63,6 @@ abstract class AbstractQueryConfiguration {
         (field) => field == ProductField.ALL,
       );
       if (!ignoreFieldsFilter) {
-        final languages = extraLanguages.toList();
-        if (language != null && !languages.contains(language)) {
-          languages.insert(0, language!);
-        }
-        final lcLanguage = LanguageHelper.fromJson(lc);
-        if (lcLanguage != OpenFoodFactsLanguage.UNDEFINED &&
-            !languages.contains(lcLanguage)) {
-          languages.insert(0, lcLanguage);
-        }
         final fieldsStrings = convertFieldsToStrings(fields!, languages);
         result.putIfAbsent('fields', () => fieldsStrings.join(','));
       }

--- a/lib/utils/AbstractQueryConfiguration.dart
+++ b/lib/utils/AbstractQueryConfiguration.dart
@@ -5,14 +5,14 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 abstract class AbstractQueryConfiguration {
   OpenFoodFactsLanguage? language;
 
-  /// The [languages] field should be used when a product is requested
+  /// The [extraLanguages] field should be used when a product is requested
   /// with fields in multiple languages. I.e. when some of the
   /// `IN_LANGS` fields are used (e.g. [ProductField.NAME_IN_LANGS]).
   ///
   /// However, the `IN_LANGS` fields are also compatible with the [language]
-  /// and [lc] fields - if only 1 language is needed, [languages] can
+  /// and [lc] fields - if only 1 language is needed, [extraLanguages] can
   /// be omitted.
-  List<OpenFoodFactsLanguage> languages;
+  List<OpenFoodFactsLanguage> extraLanguages;
   // Allow apps to directly provide the language code and country code without
   // having to use the OpenFoodFactsLanguage helper.
   String? lc;
@@ -21,7 +21,7 @@ abstract class AbstractQueryConfiguration {
 
   AbstractQueryConfiguration({
     this.language,
-    this.languages = const [],
+    this.extraLanguages = const [],
     this.lc,
     this.cc,
     this.fields,
@@ -48,7 +48,7 @@ abstract class AbstractQueryConfiguration {
         (field) => field == ProductField.ALL,
       );
       if (!ignoreFieldsFilter) {
-        final languages = this.languages.toList();
+        final languages = extraLanguages.toList();
         if (language != null && !languages.contains(language)) {
           languages.insert(0, language!);
         }

--- a/lib/utils/AbstractQueryConfiguration.dart
+++ b/lib/utils/AbstractQueryConfiguration.dart
@@ -5,14 +5,14 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 abstract class AbstractQueryConfiguration {
   OpenFoodFactsLanguage? language;
 
-  /// The [secondaryLanguages] field should be used when a product is requested
+  /// The [languages] field should be used when a product is requested
   /// with fields in multiple languages. I.e. when some of the
   /// `IN_LANGS` fields are used (e.g. [ProductField.NAME_IN_LANGS]).
   ///
   /// However, the `IN_LANGS` fields are also compatible with the [language]
-  /// and [lc] fields - if only 1 language is needed, [secondaryLanguages] can
+  /// and [lc] fields - if only 1 language is needed, [languages] can
   /// be omitted.
-  List<OpenFoodFactsLanguage> secondaryLanguages;
+  List<OpenFoodFactsLanguage> languages;
   // Allow apps to directly provide the language code and country code without
   // having to use the OpenFoodFactsLanguage helper.
   String? lc;
@@ -21,7 +21,7 @@ abstract class AbstractQueryConfiguration {
 
   AbstractQueryConfiguration({
     this.language,
-    this.secondaryLanguages = const [],
+    this.languages = const [],
     this.lc,
     this.cc,
     this.fields,
@@ -48,14 +48,14 @@ abstract class AbstractQueryConfiguration {
         (field) => field == ProductField.ALL,
       );
       if (!ignoreFieldsFilter) {
-        final languages = secondaryLanguages.toList();
+        final languages = this.languages.toList();
         if (language != null && !languages.contains(language)) {
-          languages.add(language!);
+          languages.insert(0, language!);
         }
         final lcLanguage = LanguageHelper.fromJson(lc);
         if (lcLanguage != OpenFoodFactsLanguage.UNDEFINED &&
             !languages.contains(lcLanguage)) {
-          languages.add(lcLanguage);
+          languages.insert(0, lcLanguage);
         }
         final fieldsStrings = convertFieldsToStrings(fields!, languages);
         result.putIfAbsent('fields', () => fieldsStrings.join(','));

--- a/lib/utils/LanguageHelper.dart
+++ b/lib/utils/LanguageHelper.dart
@@ -397,4 +397,54 @@ class LanguageHelper {
         (final OpenFoodFactsLanguage language) => language.code == code,
         orElse: () => OpenFoodFactsLanguage.UNDEFINED,
       );
+
+  /// Converts a Map with [OpenFoodFactsLanguage] into
+  /// a map with ISO-639-1 codes.
+  static Map<String, T>? toJsonMap<T>(Map<OpenFoodFactsLanguage, T>? map) {
+    if (map == null) {
+      return null;
+    }
+    return map.map((key, value) => MapEntry(key.code, value));
+  }
+
+  /// Converts a Map with ISO-639-1 codes into
+  /// a map with [OpenFoodFactsLanguage].
+  static Map<OpenFoodFactsLanguage, T>? fromJsonMap<T>(Map<String, T>? map) {
+    if (map == null) {
+      return null;
+    }
+    final result = <OpenFoodFactsLanguage, T>{};
+    for (final key in map.keys) {
+      result[fromJson(key)] = map[key]!;
+    }
+    return result;
+  }
+
+  /// Helper function without generic types. Needed for the
+  /// `@JsonKey` annotation (the annotation can't work with generics).
+  static Map<String, String>? toJsonStringMap(
+      Map<OpenFoodFactsLanguage, String>? map) {
+    return toJsonMap(map);
+  }
+
+  /// Helper function without generic types. Needed for the
+  /// `@JsonKey` annotation (the annotation can't work with generics).
+  static Map<OpenFoodFactsLanguage, String>? fromJsonStringMap(
+      Map<String, String>? map) {
+    return fromJsonMap(map);
+  }
+
+  /// Helper function without generic types. Needed for the
+  /// `@JsonKey` annotation (the annotation can't work with generics).
+  static Map<String, List<String>>? toJsonStringsListMap(
+      Map<OpenFoodFactsLanguage, List<String>>? map) {
+    return toJsonMap(map);
+  }
+
+  /// Helper function without generic types. Needed for the
+  /// `@JsonKey` annotation (the annotation can't work with generics).
+  static Map<OpenFoodFactsLanguage, List<String>>? fromJsonStringsListMap(
+      Map<String, List<String>>? map) {
+    return fromJsonMap(map);
+  }
 }

--- a/lib/utils/ProductFields.dart
+++ b/lib/utils/ProductFields.dart
@@ -4,13 +4,13 @@ import 'package:openfoodfacts/utils/LanguageHelper.dart';
 enum ProductField {
   BARCODE,
   NAME,
-  NAME_IN_LANGS,
+  NAME_IN_LANGUAGES,
   GENERIC_NAME,
   BRANDS,
   BRANDS_TAGS,
   COUNTRIES,
   COUNTRIES_TAGS,
-  COUNTRIES_TAGS_IN_LANGS,
+  COUNTRIES_TAGS_IN_LANGUAGES,
   LANGUAGE,
   QUANTITY,
   SERVING_SIZE,
@@ -28,20 +28,20 @@ enum ProductField {
   IMAGES,
   INGREDIENTS,
   INGREDIENTS_TAGS,
-  INGREDIENTS_TAGS_IN_LANGS,
+  INGREDIENTS_TAGS_IN_LANGUAGES,
   NUTRIMENTS,
   ADDITIVES,
   NUTRIENT_LEVELS,
   INGREDIENTS_TEXT,
-  INGREDIENTS_TEXT_IN_LANGS,
+  INGREDIENTS_TEXT_IN_LANGUAGES,
   NUTRIMENT_ENERGY_UNIT,
   NUTRIMENT_DATA_PER,
   NUTRISCORE,
   CATEGORIES,
   CATEGORIES_TAGS,
-  CATEGORIES_TAGS_IN_LANGS,
+  CATEGORIES_TAGS_IN_LANGUAGES,
   LABELS_TAGS,
-  LABELS_TAGS_IN_LANGS,
+  LABELS_TAGS_IN_LANGUAGES,
   MISC_TAGS,
   STATES_TAGS,
   TRACES_TAGS,
@@ -59,13 +59,13 @@ extension ProductFieldExtension on ProductField {
   static const Map<ProductField, String> _KEYS = {
     ProductField.BARCODE: 'code',
     ProductField.NAME: 'product_name',
-    ProductField.NAME_IN_LANGS: 'product_name_',
+    ProductField.NAME_IN_LANGUAGES: 'product_name_',
     ProductField.GENERIC_NAME: 'generic_name',
     ProductField.BRANDS: 'brands',
     ProductField.BRANDS_TAGS: 'brands_tags',
     ProductField.COUNTRIES: 'countries',
     ProductField.COUNTRIES_TAGS: 'countries_tags',
-    ProductField.COUNTRIES_TAGS_IN_LANGS: 'countries_tags_',
+    ProductField.COUNTRIES_TAGS_IN_LANGUAGES: 'countries_tags_',
     ProductField.LANGUAGE: 'lang',
     ProductField.QUANTITY: 'quantity',
     ProductField.SERVING_SIZE: 'serving_size',
@@ -83,20 +83,20 @@ extension ProductFieldExtension on ProductField {
     ProductField.IMAGES: 'images',
     ProductField.INGREDIENTS: 'ingredients',
     ProductField.INGREDIENTS_TAGS: 'ingredients_tags',
-    ProductField.INGREDIENTS_TAGS_IN_LANGS: 'ingredients_tags_',
+    ProductField.INGREDIENTS_TAGS_IN_LANGUAGES: 'ingredients_tags_',
     ProductField.NUTRIMENTS: 'nutriments',
     ProductField.ADDITIVES: 'additives_tags',
     ProductField.NUTRIENT_LEVELS: 'nutrient_levels',
     ProductField.INGREDIENTS_TEXT: 'ingredients_text',
-    ProductField.INGREDIENTS_TEXT_IN_LANGS: 'ingredients_text_',
+    ProductField.INGREDIENTS_TEXT_IN_LANGUAGES: 'ingredients_text_',
     ProductField.NUTRIMENT_ENERGY_UNIT: 'nutriment_energy_unit',
     ProductField.NUTRIMENT_DATA_PER: 'nutrition_data_per',
     ProductField.NUTRISCORE: 'nutrition_grade_fr',
     ProductField.CATEGORIES: 'categories',
     ProductField.CATEGORIES_TAGS: 'categories_tags',
-    ProductField.CATEGORIES_TAGS_IN_LANGS: 'categories_tags_',
+    ProductField.CATEGORIES_TAGS_IN_LANGUAGES: 'categories_tags_',
     ProductField.LABELS_TAGS: 'labels_tags',
-    ProductField.LABELS_TAGS_IN_LANGS: 'labels_tags_',
+    ProductField.LABELS_TAGS_IN_LANGUAGES: 'labels_tags_',
     ProductField.MISC_TAGS: 'misc',
     ProductField.STATES_TAGS: 'states_tags',
     ProductField.TRACES_TAGS: 'traces_tags',
@@ -113,23 +113,23 @@ extension ProductFieldExtension on ProductField {
   String get key => _KEYS[this] ?? '';
 }
 
-/// NOTE: if one of the fields is IN_LANGS and [languages] is empty -
+/// NOTE: if one of the fields is IN_LANGUAGES and [languages] is empty -
 /// the function will throw.
 List<String> convertFieldsToStrings(
     List<ProductField> fields, List<OpenFoodFactsLanguage> languages) {
   final fieldsStrings = <String>[];
 
-  const fieldsInLangs = [
-    ProductField.CATEGORIES_TAGS_IN_LANGS,
-    ProductField.LABELS_TAGS_IN_LANGS,
-    ProductField.NAME_IN_LANGS,
-    ProductField.COUNTRIES_TAGS_IN_LANGS,
-    ProductField.INGREDIENTS_TEXT_IN_LANGS,
-    ProductField.INGREDIENTS_TAGS_IN_LANGS,
+  const fieldsInLanguages = [
+    ProductField.CATEGORIES_TAGS_IN_LANGUAGES,
+    ProductField.LABELS_TAGS_IN_LANGUAGES,
+    ProductField.NAME_IN_LANGUAGES,
+    ProductField.COUNTRIES_TAGS_IN_LANGUAGES,
+    ProductField.INGREDIENTS_TEXT_IN_LANGUAGES,
+    ProductField.INGREDIENTS_TAGS_IN_LANGUAGES,
   ];
 
   for (final field in fields) {
-    if (fieldsInLangs.contains(field)) {
+    if (fieldsInLanguages.contains(field)) {
       if (languages.isEmpty == null) {
         throw ArgumentError(
             'Cannot request in-lang field $field without language');

--- a/lib/utils/ProductFields.dart
+++ b/lib/utils/ProductFields.dart
@@ -4,13 +4,13 @@ import 'package:openfoodfacts/utils/LanguageHelper.dart';
 enum ProductField {
   BARCODE,
   NAME,
-  NAME_TRANSLATED,
+  NAME_IN_LANGS,
   GENERIC_NAME,
   BRANDS,
   BRANDS_TAGS,
   COUNTRIES,
   COUNTRIES_TAGS,
-  COUNTRIES_TAGS_TRANSLATED,
+  COUNTRIES_TAGS_IN_LANGS,
   LANGUAGE,
   QUANTITY,
   SERVING_SIZE,
@@ -28,20 +28,20 @@ enum ProductField {
   IMAGES,
   INGREDIENTS,
   INGREDIENTS_TAGS,
-  INGREDIENTS_TAGS_TRANSLATED,
+  INGREDIENTS_TAGS_IN_LANGS,
   NUTRIMENTS,
   ADDITIVES,
   NUTRIENT_LEVELS,
   INGREDIENTS_TEXT,
-  INGREDIENTS_TEXT_TRANSLATED,
+  INGREDIENTS_TEXT_IN_LANGS,
   NUTRIMENT_ENERGY_UNIT,
   NUTRIMENT_DATA_PER,
   NUTRISCORE,
   CATEGORIES,
   CATEGORIES_TAGS,
-  CATEGORIES_TAGS_TRANSLATED,
+  CATEGORIES_TAGS_IN_LANGS,
   LABELS_TAGS,
-  LABELS_TAGS_TRANSLATED,
+  LABELS_TAGS_IN_LANGS,
   MISC_TAGS,
   STATES_TAGS,
   TRACES_TAGS,
@@ -59,13 +59,13 @@ extension ProductFieldExtension on ProductField {
   static const Map<ProductField, String> _KEYS = {
     ProductField.BARCODE: 'code',
     ProductField.NAME: 'product_name',
-    ProductField.NAME_TRANSLATED: 'product_name_',
+    ProductField.NAME_IN_LANGS: 'product_name_',
     ProductField.GENERIC_NAME: 'generic_name',
     ProductField.BRANDS: 'brands',
     ProductField.BRANDS_TAGS: 'brands_tags',
     ProductField.COUNTRIES: 'countries',
     ProductField.COUNTRIES_TAGS: 'countries_tags',
-    ProductField.COUNTRIES_TAGS_TRANSLATED: 'countries_tags_',
+    ProductField.COUNTRIES_TAGS_IN_LANGS: 'countries_tags_',
     ProductField.LANGUAGE: 'lang',
     ProductField.QUANTITY: 'quantity',
     ProductField.SERVING_SIZE: 'serving_size',
@@ -83,20 +83,20 @@ extension ProductFieldExtension on ProductField {
     ProductField.IMAGES: 'images',
     ProductField.INGREDIENTS: 'ingredients',
     ProductField.INGREDIENTS_TAGS: 'ingredients_tags',
-    ProductField.INGREDIENTS_TAGS_TRANSLATED: 'ingredients_tags_',
+    ProductField.INGREDIENTS_TAGS_IN_LANGS: 'ingredients_tags_',
     ProductField.NUTRIMENTS: 'nutriments',
     ProductField.ADDITIVES: 'additives_tags',
     ProductField.NUTRIENT_LEVELS: 'nutrient_levels',
     ProductField.INGREDIENTS_TEXT: 'ingredients_text',
-    ProductField.INGREDIENTS_TEXT_TRANSLATED: 'ingredients_text_',
+    ProductField.INGREDIENTS_TEXT_IN_LANGS: 'ingredients_text_',
     ProductField.NUTRIMENT_ENERGY_UNIT: 'nutriment_energy_unit',
     ProductField.NUTRIMENT_DATA_PER: 'nutrition_data_per',
     ProductField.NUTRISCORE: 'nutrition_grade_fr',
     ProductField.CATEGORIES: 'categories',
     ProductField.CATEGORIES_TAGS: 'categories_tags',
-    ProductField.CATEGORIES_TAGS_TRANSLATED: 'categories_tags_',
+    ProductField.CATEGORIES_TAGS_IN_LANGS: 'categories_tags_',
     ProductField.LABELS_TAGS: 'labels_tags',
-    ProductField.LABELS_TAGS_TRANSLATED: 'labels_tags_',
+    ProductField.LABELS_TAGS_IN_LANGS: 'labels_tags_',
     ProductField.MISC_TAGS: 'misc',
     ProductField.STATES_TAGS: 'states_tags',
     ProductField.TRACES_TAGS: 'traces_tags',
@@ -113,27 +113,30 @@ extension ProductFieldExtension on ProductField {
   String get key => _KEYS[this] ?? '';
 }
 
-/// NOTE: if one of the fields is TRANSLATED and language is null -
+/// NOTE: if one of the fields is IN_LANGS and [languages] is empty -
 /// the function will throw.
 List<String> convertFieldsToStrings(
-    List<ProductField> fields, OpenFoodFactsLanguage? language) {
+    List<ProductField> fields, List<OpenFoodFactsLanguage> languages) {
   final fieldsStrings = <String>[];
 
-  const translatedFields = [
-    ProductField.CATEGORIES_TAGS_TRANSLATED,
-    ProductField.LABELS_TAGS_TRANSLATED,
-    ProductField.NAME_TRANSLATED,
-    ProductField.COUNTRIES_TAGS_TRANSLATED,
-    ProductField.INGREDIENTS_TEXT_TRANSLATED,
-    ProductField.INGREDIENTS_TAGS_TRANSLATED,
+  const fieldsInLangs = [
+    ProductField.CATEGORIES_TAGS_IN_LANGS,
+    ProductField.LABELS_TAGS_IN_LANGS,
+    ProductField.NAME_IN_LANGS,
+    ProductField.COUNTRIES_TAGS_IN_LANGS,
+    ProductField.INGREDIENTS_TEXT_IN_LANGS,
+    ProductField.INGREDIENTS_TAGS_IN_LANGS,
   ];
 
   for (final field in fields) {
-    if (translatedFields.contains(field)) {
-      if (language == null) {
-        throw ArgumentError('Cannot request translated field without language');
+    if (fieldsInLangs.contains(field)) {
+      if (languages.isEmpty == null) {
+        throw ArgumentError(
+            'Cannot request in-lang field $field without language');
       }
-      fieldsStrings.add('${field.key}${language.code}');
+      for (final language in languages) {
+        fieldsStrings.add('${field.key}${language.code}');
+      }
     } else {
       fieldsStrings.add(field.key);
     }

--- a/lib/utils/ProductHelper.dart
+++ b/lib/utils/ProductHelper.dart
@@ -38,28 +38,28 @@ class ProductHelper {
   @deprecated
   static void addTranslatedFields(Product product, Map<String, dynamic> source,
       OpenFoodFactsLanguage language) {
-    product.categoriesTagsInLangs ??= {};
-    product.categoriesTagsInLangs![language] =
+    product.categoriesTagsInLanguages ??= {};
+    product.categoriesTagsInLanguages![language] =
         source['categories_tags_${language.code}'];
 
-    product.labelsTagsInLangs ??= {};
-    product.labelsTagsInLangs![language] =
+    product.labelsTagsInLanguages ??= {};
+    product.labelsTagsInLanguages![language] =
         source['labels_tags_${language.code}'];
 
-    product.ingredientsTagsInLangs ??= {};
-    product.ingredientsTagsInLangs![language] =
+    product.ingredientsTagsInLanguages ??= {};
+    product.ingredientsTagsInLanguages![language] =
         source['ingredients_tags_${language.code}'];
 
-    product.ingredientsTextInLangs ??= {};
-    product.ingredientsTextInLangs![language] =
+    product.ingredientsTextInLanguages ??= {};
+    product.ingredientsTextInLanguages![language] =
         source['ingredients_text_${language.code}'];
 
-    product.productNameInLangs = {};
-    product.productNameInLangs![language] =
+    product.productNameInLanguages = {};
+    product.productNameInLanguages![language] =
         source['product_name_${language.code}'];
 
-    product.countriesTagsInLangs = {};
-    product.countriesTagsInLangs![language] =
+    product.countriesTagsInLanguages = {};
+    product.countriesTagsInLanguages![language] =
         source['countries_tags_${language.code}'];
   }
 }

--- a/lib/utils/ProductHelper.dart
+++ b/lib/utils/ProductHelper.dart
@@ -38,14 +38,28 @@ class ProductHelper {
   @deprecated
   static void addTranslatedFields(Product product, Map<String, dynamic> source,
       OpenFoodFactsLanguage language) {
-    product.categoriesTagsTranslated =
+    product.categoriesTagsInLangs ??= {};
+    product.categoriesTagsInLangs![language] =
         source['categories_tags_${language.code}'];
-    product.labelsTagsTranslated = source['labels_tags_${language.code}'];
-    product.ingredientsTagsTranslated =
+
+    product.labelsTagsInLangs ??= {};
+    product.labelsTagsInLangs![language] =
+        source['labels_tags_${language.code}'];
+
+    product.ingredientsTagsInLangs ??= {};
+    product.ingredientsTagsInLangs![language] =
         source['ingredients_tags_${language.code}'];
-    product.ingredientsTextTranslated =
+
+    product.ingredientsTextInLangs ??= {};
+    product.ingredientsTextInLangs![language] =
         source['ingredients_text_${language.code}'];
-    product.productNameTranslated = source['product_name_${language.code}'];
-    product.countriesTagsTranslated = source['countries_tags_${language.code}'];
+
+    product.productNameInLangs = {};
+    product.productNameInLangs![language] =
+        source['product_name_${language.code}'];
+
+    product.countriesTagsInLangs = {};
+    product.countriesTagsInLangs![language] =
+        source['countries_tags_${language.code}'];
   }
 }

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -6,19 +6,19 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductListQueryConfiguration extends AbstractQueryConfiguration {
   final List<String> barcodes;
 
-  /// See [AbstractQueryConfiguration.languages] for
+  /// See [AbstractQueryConfiguration.extraLanguages] for
   /// parameter's description.
   ProductListQueryConfiguration(
     this.barcodes, {
     final OpenFoodFactsLanguage? language,
-    final List<OpenFoodFactsLanguage> languages = const [],
+    final List<OpenFoodFactsLanguage> extraLanguages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
   })  : assert(barcodes.isNotEmpty),
         super(
           language: language,
-          languages: languages,
+          extraLanguages: extraLanguages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -6,19 +6,19 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductListQueryConfiguration extends AbstractQueryConfiguration {
   final List<String> barcodes;
 
-  /// See [AbstractQueryConfiguration.extraLanguages] for
+  /// See [AbstractQueryConfiguration.languages] for
   /// parameter's description.
   ProductListQueryConfiguration(
     this.barcodes, {
     final OpenFoodFactsLanguage? language,
-    final List<OpenFoodFactsLanguage> extraLanguages = const [],
+    final List<OpenFoodFactsLanguage> languages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
   })  : assert(barcodes.isNotEmpty),
         super(
           language: language,
-          extraLanguages: extraLanguages,
+          languages: languages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -6,19 +6,19 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductListQueryConfiguration extends AbstractQueryConfiguration {
   final List<String> barcodes;
 
-  /// See [AbstractQueryConfiguration.secondaryLanguages] for
+  /// See [AbstractQueryConfiguration.languages] for
   /// parameter's description.
   ProductListQueryConfiguration(
     this.barcodes, {
     final OpenFoodFactsLanguage? language,
-    final List<OpenFoodFactsLanguage> secondaryLanguages = const [],
+    final List<OpenFoodFactsLanguage> languages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
   })  : assert(barcodes.isNotEmpty),
         super(
           language: language,
-          secondaryLanguages: secondaryLanguages,
+          languages: languages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -6,15 +6,19 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductListQueryConfiguration extends AbstractQueryConfiguration {
   final List<String> barcodes;
 
+  /// See [AbstractQueryConfiguration.secondaryLanguages] for
+  /// parameter's description.
   ProductListQueryConfiguration(
     this.barcodes, {
     final OpenFoodFactsLanguage? language,
+    final List<OpenFoodFactsLanguage> secondaryLanguages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
   })  : assert(barcodes.isNotEmpty),
         super(
           language: language,
+          secondaryLanguages: secondaryLanguages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -6,18 +6,18 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductQueryConfiguration extends AbstractQueryConfiguration {
   final String barcode;
 
-  /// See [AbstractQueryConfiguration.secondaryLanguages] for
+  /// See [AbstractQueryConfiguration.languages] for
   /// parameter's description.
   ProductQueryConfiguration(
     this.barcode, {
     final OpenFoodFactsLanguage? language,
-    final List<OpenFoodFactsLanguage> secondaryLanguages = const [],
+    final List<OpenFoodFactsLanguage> languages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
   }) : super(
           language: language,
-          secondaryLanguages: secondaryLanguages,
+          languages: languages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -6,18 +6,18 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductQueryConfiguration extends AbstractQueryConfiguration {
   final String barcode;
 
-  /// See [AbstractQueryConfiguration.languages] for
+  /// See [AbstractQueryConfiguration.extraLanguages] for
   /// parameter's description.
   ProductQueryConfiguration(
     this.barcode, {
     final OpenFoodFactsLanguage? language,
-    final List<OpenFoodFactsLanguage> languages = const [],
+    final List<OpenFoodFactsLanguage> extraLanguages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
   }) : super(
           language: language,
-          languages: languages,
+          extraLanguages: extraLanguages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -6,14 +6,18 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductQueryConfiguration extends AbstractQueryConfiguration {
   final String barcode;
 
+  /// See [AbstractQueryConfiguration.secondaryLanguages] for
+  /// parameter's description.
   ProductQueryConfiguration(
     this.barcode, {
     final OpenFoodFactsLanguage? language,
+    final List<OpenFoodFactsLanguage> secondaryLanguages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
   }) : super(
           language: language,
+          secondaryLanguages: secondaryLanguages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -6,18 +6,18 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductQueryConfiguration extends AbstractQueryConfiguration {
   final String barcode;
 
-  /// See [AbstractQueryConfiguration.extraLanguages] for
+  /// See [AbstractQueryConfiguration.languages] for
   /// parameter's description.
   ProductQueryConfiguration(
     this.barcode, {
     final OpenFoodFactsLanguage? language,
-    final List<OpenFoodFactsLanguage> extraLanguages = const [],
+    final List<OpenFoodFactsLanguage> languages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
   }) : super(
           language: language,
-          extraLanguages: extraLanguages,
+          languages: languages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -8,14 +8,18 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
   final List<Parameter> parametersList;
 
+  /// See [AbstractQueryConfiguration.secondaryLanguages] for
+  /// parameter's description.
   ProductSearchQueryConfiguration({
     final OpenFoodFactsLanguage? language,
+    final List<OpenFoodFactsLanguage> secondaryLanguages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
     required this.parametersList,
   }) : super(
           language: language,
+          secondaryLanguages: secondaryLanguages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -8,18 +8,18 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
   final List<Parameter> parametersList;
 
-  /// See [AbstractQueryConfiguration.extraLanguages] for
+  /// See [AbstractQueryConfiguration.languages] for
   /// parameter's description.
   ProductSearchQueryConfiguration({
     final OpenFoodFactsLanguage? language,
-    final List<OpenFoodFactsLanguage> extraLanguages = const [],
+    final List<OpenFoodFactsLanguage> languages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
     required this.parametersList,
   }) : super(
           language: language,
-          extraLanguages: extraLanguages,
+          languages: languages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -8,18 +8,18 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
   final List<Parameter> parametersList;
 
-  /// See [AbstractQueryConfiguration.languages] for
+  /// See [AbstractQueryConfiguration.extraLanguages] for
   /// parameter's description.
   ProductSearchQueryConfiguration({
     final OpenFoodFactsLanguage? language,
-    final List<OpenFoodFactsLanguage> languages = const [],
+    final List<OpenFoodFactsLanguage> extraLanguages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
     required this.parametersList,
   }) : super(
           language: language,
-          languages: languages,
+          extraLanguages: extraLanguages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -8,18 +8,18 @@ import 'package:openfoodfacts/utils/ProductFields.dart';
 class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
   final List<Parameter> parametersList;
 
-  /// See [AbstractQueryConfiguration.secondaryLanguages] for
+  /// See [AbstractQueryConfiguration.languages] for
   /// parameter's description.
   ProductSearchQueryConfiguration({
     final OpenFoodFactsLanguage? language,
-    final List<OpenFoodFactsLanguage> secondaryLanguages = const [],
+    final List<OpenFoodFactsLanguage> languages = const [],
     final String? lc,
     final String? cc,
     final List<ProductField>? fields,
     required this.parametersList,
   }) : super(
           language: language,
-          secondaryLanguages: secondaryLanguages,
+          languages: languages,
           lc: lc,
           cc: cc,
           fields: fields,

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -534,7 +534,7 @@ void main() {
       assert(result.product!.brandsTags != null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameInLangs == null);
+      assert(result.product!.productNameInLanguages == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -551,7 +551,7 @@ void main() {
       assert(result.product!.brandsTags == null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameInLangs == null);
+      assert(result.product!.productNameInLanguages == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -568,7 +568,7 @@ void main() {
       assert(result.product!.brandsTags == null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameInLangs == null);
+      assert(result.product!.productNameInLanguages == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -586,7 +586,7 @@ void main() {
       assert(result.product!.brandsTags == null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameInLangs == null);
+      assert(result.product!.productNameInLanguages == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -908,8 +908,10 @@ void main() {
       Product englishInputProduct = Product(
         barcode: barcode,
         lang: OpenFoodFactsLanguage.ENGLISH,
-        productNameInLangs: {OpenFoodFactsLanguage.ENGLISH: 'Pancakes'},
-        ingredientsTextInLangs: {OpenFoodFactsLanguage.ENGLISH: 'Flour, water'},
+        productNameInLanguages: {OpenFoodFactsLanguage.ENGLISH: 'Pancakes'},
+        ingredientsTextInLanguages: {
+          OpenFoodFactsLanguage.ENGLISH: 'Flour, water'
+        },
         categories: 'Beverages',
         countries: 'Russia',
       );
@@ -920,15 +922,15 @@ void main() {
 
       final fields = [
         ProductField.NAME,
-        ProductField.NAME_IN_LANGS,
+        ProductField.NAME_IN_LANGUAGES,
         ProductField.INGREDIENTS_TEXT,
-        ProductField.INGREDIENTS_TEXT_IN_LANGS,
+        ProductField.INGREDIENTS_TEXT_IN_LANGUAGES,
         ProductField.INGREDIENTS_TAGS,
-        ProductField.INGREDIENTS_TAGS_IN_LANGS,
+        ProductField.INGREDIENTS_TAGS_IN_LANGUAGES,
         ProductField.CATEGORIES_TAGS,
-        ProductField.CATEGORIES_TAGS_IN_LANGS,
+        ProductField.CATEGORIES_TAGS_IN_LANGUAGES,
         ProductField.COUNTRIES_TAGS,
-        ProductField.COUNTRIES_TAGS_IN_LANGS,
+        ProductField.COUNTRIES_TAGS_IN_LANGUAGES,
       ];
 
       ProductQueryConfiguration englishConf = ProductQueryConfiguration(barcode,
@@ -945,30 +947,30 @@ void main() {
       Product englishProduct = englishResult.product!;
 
       expect(englishProduct.productName, equals('Pancakes'));
-      expect(englishProduct.productNameInLangs,
+      expect(englishProduct.productNameInLanguages,
           equals({OpenFoodFactsLanguage.ENGLISH: 'Pancakes'}));
 
       expect(englishProduct.ingredientsText, equals('Flour, water'));
-      expect(englishProduct.ingredientsTextInLangs,
+      expect(englishProduct.ingredientsTextInLanguages,
           equals({OpenFoodFactsLanguage.ENGLISH: 'Flour, water'}));
 
       expect(englishProduct.ingredientsTags, equals(['en:flour', 'en:water']));
       expect(
-          englishProduct.ingredientsTagsInLangs,
+          englishProduct.ingredientsTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: ['Flour', 'Water']
           }));
 
       expect(englishProduct.categoriesTags, equals(['en:beverages']));
       expect(
-          englishProduct.categoriesTagsInLangs,
+          englishProduct.categoriesTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: ['Beverages']
           }));
 
       expect(englishProduct.countriesTags, equals(['en:russia']));
       expect(
-          englishProduct.countriesTagsInLangs,
+          englishProduct.countriesTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: ['Russia']
           }));
@@ -982,28 +984,28 @@ void main() {
       Product russianProduct = russianResult.product!;
 
       expect(russianProduct.productName, equals('Pancakes'));
-      expect(russianProduct.productNameInLangs, isNull);
+      expect(russianProduct.productNameInLanguages, isNull);
 
       expect(russianProduct.ingredientsText, equals('Flour, water'));
-      expect(russianProduct.ingredientsTextInLangs, isNull);
+      expect(russianProduct.ingredientsTextInLanguages, isNull);
 
       expect(russianProduct.ingredientsTags, equals(['en:flour', 'en:water']));
       expect(
-          russianProduct.ingredientsTagsInLangs,
+          russianProduct.ingredientsTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.RUSSIAN: ['Мука', 'Вода']
           }));
 
       expect(russianProduct.categoriesTags, equals(['en:beverages']));
       expect(
-          russianProduct.categoriesTagsInLangs,
+          russianProduct.categoriesTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.RUSSIAN: ['Напитки']
           }));
 
       expect(russianProduct.countriesTags, equals(['en:russia']));
       expect(
-          russianProduct.countriesTagsInLangs,
+          russianProduct.countriesTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.RUSSIAN: ['Россия']
           }));
@@ -1016,16 +1018,20 @@ void main() {
       Product englishInputProduct = Product(
         barcode: barcode,
         lang: OpenFoodFactsLanguage.ENGLISH,
-        productNameInLangs: {OpenFoodFactsLanguage.ENGLISH: 'Pancakes'},
-        ingredientsTextInLangs: {OpenFoodFactsLanguage.ENGLISH: 'Flour, water'},
+        productNameInLanguages: {OpenFoodFactsLanguage.ENGLISH: 'Pancakes'},
+        ingredientsTextInLanguages: {
+          OpenFoodFactsLanguage.ENGLISH: 'Flour, water'
+        },
         categories: 'Beverages',
         countries: 'Russia',
       );
 
       Product russianInputProduct = Product(
         barcode: barcode,
-        productNameInLangs: {OpenFoodFactsLanguage.RUSSIAN: 'Блинчики'},
-        ingredientsTextInLangs: {OpenFoodFactsLanguage.RUSSIAN: 'Мука, вода'},
+        productNameInLanguages: {OpenFoodFactsLanguage.RUSSIAN: 'Блинчики'},
+        ingredientsTextInLanguages: {
+          OpenFoodFactsLanguage.RUSSIAN: 'Мука, вода'
+        },
       );
 
       await OpenFoodAPIClient.saveProduct(
@@ -1037,15 +1043,15 @@ void main() {
 
       final fields = [
         ProductField.NAME,
-        ProductField.NAME_IN_LANGS,
+        ProductField.NAME_IN_LANGUAGES,
         ProductField.INGREDIENTS_TEXT,
-        ProductField.INGREDIENTS_TEXT_IN_LANGS,
+        ProductField.INGREDIENTS_TEXT_IN_LANGUAGES,
         ProductField.INGREDIENTS_TAGS,
-        ProductField.INGREDIENTS_TAGS_IN_LANGS,
+        ProductField.INGREDIENTS_TAGS_IN_LANGUAGES,
         ProductField.CATEGORIES_TAGS,
-        ProductField.CATEGORIES_TAGS_IN_LANGS,
+        ProductField.CATEGORIES_TAGS_IN_LANGUAGES,
         ProductField.COUNTRIES_TAGS,
-        ProductField.COUNTRIES_TAGS_IN_LANGS,
+        ProductField.COUNTRIES_TAGS_IN_LANGUAGES,
       ];
 
       ProductQueryConfiguration englishConf = ProductQueryConfiguration(barcode,
@@ -1062,30 +1068,30 @@ void main() {
       Product englishProduct = englishResult.product!;
 
       expect(englishProduct.productName, equals('Pancakes'));
-      expect(englishProduct.productNameInLangs,
+      expect(englishProduct.productNameInLanguages,
           equals({OpenFoodFactsLanguage.ENGLISH: 'Pancakes'}));
 
       expect(englishProduct.ingredientsText, equals('Flour, water'));
-      expect(englishProduct.ingredientsTextInLangs,
+      expect(englishProduct.ingredientsTextInLanguages,
           equals({OpenFoodFactsLanguage.ENGLISH: 'Flour, water'}));
 
       expect(englishProduct.ingredientsTags, equals(['en:flour', 'en:water']));
       expect(
-          englishProduct.ingredientsTagsInLangs,
+          englishProduct.ingredientsTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: ['Flour', 'Water']
           }));
 
       expect(englishProduct.categoriesTags, equals(['en:beverages']));
       expect(
-          englishProduct.categoriesTagsInLangs,
+          englishProduct.categoriesTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: ['Beverages']
           }));
 
       expect(englishProduct.countriesTags, equals(['en:russia']));
       expect(
-          englishProduct.countriesTagsInLangs,
+          englishProduct.countriesTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: ['Russia']
           }));
@@ -1099,47 +1105,47 @@ void main() {
       Product russianProduct = russianResult.product!;
 
       expect(russianProduct.productName, equals('Блинчики'));
-      expect(russianProduct.productNameInLangs,
+      expect(russianProduct.productNameInLanguages,
           equals({OpenFoodFactsLanguage.RUSSIAN: 'Блинчики'}));
 
       expect(russianProduct.ingredientsText, equals('Мука, вода'));
-      expect(russianProduct.ingredientsTextInLangs,
+      expect(russianProduct.ingredientsTextInLanguages,
           equals({OpenFoodFactsLanguage.RUSSIAN: 'Мука, вода'}));
 
       expect(russianProduct.ingredientsTags, equals(['en:flour', 'en:water']));
       expect(
-          russianProduct.ingredientsTagsInLangs,
+          russianProduct.ingredientsTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.RUSSIAN: ['Мука', 'Вода']
           }));
 
       expect(russianProduct.categoriesTags, equals(['en:beverages']));
       expect(
-          russianProduct.categoriesTagsInLangs,
+          russianProduct.categoriesTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.RUSSIAN: ['Напитки']
           }));
 
       expect(russianProduct.countriesTags, equals(['en:russia']));
       expect(
-          russianProduct.countriesTagsInLangs,
+          russianProduct.countriesTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.RUSSIAN: ['Россия']
           }));
     });
 
-    test('multiple secondary languages', () async {
+    test('multiple languages and in-languages fields', () async {
       String barcode = '2222222222224';
 
       Product inputProduct = Product(
         barcode: barcode,
         lang: OpenFoodFactsLanguage.ENGLISH,
-        productNameInLangs: {
+        productNameInLanguages: {
           OpenFoodFactsLanguage.ENGLISH: 'Pancakes',
           OpenFoodFactsLanguage.RUSSIAN: 'Блинчики',
           OpenFoodFactsLanguage.GERMAN: 'Pfannkuchen',
         },
-        ingredientsTextInLangs: {
+        ingredientsTextInLanguages: {
           OpenFoodFactsLanguage.ENGLISH: 'Flour, water',
           OpenFoodFactsLanguage.RUSSIAN: 'Мука, вода',
           OpenFoodFactsLanguage.GERMAN: 'Mehl, wasser',
@@ -1153,19 +1159,19 @@ void main() {
 
       final fields = [
         ProductField.NAME,
-        ProductField.NAME_IN_LANGS,
+        ProductField.NAME_IN_LANGUAGES,
         ProductField.INGREDIENTS_TEXT,
-        ProductField.INGREDIENTS_TEXT_IN_LANGS,
+        ProductField.INGREDIENTS_TEXT_IN_LANGUAGES,
         ProductField.INGREDIENTS_TAGS,
-        ProductField.INGREDIENTS_TAGS_IN_LANGS,
+        ProductField.INGREDIENTS_TAGS_IN_LANGUAGES,
         ProductField.CATEGORIES_TAGS,
-        ProductField.CATEGORIES_TAGS_IN_LANGS,
+        ProductField.CATEGORIES_TAGS_IN_LANGUAGES,
         ProductField.COUNTRIES_TAGS,
-        ProductField.COUNTRIES_TAGS_IN_LANGS,
+        ProductField.COUNTRIES_TAGS_IN_LANGUAGES,
       ];
 
       ProductQueryConfiguration conf = ProductQueryConfiguration(barcode,
-          extraLanguages: [
+          languages: [
             OpenFoodFactsLanguage.ENGLISH,
             OpenFoodFactsLanguage.RUSSIAN,
             OpenFoodFactsLanguage.GERMAN
@@ -1178,7 +1184,7 @@ void main() {
 
       expect(product.productName, equals('Pancakes'));
       expect(
-          product.productNameInLangs,
+          product.productNameInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: 'Pancakes',
             OpenFoodFactsLanguage.RUSSIAN: 'Блинчики',
@@ -1187,7 +1193,7 @@ void main() {
 
       expect(product.ingredientsText, equals('Flour, water'));
       expect(
-          product.ingredientsTextInLangs,
+          product.ingredientsTextInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: 'Flour, water',
             OpenFoodFactsLanguage.RUSSIAN: 'Мука, вода',
@@ -1196,7 +1202,7 @@ void main() {
 
       expect(product.ingredientsTags, equals(['en:flour', 'en:water']));
       expect(
-          product.ingredientsTagsInLangs,
+          product.ingredientsTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: ['Flour', 'Water'],
             OpenFoodFactsLanguage.RUSSIAN: ['Мука', 'Вода'],
@@ -1205,7 +1211,7 @@ void main() {
 
       expect(product.categoriesTags, equals(['en:beverages']));
       expect(
-          product.categoriesTagsInLangs,
+          product.categoriesTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: ['Beverages'],
             OpenFoodFactsLanguage.RUSSIAN: ['Напитки'],
@@ -1214,12 +1220,85 @@ void main() {
 
       expect(product.countriesTags, equals(['en:russia']));
       expect(
-          product.countriesTagsInLangs,
+          product.countriesTagsInLanguages,
           equals({
             OpenFoodFactsLanguage.ENGLISH: ['Russia'],
             OpenFoodFactsLanguage.RUSSIAN: ['Россия'],
             OpenFoodFactsLanguage.GERMAN: ['Russland'],
           }));
+    });
+
+    test('multiple languages and text fields priority', () async {
+      String barcode = '2222222222225';
+
+      Product inputProduct = Product(
+        barcode: barcode,
+        lang: OpenFoodFactsLanguage.ENGLISH,
+        productNameInLanguages: {
+          OpenFoodFactsLanguage.ENGLISH: 'Pancakes',
+          OpenFoodFactsLanguage.RUSSIAN: 'Блинчики',
+          OpenFoodFactsLanguage.GERMAN: 'Pfannkuchen',
+        },
+        ingredientsTextInLanguages: {
+          OpenFoodFactsLanguage.ENGLISH: 'Flour, water',
+          OpenFoodFactsLanguage.GERMAN: 'Mehl, wasser',
+        },
+      );
+
+      await OpenFoodAPIClient.saveProduct(TestConstants.TEST_USER, inputProduct,
+          queryType: QueryType.TEST);
+
+      final fields = [
+        ProductField.NAME,
+        ProductField.INGREDIENTS_TEXT,
+      ];
+
+      // English first
+      ProductQueryConfiguration conf = ProductQueryConfiguration(barcode,
+          languages: [
+            OpenFoodFactsLanguage.ENGLISH,
+            OpenFoodFactsLanguage.RUSSIAN,
+            OpenFoodFactsLanguage.GERMAN,
+          ],
+          fields: fields);
+      ProductResult result = await OpenFoodAPIClient.getProduct(conf,
+          user: TestConstants.TEST_USER, queryType: QueryType.TEST);
+      Product product = result.product!;
+      // English was of highest priority so English texts are expected
+      expect(product.productName, equals('Pancakes'));
+      expect(product.ingredientsText, equals('Flour, water'));
+
+      // German first
+      conf = ProductQueryConfiguration(barcode,
+          languages: [
+            OpenFoodFactsLanguage.GERMAN,
+            OpenFoodFactsLanguage.RUSSIAN,
+            OpenFoodFactsLanguage.ENGLISH,
+          ],
+          fields: fields);
+      result = await OpenFoodAPIClient.getProduct(conf,
+          user: TestConstants.TEST_USER, queryType: QueryType.TEST);
+      product = result.product!;
+      // German was of highest priority so German texts are expected
+      expect(product.productName, equals('Pfannkuchen'));
+      expect(product.ingredientsText, equals('Mehl, wasser'));
+
+      // Russian first
+      conf = ProductQueryConfiguration(barcode,
+          languages: [
+            OpenFoodFactsLanguage.RUSSIAN,
+            OpenFoodFactsLanguage.GERMAN,
+            OpenFoodFactsLanguage.ENGLISH,
+          ],
+          fields: fields);
+      result = await OpenFoodAPIClient.getProduct(conf,
+          user: TestConstants.TEST_USER, queryType: QueryType.TEST);
+      product = result.product!;
+      // Russian was of highest priority so Russian _name_ is expected...
+      expect(product.productName, equals('Блинчики'));
+      // ...but there's no ingredients list in Russian so ingredients list with
+      // next priority (German) is expected to be used.
+      expect(product.ingredientsText, equals('Mehl, wasser'));
     });
 
     test('product with quotes', () async {

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -534,7 +534,7 @@ void main() {
       assert(result.product!.brandsTags != null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameTranslated == null);
+      assert(result.product!.productNameInLangs == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -551,7 +551,7 @@ void main() {
       assert(result.product!.brandsTags == null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameTranslated == null);
+      assert(result.product!.productNameInLangs == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -568,7 +568,7 @@ void main() {
       assert(result.product!.brandsTags == null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameTranslated == null);
+      assert(result.product!.productNameInLangs == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -586,7 +586,7 @@ void main() {
       assert(result.product!.brandsTags == null);
       assert(result.product!.ingredients == null);
       assert(result.product!.ingredientsText == null);
-      assert(result.product!.productNameTranslated == null);
+      assert(result.product!.productNameInLangs == null);
       assert(result.product!.additives!.ids.isEmpty);
       assert(result.product!.additives!.names.isEmpty);
       assert(result.product!.nutrientLevels!.levels.isEmpty);
@@ -901,15 +901,15 @@ void main() {
     });
 
     test(
-        'translated fields when product is not translated into a second language',
+        'localized fields when a product is not available in a second language',
         () async {
       String barcode = '3333333333333';
 
       Product englishInputProduct = Product(
         barcode: barcode,
         lang: OpenFoodFactsLanguage.ENGLISH,
-        productNameTranslated: 'Pancakes',
-        ingredientsTextTranslated: 'Flour, water',
+        productNameInLangs: {OpenFoodFactsLanguage.ENGLISH: 'Pancakes'},
+        ingredientsTextInLangs: {OpenFoodFactsLanguage.ENGLISH: 'Flour, water'},
         categories: 'Beverages',
         countries: 'Russia',
       );
@@ -920,15 +920,15 @@ void main() {
 
       final fields = [
         ProductField.NAME,
-        ProductField.NAME_TRANSLATED,
+        ProductField.NAME_IN_LANGS,
         ProductField.INGREDIENTS_TEXT,
-        ProductField.INGREDIENTS_TEXT_TRANSLATED,
+        ProductField.INGREDIENTS_TEXT_IN_LANGS,
         ProductField.INGREDIENTS_TAGS,
-        ProductField.INGREDIENTS_TAGS_TRANSLATED,
+        ProductField.INGREDIENTS_TAGS_IN_LANGS,
         ProductField.CATEGORIES_TAGS,
-        ProductField.CATEGORIES_TAGS_TRANSLATED,
+        ProductField.CATEGORIES_TAGS_IN_LANGS,
         ProductField.COUNTRIES_TAGS,
-        ProductField.COUNTRIES_TAGS_TRANSLATED,
+        ProductField.COUNTRIES_TAGS_IN_LANGS,
       ];
 
       ProductQueryConfiguration englishConf = ProductQueryConfiguration(barcode,
@@ -945,23 +945,33 @@ void main() {
       Product englishProduct = englishResult.product!;
 
       expect(englishProduct.productName, equals('Pancakes'));
-      expect(englishProduct.productNameTranslated, equals('Pancakes'));
+      expect(englishProduct.productNameInLangs,
+          equals({OpenFoodFactsLanguage.ENGLISH: 'Pancakes'}));
 
       expect(englishProduct.ingredientsText, equals('Flour, water'));
-      expect(englishProduct.ingredientsTextTranslated, equals('Flour, water'));
+      expect(englishProduct.ingredientsTextInLangs,
+          equals({OpenFoodFactsLanguage.ENGLISH: 'Flour, water'}));
 
       expect(englishProduct.ingredientsTags, equals(['en:flour', 'en:water']));
       expect(
-          englishProduct.ingredientsTagsTranslated, equals(['Flour', 'Water']));
+          englishProduct.ingredientsTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: ['Flour', 'Water']
+          }));
 
       expect(englishProduct.categoriesTags, equals(['en:beverages']));
-      expect(englishProduct.categoriesTagsTranslated, equals(['Beverages']));
+      expect(
+          englishProduct.categoriesTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: ['Beverages']
+          }));
 
       expect(englishProduct.countriesTags, equals(['en:russia']));
-      expect(englishProduct.countriesTagsTranslated, equals(['Russia']));
-
       expect(
-          englishProduct.translatedLang, equals(OpenFoodFactsLanguage.ENGLISH));
+          englishProduct.countriesTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: ['Russia']
+          }));
 
       // Russian!
 
@@ -972,43 +982,50 @@ void main() {
       Product russianProduct = russianResult.product!;
 
       expect(russianProduct.productName, equals('Pancakes'));
-      expect(russianProduct.productNameTranslated, isNull);
+      expect(russianProduct.productNameInLangs, isNull);
 
       expect(russianProduct.ingredientsText, equals('Flour, water'));
-      expect(russianProduct.ingredientsTextTranslated, isNull);
+      expect(russianProduct.ingredientsTextInLangs, isNull);
 
       expect(russianProduct.ingredientsTags, equals(['en:flour', 'en:water']));
       expect(
-          russianProduct.ingredientsTagsTranslated, equals(['Мука', 'Вода']));
+          russianProduct.ingredientsTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.RUSSIAN: ['Мука', 'Вода']
+          }));
 
       expect(russianProduct.categoriesTags, equals(['en:beverages']));
-      expect(russianProduct.categoriesTagsTranslated, equals(['Напитки']));
+      expect(
+          russianProduct.categoriesTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.RUSSIAN: ['Напитки']
+          }));
 
       expect(russianProduct.countriesTags, equals(['en:russia']));
-      expect(russianProduct.countriesTagsTranslated, equals(['Россия']));
-
       expect(
-          russianProduct.translatedLang, equals(OpenFoodFactsLanguage.RUSSIAN));
+          russianProduct.countriesTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.RUSSIAN: ['Россия']
+          }));
     });
 
-    test('translated fields when product is translated into a second language',
+    test('localized fields when a product is available in a second language',
         () async {
       String barcode = '2222222222222';
 
       Product englishInputProduct = Product(
         barcode: barcode,
         lang: OpenFoodFactsLanguage.ENGLISH,
-        productNameTranslated: 'Pancakes',
-        ingredientsTextTranslated: 'Flour, water',
+        productNameInLangs: {OpenFoodFactsLanguage.ENGLISH: 'Pancakes'},
+        ingredientsTextInLangs: {OpenFoodFactsLanguage.ENGLISH: 'Flour, water'},
         categories: 'Beverages',
         countries: 'Russia',
       );
 
       Product russianInputProduct = Product(
         barcode: barcode,
-        translatedLang: OpenFoodFactsLanguage.RUSSIAN,
-        productNameTranslated: 'Блинчики',
-        ingredientsTextTranslated: 'Мука, вода',
+        productNameInLangs: {OpenFoodFactsLanguage.RUSSIAN: 'Блинчики'},
+        ingredientsTextInLangs: {OpenFoodFactsLanguage.RUSSIAN: 'Мука, вода'},
       );
 
       await OpenFoodAPIClient.saveProduct(
@@ -1020,15 +1037,15 @@ void main() {
 
       final fields = [
         ProductField.NAME,
-        ProductField.NAME_TRANSLATED,
+        ProductField.NAME_IN_LANGS,
         ProductField.INGREDIENTS_TEXT,
-        ProductField.INGREDIENTS_TEXT_TRANSLATED,
+        ProductField.INGREDIENTS_TEXT_IN_LANGS,
         ProductField.INGREDIENTS_TAGS,
-        ProductField.INGREDIENTS_TAGS_TRANSLATED,
+        ProductField.INGREDIENTS_TAGS_IN_LANGS,
         ProductField.CATEGORIES_TAGS,
-        ProductField.CATEGORIES_TAGS_TRANSLATED,
+        ProductField.CATEGORIES_TAGS_IN_LANGS,
         ProductField.COUNTRIES_TAGS,
-        ProductField.COUNTRIES_TAGS_TRANSLATED,
+        ProductField.COUNTRIES_TAGS_IN_LANGS,
       ];
 
       ProductQueryConfiguration englishConf = ProductQueryConfiguration(barcode,
@@ -1045,23 +1062,33 @@ void main() {
       Product englishProduct = englishResult.product!;
 
       expect(englishProduct.productName, equals('Pancakes'));
-      expect(englishProduct.productNameTranslated, equals('Pancakes'));
+      expect(englishProduct.productNameInLangs,
+          equals({OpenFoodFactsLanguage.ENGLISH: 'Pancakes'}));
 
       expect(englishProduct.ingredientsText, equals('Flour, water'));
-      expect(englishProduct.ingredientsTextTranslated, equals('Flour, water'));
+      expect(englishProduct.ingredientsTextInLangs,
+          equals({OpenFoodFactsLanguage.ENGLISH: 'Flour, water'}));
 
       expect(englishProduct.ingredientsTags, equals(['en:flour', 'en:water']));
       expect(
-          englishProduct.ingredientsTagsTranslated, equals(['Flour', 'Water']));
+          englishProduct.ingredientsTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: ['Flour', 'Water']
+          }));
 
       expect(englishProduct.categoriesTags, equals(['en:beverages']));
-      expect(englishProduct.categoriesTagsTranslated, equals(['Beverages']));
+      expect(
+          englishProduct.categoriesTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: ['Beverages']
+          }));
 
       expect(englishProduct.countriesTags, equals(['en:russia']));
-      expect(englishProduct.countriesTagsTranslated, equals(['Russia']));
-
       expect(
-          englishProduct.translatedLang, equals(OpenFoodFactsLanguage.ENGLISH));
+          englishProduct.countriesTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: ['Russia']
+          }));
 
       // Russian!
 
@@ -1072,23 +1099,127 @@ void main() {
       Product russianProduct = russianResult.product!;
 
       expect(russianProduct.productName, equals('Блинчики'));
-      expect(russianProduct.productNameTranslated, equals('Блинчики'));
+      expect(russianProduct.productNameInLangs,
+          equals({OpenFoodFactsLanguage.RUSSIAN: 'Блинчики'}));
 
       expect(russianProduct.ingredientsText, equals('Мука, вода'));
-      expect(russianProduct.ingredientsTextTranslated, equals('Мука, вода'));
+      expect(russianProduct.ingredientsTextInLangs,
+          equals({OpenFoodFactsLanguage.RUSSIAN: 'Мука, вода'}));
 
       expect(russianProduct.ingredientsTags, equals(['en:flour', 'en:water']));
       expect(
-          russianProduct.ingredientsTagsTranslated, equals(['Мука', 'Вода']));
+          russianProduct.ingredientsTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.RUSSIAN: ['Мука', 'Вода']
+          }));
 
       expect(russianProduct.categoriesTags, equals(['en:beverages']));
-      expect(russianProduct.categoriesTagsTranslated, equals(['Напитки']));
+      expect(
+          russianProduct.categoriesTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.RUSSIAN: ['Напитки']
+          }));
 
       expect(russianProduct.countriesTags, equals(['en:russia']));
-      expect(russianProduct.countriesTagsTranslated, equals(['Россия']));
-
       expect(
-          russianProduct.translatedLang, equals(OpenFoodFactsLanguage.RUSSIAN));
+          russianProduct.countriesTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.RUSSIAN: ['Россия']
+          }));
+    });
+
+    test('multiple secondary languages', () async {
+      String barcode = '2222222222224';
+
+      Product inputProduct = Product(
+        barcode: barcode,
+        lang: OpenFoodFactsLanguage.ENGLISH,
+        productNameInLangs: {
+          OpenFoodFactsLanguage.ENGLISH: 'Pancakes',
+          OpenFoodFactsLanguage.RUSSIAN: 'Блинчики',
+          OpenFoodFactsLanguage.GERMAN: 'Pfannkuchen',
+        },
+        ingredientsTextInLangs: {
+          OpenFoodFactsLanguage.ENGLISH: 'Flour, water',
+          OpenFoodFactsLanguage.RUSSIAN: 'Мука, вода',
+          OpenFoodFactsLanguage.GERMAN: 'Mehl, wasser',
+        },
+        categories: 'Beverages',
+        countries: 'Russia',
+      );
+
+      await OpenFoodAPIClient.saveProduct(TestConstants.TEST_USER, inputProduct,
+          queryType: QueryType.TEST);
+
+      final fields = [
+        ProductField.NAME,
+        ProductField.NAME_IN_LANGS,
+        ProductField.INGREDIENTS_TEXT,
+        ProductField.INGREDIENTS_TEXT_IN_LANGS,
+        ProductField.INGREDIENTS_TAGS,
+        ProductField.INGREDIENTS_TAGS_IN_LANGS,
+        ProductField.CATEGORIES_TAGS,
+        ProductField.CATEGORIES_TAGS_IN_LANGS,
+        ProductField.COUNTRIES_TAGS,
+        ProductField.COUNTRIES_TAGS_IN_LANGS,
+      ];
+
+      ProductQueryConfiguration conf = ProductQueryConfiguration(barcode,
+          secondaryLanguages: [
+            OpenFoodFactsLanguage.ENGLISH,
+            OpenFoodFactsLanguage.RUSSIAN,
+            OpenFoodFactsLanguage.GERMAN
+          ],
+          fields: fields);
+
+      ProductResult result = await OpenFoodAPIClient.getProduct(conf,
+          user: TestConstants.TEST_USER, queryType: QueryType.TEST);
+      Product product = result.product!;
+
+      expect(product.productName, equals('Pancakes'));
+      expect(
+          product.productNameInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: 'Pancakes',
+            OpenFoodFactsLanguage.RUSSIAN: 'Блинчики',
+            OpenFoodFactsLanguage.GERMAN: 'Pfannkuchen',
+          }));
+
+      expect(product.ingredientsText, equals('Flour, water'));
+      expect(
+          product.ingredientsTextInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: 'Flour, water',
+            OpenFoodFactsLanguage.RUSSIAN: 'Мука, вода',
+            OpenFoodFactsLanguage.GERMAN: 'Mehl, wasser',
+          }));
+
+      expect(product.ingredientsTags, equals(['en:flour', 'en:water']));
+      expect(
+          product.ingredientsTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: ['Flour', 'Water'],
+            OpenFoodFactsLanguage.RUSSIAN: ['Мука', 'Вода'],
+            OpenFoodFactsLanguage.GERMAN: ['Mehl', 'Wasser'],
+          }));
+
+      expect(product.categoriesTags, equals(['en:beverages']));
+      expect(
+          product.categoriesTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: ['Beverages'],
+            OpenFoodFactsLanguage.RUSSIAN: ['Напитки'],
+            OpenFoodFactsLanguage.GERMAN: ['Getränke'],
+          }));
+
+      expect(product.countriesTags, equals(['en:russia']));
+      expect(
+          product.countriesTagsInLangs,
+          equals({
+            OpenFoodFactsLanguage.ENGLISH: ['Russia'],
+            OpenFoodFactsLanguage.RUSSIAN: ['Россия'],
+            OpenFoodFactsLanguage.GERMAN: ['Russland'],
+          }));
     });
 
     test('product with quotes', () async {

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1165,7 +1165,7 @@ void main() {
       ];
 
       ProductQueryConfiguration conf = ProductQueryConfiguration(barcode,
-          languages: [
+          extraLanguages: [
             OpenFoodFactsLanguage.ENGLISH,
             OpenFoodFactsLanguage.RUSSIAN,
             OpenFoodFactsLanguage.GERMAN

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1165,7 +1165,7 @@ void main() {
       ];
 
       ProductQueryConfiguration conf = ProductQueryConfiguration(barcode,
-          secondaryLanguages: [
+          languages: [
             OpenFoodFactsLanguage.ENGLISH,
             OpenFoodFactsLanguage.RUSSIAN,
             OpenFoodFactsLanguage.GERMAN

--- a/test/api_saveProduct_test.dart
+++ b/test/api_saveProduct_test.dart
@@ -90,7 +90,7 @@ void main() {
       // save french product name
       Product frenchProduct = Product(
         barcode: barcode,
-        productNameInLangs: {
+        productNameInLanguages: {
           OpenFoodFactsLanguage.FRENCH: "Flocons d'epeautre au blé complet"
         },
         quantity: '500 g',
@@ -109,7 +109,7 @@ void main() {
       // save german product name
       Product germanProduct = Product(
         barcode: barcode,
-        productNameInLangs: {OpenFoodFactsLanguage.GERMAN: 'Dinkelflakes'},
+        productNameInLanguages: {OpenFoodFactsLanguage.GERMAN: 'Dinkelflakes'},
         quantity: '500 g',
         brands: 'Seitenbacher',
         lang: OpenFoodFactsLanguage.GERMAN,

--- a/test/api_saveProduct_test.dart
+++ b/test/api_saveProduct_test.dart
@@ -90,7 +90,9 @@ void main() {
       // save french product name
       Product frenchProduct = Product(
         barcode: barcode,
-        productNameFR: "Flocons d'epeautre au blé complet",
+        productNameInLangs: {
+          OpenFoodFactsLanguage.FRENCH: "Flocons d'epeautre au blé complet"
+        },
         quantity: '500 g',
         brands: 'Seitenbacher',
         lang: OpenFoodFactsLanguage.FRENCH,
@@ -107,7 +109,7 @@ void main() {
       // save german product name
       Product germanProduct = Product(
         barcode: barcode,
-        productNameDE: 'Dinkelflakes',
+        productNameInLangs: {OpenFoodFactsLanguage.GERMAN: 'Dinkelflakes'},
         quantity: '500 g',
         brands: 'Seitenbacher',
         lang: OpenFoodFactsLanguage.GERMAN,

--- a/test/api_searchProducts_test.dart
+++ b/test/api_searchProducts_test.dart
@@ -162,7 +162,7 @@ void main() {
           queryType: QueryType.TEST);
 
       expect(result.count! < totalCount, true);
-    });
+    }, skip: 'https://github.com/openfoodfacts/openfoodfacts-dart/issues/189');
 
     test('search products with filter on tags', () async {
       var parameters = <Parameter>[
@@ -299,6 +299,6 @@ void main() {
       expect(result.products!.length, 24);
       expect(result.products![0].runtimeType, Product);
       expect(result.count! > 1500, true);
-    });
+    }, skip: 'https://github.com/openfoodfacts/openfoodfacts-dart/issues/189');
   });
 }

--- a/test/api_searchProducts_test.dart
+++ b/test/api_searchProducts_test.dart
@@ -285,6 +285,6 @@ void main() {
       expect(result.products!.length, 24);
       expect(result.products![0].runtimeType, Product);
       expect(result.count! > 1500, true);
-    }, skip: 'https://github.com/openfoodfacts/openfoodfacts-dart/issues/189');
+    });
   });
 }


### PR DESCRIPTION
Adding ability to request and set multiple translated product fields at once.

If some user of an OFF-based application knows multiple languages (e.g. English and German), it might be very useful for the user to be able to request and see a product fields translated into several languages.

For example, a product might have its name set in English but have a German ingredients list (no English ingredients list).
When a user requests such a product and the request's language is set to English, the user won't see ingredients list.
But if the user did let the app know they also know German language and the app would request the product with both English and German translation, then the user would get much more comprehensive data - both name and ingredients list of the product.

This pull request unfortunately has breaking changes (type of the `translated` fields is changed).
At first I tried to make no breaking changes but code started to look very-very clumsy.
The clumsy version of the changes is still stored on my computer so I can remove the breaking changes if necessary... Although I hope it's not necessary since the number of `translated` fields would increase 2x and it would be a bit harder to use the SDK.