### PR TITLE
New recommended linting rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   exclude:
@@ -10,3 +10,8 @@ analyzer:
     missing_required_param: warning
     missing_return: warning
     prefer_single_quotes: warning
+
+linter:
+  rules:
+    constant_identifier_names: false
+    file_names: false

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,3 +13,4 @@ dependencies:
 
 dev_dependencies:
   test: any
+  lints: ^1.0.1

--- a/lib/interface/JsonObject.dart
+++ b/lib/interface/JsonObject.dart
@@ -52,11 +52,11 @@ abstract class JsonObject {
   static Map<String, dynamic> removeNullEntries(
       final Map<String, dynamic> input) {
     final Map<String, dynamic> result = {};
-    input.entries.forEach((element) {
+    for (var element in input.entries) {
       if (element.value != null) {
         result[element.key] = element.value;
       }
-    });
+    }
     return result;
   }
 

--- a/lib/model/EcoscoreData.dart
+++ b/lib/model/EcoscoreData.dart
@@ -45,6 +45,5 @@ class EcoscoreData extends JsonObject {
   @override
   Map<String, dynamic> toJson() => _$EcoscoreDataToJson(this);
 
-  static Map<String, dynamic>? toJsonHelper(EcoscoreData? d) =>
-      d != null ? d.toJson() : null;
+  static Map<String, dynamic>? toJsonHelper(EcoscoreData? d) => d?.toJson();
 }

--- a/lib/model/KnowledgePanel.dart
+++ b/lib/model/KnowledgePanel.dart
@@ -59,6 +59,8 @@ enum Grade {
 @JsonSerializable()
 class KnowledgePanel extends JsonObject {
   /// Panel id of the parent panel.
+  //TODO:(jasmeet) edit name to match linting rules
+  //ignore: non_constant_identifier_names
   final String parent_panel_id;
 
   final KnowledgePanelType type;
@@ -95,6 +97,7 @@ class KnowledgePanel extends JsonObject {
   final Grade? grade;
 
   const KnowledgePanel({
+    //ignore: non_constant_identifier_names
     required this.parent_panel_id,
     required this.type,
     required this.level,

--- a/lib/model/KnowledgePanels.dart
+++ b/lib/model/KnowledgePanels.dart
@@ -9,8 +9,9 @@ class KnowledgePanels {
 
   factory KnowledgePanels.fromJson(Map<String, dynamic> json) {
     Map<String, KnowledgePanel> map = {};
-    json.keys.forEach(
-        (panelId) => map[panelId] = KnowledgePanel.fromJson(json[panelId]));
+    for (var panelId in json.keys) {
+      map[panelId] = KnowledgePanel.fromJson(json[panelId]);
+    }
     return KnowledgePanels(panelIdToPanelMap: map);
   }
 

--- a/lib/model/Status.dart
+++ b/lib/model/Status.dart
@@ -23,7 +23,7 @@ class Status extends JsonObject {
   final int? imageId;
 
   Status({
-    this.status,
+    required this.status,
     this.statusVerbose,
     this.body,
     this.error,

--- a/lib/model/Status.dart
+++ b/lib/model/Status.dart
@@ -10,7 +10,7 @@ class Status extends JsonObject {
   static const WRONG_USER_OR_PASSWORD_ERROR_MESSAGE =
       'Incorrect user name or password';
 
-  final status;
+  final dynamic status;
 
   @JsonKey(name: 'status_verbose')
   final String? statusVerbose;
@@ -23,7 +23,7 @@ class Status extends JsonObject {
   final int? imageId;
 
   Status({
-    required this.status,
+    this.status,
     this.statusVerbose,
     this.body,
     this.error,

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -410,9 +410,9 @@ class OpenFoodAPIClient {
     }
 
     List<String?> typesValues = [];
-    types.forEach((t) {
+    for (var t in types) {
       typesValues.add(t.value);
-    });
+    }
 
     String parsedTypes = typesValues.join(',');
 
@@ -578,12 +578,12 @@ class OpenFoodAPIClient {
   /// Creates a new user
   /// Returns [Status.status] 201 = complete; 400 = wrong inputs + [Status.error]; 500 = server error;
   ///
-  /// When creating a [producer account](https://world.pro.openfoodfacts.org/) use [requested_org] to name the Producer or brand
+  /// When creating a [producer account](https://world.pro.openfoodfacts.org/) use [orgName] to name the Producer or brand
   static Future<Status> register({
     required User user,
     required String name,
     required String email,
-    String? requested_org,
+    String? orgName,
     bool newsletter = true,
     QueryType? queryType,
   }) async {
@@ -598,9 +598,9 @@ class OpenFoodAPIClient {
       'userid': user.userId,
       'password': user.password,
       'confirm_password': user.password,
-      if (requested_org != null) 'pro': 'on',
+      if (orgName != null) 'pro': 'on',
       'pro_checkbox': '1',
-      'requested_org': requested_org ?? ' ',
+      'requested_org': orgName ?? ' ',
       if (newsletter) 'newsletter': 'on',
       'action': 'process',
       'type': 'add',

--- a/lib/utils/LanguageHelper.dart
+++ b/lib/utils/LanguageHelper.dart
@@ -791,7 +791,7 @@ class LanguageHelper {
     if (map == null) {
       return null;
     }
-    if (!(map is Map<String, dynamic>)) {
+    if (map is! Map<String, dynamic>) {
       throw Exception('Expected type: Map<String, String>');
     }
     final result = <OpenFoodFactsLanguage, String>{};
@@ -815,7 +815,7 @@ class LanguageHelper {
     if (map == null) {
       return null;
     }
-    if (!(map is Map<String, dynamic>)) {
+    if (map is! Map<String, dynamic>) {
       throw Exception('Expected type: Map<String, List<String>>');
     }
     final result = <OpenFoodFactsLanguage, List<String>>{};

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,11 @@ dependencies:
   json_annotation: ^4.1.0
   http: ^0.13.3
   path: ^1.8.0
-  image: ^3.0.4
+  image: ^3.0.7
 
 dev_dependencies:
-  analyzer: ^2.2.0
-  build_runner: ^2.1.2
-  json_serializable: ^5.0.0
-  pedantic: ^1.11.1
-  test: ^1.17.12
+  analyzer: ^2.4.0
+  build_runner: ^2.1.4
+  json_serializable: ^5.0.2
+  lints: ^1.0.1
+  test: ^1.18.2

--- a/test/json_product_generation_test.dart
+++ b/test/json_product_generation_test.dart
@@ -53,19 +53,19 @@ void main() {
       'en:non-vegan',
       'en:palm-oil-content-unknown',
     ];
-    IngredientsAnalysisTags ingredients_analysis_tags =
+    IngredientsAnalysisTags ingredientsAnalysisTags =
         IngredientsAnalysisTags(data);
-    assert(ingredients_analysis_tags.vegetarianStatus ==
+    assert(ingredientsAnalysisTags.vegetarianStatus ==
         VegetarianStatus.VEGETARIAN);
-    assert(ingredients_analysis_tags.veganStatus == VeganStatus.NON_VEGAN);
-    assert(ingredients_analysis_tags.palmOilFreeStatus ==
+    assert(ingredientsAnalysisTags.veganStatus == VeganStatus.NON_VEGAN);
+    assert(ingredientsAnalysisTags.palmOilFreeStatus ==
         PalmOilFreeStatus.PALM_OIL_CONTENT_UNKNOWN);
 
-    List<String> json_strings =
-        IngredientsAnalysisTags.toJson(ingredients_analysis_tags);
-    assert(json_strings[0] == 'en:non-vegan');
-    assert(json_strings[1] == 'en:vegetarian');
-    assert(json_strings[2] == 'en:palm-oil-content-unknown');
+    List<String> jsonStrings =
+        IngredientsAnalysisTags.toJson(ingredientsAnalysisTags);
+    assert(jsonStrings[0] == 'en:non-vegan');
+    assert(jsonStrings[1] == 'en:vegetarian');
+    assert(jsonStrings[2] == 'en:palm-oil-content-unknown');
   });
 }
 


### PR DESCRIPTION
[pedantic](https://pub.dev/packages/pedantic) is discontinued and deprecated, insted we should now use `package:lints` (or `package:flutter_lints`)

The analyzer complained that it couldn't find `package:lints` in the example folder, so I added it there too.

I renamed `requested_org` to `orgName` to fit the linting rules in register without deprecating it, also this name makes more sense this way