### PR TITLE
docs: prepare release of version 1.3.1 of the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.3.1] - 22.07.2021
+- Fixed toJson and fromJson for the fields in multiple languages
 ## [1.3.0] - 21.07.2021
 - Added explicit parameter WithoutAdditives to replace ContainsAdditives (deprecated)
 - Added new InvalidBarcodes class

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openfoodfacts
 description: Dart package for the Open Food Facts API, a food products database made by everyone, for everyone.
-version: 1.3.0
+version: 1.3.1
 homepage: https://github.com/openfoodfacts/openfoodfacts-dart
 
 environment:


### PR DESCRIPTION
This is to fix issue #201 that prevents saving a product to JSON and reading it back.