### PR TITLE
feature/#210 - add nutrient order and list

### DIFF
--- a/lib/model/OrderedNutrient.dart
+++ b/lib/model/OrderedNutrient.dart
@@ -8,28 +8,24 @@ part 'OrderedNutrient.g.dart';
 /// cf. https://github.com/openfoodfacts/openfoodfacts-dart/issues/210
 /// Example in https://fr.openfoodfacts.org/cgi/nutrients.pl
 /// To be compared to [OrderedNutrients], which is the root of the structure.
-@JsonSerializable()
+@JsonSerializable(includeIfNull: false)
 class OrderedNutrient extends JsonObject {
   /// Nutrient ID (e.g. 'energy-kcal')
-  @JsonKey(name: 'id', includeIfNull: false)
+  @JsonKey()
   final String id;
 
   /// Localized nutrient name (e.g. 'Energía (kcal)' in Spanish)
-  @JsonKey(name: 'name', includeIfNull: false)
+  @JsonKey()
   final String? name;
 
-  @JsonKey(name: 'important', includeIfNull: false)
+  @JsonKey()
   final bool important;
 
-  @JsonKey(name: 'display_in_edit_form', includeIfNull: false)
+  @JsonKey(name: 'display_in_edit_form')
   final bool displayInEditForm;
 
   /// Hierarchically related nutrients
-  @JsonKey(
-      name: 'nutrients',
-      fromJson: fromJsonOrderedNutrients,
-      toJson: toJsonOrderedNutrients,
-      includeIfNull: false)
+  @JsonKey(name: 'nutrients')
   final List<OrderedNutrient>? subNutrients;
 
   OrderedNutrient({
@@ -45,32 +41,4 @@ class OrderedNutrient extends JsonObject {
 
   @override
   Map<String, dynamic> toJson() => _$OrderedNutrientToJson(this);
-
-  @override
-  String toString() => toJson().toString();
-
-  static List<OrderedNutrient>? fromJsonOrderedNutrients(dynamic list) {
-    if (list == null) {
-      return null;
-    }
-    if (!(list is List<dynamic>)) {
-      throw Exception('Expected type: List<dynamic>');
-    }
-    final List<OrderedNutrient> result = [];
-    for (final item in list) {
-      result.add(OrderedNutrient.fromJson(item));
-    }
-    return result;
-  }
-
-  static List<dynamic>? toJsonOrderedNutrients(List<OrderedNutrient>? list) {
-    if (list == null) {
-      return null;
-    }
-    final List<dynamic> result = [];
-    for (final item in list) {
-      result.add(item.toJson());
-    }
-    return result;
-  }
 }

--- a/lib/model/OrderedNutrient.g.dart
+++ b/lib/model/OrderedNutrient.g.dart
@@ -12,7 +12,9 @@ OrderedNutrient _$OrderedNutrientFromJson(Map<String, dynamic> json) =>
       id: json['id'] as String,
       displayInEditForm: json['display_in_edit_form'] as bool,
       name: json['name'] as String?,
-      subNutrients: OrderedNutrient.fromJsonOrderedNutrients(json['nutrients']),
+      subNutrients: (json['nutrients'] as List<dynamic>?)
+          ?.map((e) => OrderedNutrient.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Map<String, dynamic> _$OrderedNutrientToJson(OrderedNutrient instance) {
@@ -29,7 +31,6 @@ Map<String, dynamic> _$OrderedNutrientToJson(OrderedNutrient instance) {
   writeNotNull('name', instance.name);
   val['important'] = instance.important;
   val['display_in_edit_form'] = instance.displayInEditForm;
-  writeNotNull('nutrients',
-      OrderedNutrient.toJsonOrderedNutrients(instance.subNutrients));
+  writeNotNull('nutrients', instance.subNutrients);
   return val;
 }

--- a/lib/model/OrderedNutrients.dart
+++ b/lib/model/OrderedNutrients.dart
@@ -11,22 +11,15 @@ part 'OrderedNutrients.g.dart';
 /// Compared to [OrderedNutrient], this is the root of the structure.
 @JsonSerializable()
 class OrderedNutrients extends JsonObject {
-  /// Most important nutrients
-  @JsonKey(
-      name: 'nutrients',
-      fromJson: OrderedNutrient.fromJsonOrderedNutrients,
-      toJson: OrderedNutrient.toJsonOrderedNutrients,
-      includeIfNull: false)
-  final List<OrderedNutrient>? subNutrients;
+  /// Most important nutrients (level 0 in the hierarchy)
+  @JsonKey()
+  final List<OrderedNutrient> nutrients;
 
-  OrderedNutrients({required this.subNutrients});
+  OrderedNutrients({required this.nutrients});
 
   factory OrderedNutrients.fromJson(Map<String, dynamic> json) =>
       _$OrderedNutrientsFromJson(json);
 
   @override
   Map<String, dynamic> toJson() => _$OrderedNutrientsToJson(this);
-
-  @override
-  String toString() => toJson().toString();
 }

--- a/lib/model/OrderedNutrients.g.dart
+++ b/lib/model/OrderedNutrients.g.dart
@@ -8,19 +8,12 @@ part of 'OrderedNutrients.dart';
 
 OrderedNutrients _$OrderedNutrientsFromJson(Map<String, dynamic> json) =>
     OrderedNutrients(
-      subNutrients: OrderedNutrient.fromJsonOrderedNutrients(json['nutrients']),
+      nutrients: (json['nutrients'] as List<dynamic>)
+          .map((e) => OrderedNutrient.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
-Map<String, dynamic> _$OrderedNutrientsToJson(OrderedNutrients instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('nutrients',
-      OrderedNutrient.toJsonOrderedNutrients(instance.subNutrients));
-  return val;
-}
+Map<String, dynamic> _$OrderedNutrientsToJson(OrderedNutrients instance) =>
+    <String, dynamic>{
+      'nutrients': instance.nutrients,
+    };

--- a/test/ordered_nutrient_test.dart
+++ b/test/ordered_nutrient_test.dart
@@ -15,6 +15,9 @@ void main() {
 
   group('$OpenFoodAPIClient ordered nutrients', () {
     test('find expected nutrients', () async {
+      // Very long list, experimentally created from the 3 initial URLs.
+      // Don't hesitate to edit this list if you have clear functional ideas
+      // about which nutrients should actually be there.
       const Set<String> expectedNutrients = {
         'alcohol',
         'alpha-linolenic-acid',
@@ -123,24 +126,6 @@ void main() {
         'zinc',
       };
 
-      /* debug function
-    void displayOrderedNutrients(
-      final List<OrderedNutrient>? list,
-      final int level, // 0 for OrderedNutrients.subNutrients
-    ) {
-      if (list == null) {
-        return;
-      }
-      final String prefix = '-' * level;
-      for (final OrderedNutrient item in list) {
-        print('$prefix${item.id}');
-        if (item.subNutrients != null) {
-          displayOrderedNutrients(item.subNutrients!, level + 1);
-        }
-      }
-    }
-     */
-
       const List<String> urls = [
         'https://fr.openfoodfacts.org/cgi/nutrients.pl',
         'https://us.openfoodfacts.org/cgi/nutrients.pl',
@@ -154,8 +139,7 @@ void main() {
             OrderedNutrients.fromJson(json);
         for (final String expectedNutrient in expectedNutrients) {
           expect(
-            _findOrderedNutrient(
-                orderedNutrients.subNutrients, expectedNutrient),
+            _findOrderedNutrient(orderedNutrients.nutrients, expectedNutrient),
             isNotNull,
             reason: 'Could not find $expectedNutrient in $url',
           );
@@ -177,7 +161,7 @@ void main() {
         final OrderedNutrients orderedNutrients =
             OrderedNutrients.fromJson(json);
         final OrderedNutrient? found =
-            _findOrderedNutrient(orderedNutrients.subNutrients, nutrientId);
+            _findOrderedNutrient(orderedNutrients.nutrients, nutrientId);
         expect(found, isNotNull);
         expect(found!.name, energies[url]);
       }


### PR DESCRIPTION
New files:
* `ordered_nutrient_test.dart`: Tests related to `OrderedNutrient` and `OrderedNutrients`
* `OrderedNutrient.dart`: Nutrient, as a hierarchically ordered and localized entity.
* `OrderedNutrients.dart`: Nutrients, as hierarchically ordered and localized entities.

Generated files (from JsonSerializable):
* `OrderedNutrient.g.dart`
* `OrderedNutrients.g.dart`