### PR TITLE
feat: #233 - new class OpenFoodFactsCountry, clearer than "cc"

### DIFF
--- a/lib/model/TaxonomyAdditive.dart
+++ b/lib/model/TaxonomyAdditive.dart
@@ -336,7 +336,7 @@ class TaxonomyAdditiveQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyAdditiveQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
-    String? cc,
+    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyAdditiveField> fields = const [],
     List<Parameter> additionalParameters = const [],

--- a/lib/model/TaxonomyAdditive.dart
+++ b/lib/model/TaxonomyAdditive.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
 
@@ -336,6 +337,7 @@ class TaxonomyAdditiveQueryConfiguration extends TaxonomyQueryConfiguration<
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
     String? cc,
+    OpenFoodFactsCountry? country,
     List<TaxonomyAdditiveField> fields = const [],
     List<Parameter> additionalParameters = const [],
   }) : super(
@@ -343,6 +345,7 @@ class TaxonomyAdditiveQueryConfiguration extends TaxonomyQueryConfiguration<
           tags,
           languages: languages,
           cc: cc,
+          country: country,
           includeChildren: false,
           fields: fields,
           additionalParameters: additionalParameters,

--- a/lib/model/TaxonomyAllergen.dart
+++ b/lib/model/TaxonomyAllergen.dart
@@ -80,7 +80,7 @@ class TaxonomyAllergenQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyAllergenQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
-    String? cc,
+    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyAllergenField> fields = const [],
     List<Parameter> additionalParameters = const [],

--- a/lib/model/TaxonomyAllergen.dart
+++ b/lib/model/TaxonomyAllergen.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
 
@@ -80,6 +81,7 @@ class TaxonomyAllergenQueryConfiguration extends TaxonomyQueryConfiguration<
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
     String? cc,
+    OpenFoodFactsCountry? country,
     List<TaxonomyAllergenField> fields = const [],
     List<Parameter> additionalParameters = const [],
   }) : super(
@@ -87,6 +89,7 @@ class TaxonomyAllergenQueryConfiguration extends TaxonomyQueryConfiguration<
           tags,
           languages: languages,
           cc: cc,
+          country: country,
           includeChildren: false,
           fields: fields,
           additionalParameters: additionalParameters,

--- a/lib/model/TaxonomyCategory.dart
+++ b/lib/model/TaxonomyCategory.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
 
@@ -335,6 +336,7 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
     String? cc,
+    OpenFoodFactsCountry? country,
     bool includeChildren = false,
     List<TaxonomyCategoryField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -343,6 +345,7 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
           tags,
           languages: languages,
           cc: cc,
+          country: country,
           includeChildren: includeChildren,
           fields: fields,
           additionalParameters: additionalParameters,
@@ -351,6 +354,7 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyCategoryQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages = const [],
     String? cc,
+    OpenFoodFactsCountry? country,
     bool includeChildren = false,
     List<TaxonomyCategoryField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -358,6 +362,7 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
           TagType.CATEGORIES,
           languages: languages,
           cc: cc,
+          country: country,
           includeChildren: includeChildren,
           fields: fields,
           additionalParameters: additionalParameters,

--- a/lib/model/TaxonomyCategory.dart
+++ b/lib/model/TaxonomyCategory.dart
@@ -335,7 +335,7 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyCategoryQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
-    String? cc,
+    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     bool includeChildren = false,
     List<TaxonomyCategoryField> fields = const [],
@@ -353,7 +353,7 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
 
   TaxonomyCategoryQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages = const [],
-    String? cc,
+    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     bool includeChildren = false,
     List<TaxonomyCategoryField> fields = const [],

--- a/lib/model/TaxonomyCountry.dart
+++ b/lib/model/TaxonomyCountry.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
 
@@ -104,6 +105,7 @@ class TaxonomyCountryQueryConfiguration
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
     String? cc,
+    OpenFoodFactsCountry? country,
     List<TaxonomyCountryField> fields = const [],
     List<Parameter> additionalParameters = const [],
   }) : super(
@@ -111,6 +113,7 @@ class TaxonomyCountryQueryConfiguration
           tags,
           languages: languages,
           cc: cc,
+          country: country,
           includeChildren: false,
           fields: fields,
           additionalParameters: additionalParameters,

--- a/lib/model/TaxonomyCountry.dart
+++ b/lib/model/TaxonomyCountry.dart
@@ -104,7 +104,7 @@ class TaxonomyCountryQueryConfiguration
   TaxonomyCountryQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
-    String? cc,
+    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyCountryField> fields = const [],
     List<Parameter> additionalParameters = const [],

--- a/lib/model/TaxonomyIngredient.dart
+++ b/lib/model/TaxonomyIngredient.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
 
@@ -472,6 +473,7 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
     String? cc,
+    OpenFoodFactsCountry? country,
     List<TaxonomyIngredientField> fields = const [],
     List<Parameter> additionalParameters = const [],
     bool includeChildren = false,
@@ -480,6 +482,7 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
           tags,
           languages: languages,
           cc: cc,
+          country: country,
           includeChildren: includeChildren,
           fields: fields,
           additionalParameters: additionalParameters,
@@ -488,6 +491,7 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyIngredientQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages = const [],
     String? cc,
+    OpenFoodFactsCountry? country,
     List<TaxonomyIngredientField> fields = const [],
     List<Parameter> additionalParameters = const [],
     bool includeChildren = false,
@@ -495,6 +499,7 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
           TagType.INGREDIENTS,
           languages: languages,
           cc: cc,
+          country: country,
           includeChildren: includeChildren,
           fields: fields,
           additionalParameters: additionalParameters,

--- a/lib/model/TaxonomyIngredient.dart
+++ b/lib/model/TaxonomyIngredient.dart
@@ -472,7 +472,7 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyIngredientQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
-    String? cc,
+    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyIngredientField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -490,7 +490,7 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
 
   TaxonomyIngredientQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages = const [],
-    String? cc,
+    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyIngredientField> fields = const [],
     List<Parameter> additionalParameters = const [],

--- a/lib/model/TaxonomyLabel.dart
+++ b/lib/model/TaxonomyLabel.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
 
@@ -280,6 +281,7 @@ class TaxonomyLabelQueryConfiguration
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
     String? cc,
+    OpenFoodFactsCountry? country,
     List<TaxonomyLabelField> fields = const [],
     List<Parameter> additionalParameters = const [],
   }) : super(
@@ -287,6 +289,7 @@ class TaxonomyLabelQueryConfiguration
           tags,
           languages: languages,
           cc: cc,
+          country: country,
           includeChildren: false,
           fields: fields,
           additionalParameters: additionalParameters,
@@ -295,12 +298,14 @@ class TaxonomyLabelQueryConfiguration
   TaxonomyLabelQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages = const [],
     String? cc,
+    OpenFoodFactsCountry? country,
     List<TaxonomyLabelField> fields = const [],
     List<Parameter> additionalParameters = const [],
   }) : super.roots(
           TagType.LABELS,
           languages: languages,
           cc: cc,
+          country: country,
           includeChildren: false,
           fields: fields,
           additionalParameters: additionalParameters,

--- a/lib/model/TaxonomyLabel.dart
+++ b/lib/model/TaxonomyLabel.dart
@@ -280,7 +280,7 @@ class TaxonomyLabelQueryConfiguration
   TaxonomyLabelQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
-    String? cc,
+    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyLabelField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -297,7 +297,7 @@ class TaxonomyLabelQueryConfiguration
 
   TaxonomyLabelQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages = const [],
-    String? cc,
+    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyLabelField> fields = const [],
     List<Parameter> additionalParameters = const [],

--- a/lib/model/TaxonomyLanguage.dart
+++ b/lib/model/TaxonomyLanguage.dart
@@ -95,7 +95,7 @@ class TaxonomyLanguageQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyLanguageQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
-    String? cc,
+    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyLanguageField> fields = const [],
     List<Parameter> additionalParameters = const [],

--- a/lib/model/TaxonomyLanguage.dart
+++ b/lib/model/TaxonomyLanguage.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
 
@@ -95,6 +96,7 @@ class TaxonomyLanguageQueryConfiguration extends TaxonomyQueryConfiguration<
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages = const [],
     String? cc,
+    OpenFoodFactsCountry? country,
     List<TaxonomyLanguageField> fields = const [],
     List<Parameter> additionalParameters = const [],
   }) : super(
@@ -102,6 +104,7 @@ class TaxonomyLanguageQueryConfiguration extends TaxonomyQueryConfiguration<
           tags,
           languages: languages,
           cc: cc,
+          country: country,
           includeChildren: false,
           fields: fields,
           additionalParameters: additionalParameters,

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -835,7 +835,7 @@ class OpenFoodAPIClient {
       queryParameters: <String, String>{
         'fields': KNOWLEDGE_PANELS_FIELD,
         'lc': configuration.language!.code,
-        'cc': configuration.cc!,
+        'cc': configuration.computeCountryCode()!,
       },
     );
 

--- a/lib/utils/AbstractQueryConfiguration.dart
+++ b/lib/utils/AbstractQueryConfiguration.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 import 'package:openfoodfacts/model/parameter/TagFilter.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
@@ -29,7 +30,13 @@ abstract class AbstractQueryConfiguration {
   @Deprecated('Use parameters language or languages instead')
   String? lc;
 
+  // TODO: deprecated from 2021-11-15 (#233); remove when old enough
+  @Deprecated('Use parameter country instead')
   String? cc;
+
+  /// The country for this query, if any.
+  final OpenFoodFactsCountry? country;
+
   List<ProductField>? fields;
 
   List<Parameter> additionalParameters;
@@ -39,6 +46,7 @@ abstract class AbstractQueryConfiguration {
     this.languages,
     this.lc,
     this.cc,
+    this.country,
     this.fields,
     this.additionalParameters = const [],
   }) {
@@ -78,10 +86,9 @@ abstract class AbstractQueryConfiguration {
       result.putIfAbsent('lc', () => lc!);
     }
 
-    if (cc != null) {
-      result.putIfAbsent('cc', () => cc!);
-    } else if (OpenFoodAPIConfiguration.globalCC != null) {
-      result.putIfAbsent('cc', () => OpenFoodAPIConfiguration.globalCC!);
+    final String? countryCode = computeCountryCode();
+    if (countryCode != null) {
+      result.putIfAbsent('cc', () => countryCode);
     }
 
     if (fields != null) {
@@ -110,4 +117,8 @@ abstract class AbstractQueryConfiguration {
 
     return result;
   }
+
+  String? computeCountryCode() =>
+      // ignore: deprecated_member_use_from_same_package
+      OpenFoodAPIConfiguration.computeCountryCode(country, cc);
 }

--- a/lib/utils/CountryHelper.dart
+++ b/lib/utils/CountryHelper.dart
@@ -1,0 +1,1005 @@
+/// Countries, cf. https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+enum OpenFoodFactsCountry {
+  /// Andorra
+  ANDORRA,
+
+  /// United Arab Emirates
+  UNITED_ARAB_EMIRATES,
+
+  /// Afghanistan
+  AFGHANISTAN,
+
+  /// Antigua and Barbuda
+  ANTIGUA_AND_BARBUDA,
+
+  /// Anguilla
+  ANGUILLA,
+
+  /// Albania
+  ALBANIA,
+
+  /// Armenia
+  ARMENIA,
+
+  /// Angola
+  ANGOLA,
+
+  /// Antarctica
+  ANTARCTICA,
+
+  /// Argentina
+  ARGENTINA,
+
+  /// American Samoa
+  AMERICAN_SAMOA,
+
+  /// Austria
+  AUSTRIA,
+
+  /// Australia
+  AUSTRALIA,
+
+  /// Aruba
+  ARUBA,
+
+  /// Åland Islands
+  ALAND_ISLANDS,
+
+  /// Azerbaijan
+  AZERBAIJAN,
+
+  /// Bosnia and Herzegovina
+  BOSNIA_AND_HERZEGOVINA,
+
+  /// Barbados
+  BARBADOS,
+
+  /// Bangladesh
+  BANGLADESH,
+
+  /// Belgium
+  BELGIUM,
+
+  /// Burkina Faso
+  BURKINA_FASO,
+
+  /// Bulgaria
+  BULGARIA,
+
+  /// Bahrain
+  BAHRAIN,
+
+  /// Burundi
+  BURUNDI,
+
+  /// Benin
+  BENIN,
+
+  /// Saint Barthélemy
+  SAINT_BARTHELEMY,
+
+  /// Bermuda
+  BERMUDA,
+
+  /// Brunei Darussalam
+  BRUNEI_DARUSSALAM,
+
+  /// Bolivia (Plurinational State of)
+  BOLIVIA,
+
+  /// Bonaire, Sint Eustatius and Saba
+  BONAIRE,
+
+  /// Brazil
+  BRAZIL,
+
+  /// Bahamas
+  BAHAMAS,
+
+  /// Bhutan
+  BHUTAN,
+
+  /// Bouvet Island
+  BOUVET_ISLAND,
+
+  /// Botswana
+  BOTSWANA,
+
+  /// Belarus
+  BELARUS,
+
+  /// Belize
+  BELIZE,
+
+  /// Canada
+  CANADA,
+
+  /// Cocos (Keeling) Islands
+  COCOS_ISLANDS,
+
+  /// Congo, Democratic Republic of the
+  DEMOCRATIC_REPUBLIC_OF_THE_CONGO,
+
+  /// Central African Republic
+  CENTRAL_AFRICAN_REPUBLIC,
+
+  /// Congo
+  CONGO,
+
+  /// Switzerland
+  SWITZERLAND,
+
+  /// Côte d'Ivoire
+  COTE_D_IVOIRE,
+
+  /// Cook Islands
+  COOK_ISLANDS,
+
+  /// Chile
+  CHILE,
+
+  /// Cameroon
+  CAMEROON,
+
+  /// China
+  CHINA,
+
+  /// Colombia
+  COLOMBIA,
+
+  /// Costa Rica
+  COSTA_RICA,
+
+  /// Cuba
+  CUBA,
+
+  /// Cabo Verde
+  CABO_VERDE,
+
+  /// Curaçao
+  CURACAO,
+
+  /// Christmas Island
+  CHRISTMAS_ISLAND,
+
+  ///Cyprus
+  CYPRUS,
+
+  /// Czechia
+  CZECHIA,
+
+  /// Germany
+  GERMANY,
+
+  /// Djibouti
+  DJIBOUTI,
+
+  /// Denmark
+  DENMARK,
+
+  /// Dominica
+  DOMINICA,
+
+  /// Dominican Republic
+  DOMINICAN_REPUBLIC,
+
+  /// Algeria
+  ALGERIA,
+
+  /// Ecuador
+  ECUADOR,
+
+  /// Estonia
+  ESTONIA,
+
+  /// Egypt
+  EGYPT,
+
+  /// Western Sahara
+  WESTERN_SAHARA,
+
+  /// Eritrea
+  ERITREA,
+
+  /// Spain
+  SPAIN,
+
+  /// Ethiopia
+  ETHIOPIA,
+
+  /// Finland
+  FINLAND,
+
+  /// Fiji
+  FIJI,
+
+  /// Falkland Islands (Malvinas)
+  FALKLAND_ISLANDS,
+
+  /// Micronesia (Federated States of)
+  MICRONESIA,
+
+  /// Faroe Islands
+  FAROE_ISLANDS,
+
+  /// France
+  FRANCE,
+
+  /// Gabon
+  GABON,
+
+  /// United Kingdom of Great Britain and Northern Ireland
+  UNITED_KINGDOM,
+
+  /// Grenada
+  GRENADA,
+
+  /// Georgia
+  GEORGIA,
+
+  /// French Guiana
+  FRENCH_GUIANA,
+
+  /// Guernsey
+  GUERNSEY,
+
+  /// Ghana
+  GHANA,
+
+  /// Gibraltar
+  GIBRALTAR,
+
+  /// Greenland
+  GREENLAND,
+
+  /// Gambia
+  GAMBIA,
+
+  /// Guinea
+  GUINEA,
+
+  /// Guadeloupe
+  GUADELOUPE,
+
+  /// Equatorial Guinea
+  EQUATORIAL_GUINEA,
+
+  /// Greece
+  GREECE,
+
+  /// South Georgia and the South Sandwich Islands
+  SOUTH_GEORGIA,
+
+  /// Guatemala
+  GUATEMALA,
+
+  /// Guam
+  GUAM,
+
+  /// Guinea-Bissau
+  GUINEA_BISSAU,
+
+  /// Guyana
+  GUYANA,
+
+  /// Hong Kong
+  HONG_KONG,
+
+  /// Heard Island and McDonald Islands
+  HEARD_ISLAND,
+
+  /// Honduras
+  HONDURAS,
+
+  /// Croatia
+  CROATIA,
+
+  /// Haiti
+  HAITI,
+
+  /// Hungary
+  HUNGARY,
+
+  /// Indonesia
+  INDONESIA,
+
+  /// Ireland
+  IRELAND,
+
+  /// Israel
+  ISRAEL,
+
+  /// Isle of Man
+  ISLE_OF_MAN,
+
+  /// India
+  INDIA,
+
+  /// British Indian Ocean Territory
+  BRITISH_INDIAN_OCEAN_TERRITORY,
+
+  /// Iraq
+  IRAQ,
+
+  /// Iran (Islamic Republic of)
+  IRAN,
+
+  /// Iceland
+  ICELAND,
+
+  /// Italy
+  ITALY,
+
+  /// Jersey
+  JERSEY,
+
+  /// Jamaica
+  JAMAICA,
+
+  /// Jordan
+  JORDAN,
+
+  /// Japan
+  JAPAN,
+
+  /// Kenya
+  KENYA,
+
+  /// Kyrgyzstan
+  KYRGYZSTAN,
+
+  /// Cambodia
+  CAMBODIA,
+
+  /// Kiribati
+  KIRIBATI,
+
+  /// Comoros
+  COMOROS,
+
+  /// Saint Kitts and Nevis
+  SAINT_KITTS_AND_NEVIS,
+
+  /// Korea (Democratic People's Republic of)
+  NORTH_KOREA,
+
+  /// Korea, Republic of
+  SOUTH_KOREA,
+
+  /// Kuwait
+  KUWAIT,
+
+  /// Cayman Islands
+  CAYMAN_ISLANDS,
+
+  /// Kazakhstan
+  KAZAKHSTAN,
+
+  /// Lao People's Democratic Republic
+  LAOS,
+
+  /// Lebanon
+  LEBANON,
+
+  /// Saint Lucia
+  SAINT_LUCIA,
+
+  /// Liechtenstein
+  LIECHTENSTEIN,
+
+  /// Sri Lanka
+  SRI_LANKA,
+
+  /// Liberia
+  LIBERIA,
+
+  /// Lesotho
+  LESOTHO,
+
+  /// Lithuania
+  LITHUANIA,
+
+  /// Luxembourg
+  LUXEMBOURG,
+
+  /// Latvia
+  LATVIA,
+
+  /// Libya
+  LIBYA,
+
+  /// Morocco
+  MOROCCO,
+
+  /// Monaco
+  MONACO,
+
+  /// Moldova, Republic of
+  MOLDOVA,
+
+  /// Montenegro
+  MONTENEGRO,
+
+  /// Saint Martin (French part)
+  SAINT_MARTIN,
+
+  /// Madagascar
+  MADAGASCAR,
+
+  /// Marshall Islands
+  MARSHALL_ISLANDS,
+
+  /// North Macedonia
+  NORTH_MACEDONIA,
+
+  /// Mali
+  MALI,
+
+  /// Myanmar
+  MYANMAR,
+
+  /// Mongolia
+  MONGOLIA,
+
+  /// Macao
+  MACAO,
+
+  /// Northern Mariana Islands
+  NORTHERN_MARIANA_ISLANDS,
+
+  /// Martinique
+  MARTINIQUE,
+
+  /// Mauritania
+  MAURITANIA,
+
+  /// Montserrat
+  MONTSERRAT,
+
+  /// Malta
+  MALTA,
+
+  /// Mauritius
+  MAURITIUS,
+
+  /// Maldives
+  MALDIVES,
+
+  /// Malawi
+  MALAWI,
+
+  /// Mexico
+  MEXICO,
+
+  /// Malaysia
+  MALAYSIA,
+
+  /// Mozambique
+  MOZAMBIQUE,
+
+  /// Namibia
+  NAMIBIA,
+
+  /// New Caledonia
+  NEW_CALEDONIA,
+
+  /// Niger
+  NIGER,
+
+  /// Norfolk Island
+  NORFOLK_ISLAND,
+
+  /// Nigeria
+  NIGERIA,
+
+  /// Nicaragua
+  NICARAGUA,
+
+  /// Netherlands
+  NETHERLANDS,
+
+  /// Norway
+  NORWAY,
+
+  /// Nepal
+  NEPAL,
+
+  /// Nauru
+  NAURU,
+
+  /// Niue
+  NIUE,
+
+  /// New Zealand
+  NEW_ZEALAND,
+
+  /// Oman
+  OMAN,
+
+  /// Panama
+  PANAMA,
+
+  /// Peru
+  PERU,
+
+  /// French Polynesia
+  FRENCH_POLYNESIA,
+
+  /// Papua New Guinea
+  PAPUA_NEW_GUINEA,
+
+  /// Philippines
+  PHILIPPINES,
+
+  /// Pakistan
+  PAKISTAN,
+
+  /// Poland
+  POLAND,
+
+  /// Saint Pierre and Miquelon
+  SAINT_PIERRE_AND_MIQUELON,
+
+  /// Pitcairn
+  PITCAIRN,
+
+  /// Puerto Rico
+  PUERTO_RICO,
+
+  /// Palestine, State of
+  PALESTINE,
+
+  /// Portugal
+  PORTUGAL,
+
+  /// Palau
+  PALAU,
+
+  /// Paraguay
+  PARAGUAY,
+
+  /// Qatar
+  QATAR,
+
+  /// Réunion
+  REUNION,
+
+  /// Romania
+  ROMANIA,
+
+  /// Serbia
+  SERBIA,
+
+  /// Russian Federation
+  RUSSIA,
+
+  /// Rwanda
+  RWANDA,
+
+  /// Saudi Arabia
+  SAUDI_ARABIA,
+
+  /// Solomon Islands
+  SOLOMON_ISLANDS,
+
+  /// Seychelles
+  SEYCHELLES,
+
+  /// Sudan
+  SUDAN,
+
+  /// Sweden
+  SWEDEN,
+
+  /// Singapore
+  SINGAPORE,
+
+  /// Saint Helena, Ascension and Tristan da Cunha
+  SAINT_HELENA,
+
+  /// Slovenia
+  SLOVENIA,
+
+  /// Svalbard and Jan Mayen
+  SVALBARD_AND_JAN_MAYEN,
+
+  /// Slovakia
+  SLOVAKIA,
+
+  /// Sierra Leone
+  SIERRA_LEONE,
+
+  /// San Marino
+  SAN_MARINO,
+
+  /// Senegal
+  SENEGAL,
+
+  /// Somalia
+  SOMALIA,
+
+  /// Suriname
+  SURINAME,
+
+  /// South Sudan
+  SOUTH_SUDAN,
+
+  /// Sao Tome and Principe
+  SAO_TOME_AND_PRINCIPE,
+
+  /// El Salvador
+  EL_SALVADOR,
+
+  /// Sint Maarten (Dutch part)
+  SINT_MAARTEN,
+
+  /// Syrian Arab Republic
+  SYRIA,
+
+  /// Eswatini
+  ESWATINI,
+
+  /// Turks and Caicos Islands
+  TURKS_AND_CAICOS_ISLANDS,
+
+  /// Chad
+  CHAD,
+
+  /// French Southern Territories
+  FRENCH_SOUTHERN_TERRITORIES,
+
+  /// Togo
+  TOGO,
+
+  /// Thailand
+  THAILAND,
+
+  /// Tajikistan
+  TAJIKISTAN,
+
+  /// Tokelau
+  TOKELAU,
+
+  /// Timor-Leste
+  TIMOR_LESTE,
+
+  /// Turkmenistan
+  TURKMENISTAN,
+
+  /// Tunisia
+  TUNISIA,
+
+  /// Tonga
+  TONGA,
+
+  /// Turkey
+  TURKEY,
+
+  /// Trinidad and Tobago
+  TRINIDAD_AND_TOBAGO,
+
+  /// Tuvalu
+  TUVALU,
+
+  /// Taiwan, Province of China
+  TAIWAN,
+
+  /// Tanzania, United Republic of
+  TANZANIA,
+
+  /// Ukraine
+  UKRAINE,
+
+  /// Uganda
+  UGANDA,
+
+  /// United States Minor Outlying Islands
+  UNITED_STATES_MINOR_OUTLYING_ISLANDS,
+
+  /// United States of America
+  USA,
+
+  /// Uruguay
+  URUGUAY,
+
+  /// Uzbekistan
+  UZBEKISTAN,
+
+  /// Holy See
+  HOLY_SEE,
+
+  /// Saint Vincent and the Grenadines
+  SAINT_VINCENT_AND_THE_GRENADINES,
+
+  /// Venezuela (Bolivarian Republic of)
+  VENEZUELA,
+
+  /// Virgin Islands (British)
+  BRITISH_VIRGIN_ISLANDS,
+
+  /// Virgin Islands (U.S.)
+  US_VIRGIN_ISLANDS,
+
+  /// Viet Nam
+  VIET_NAM,
+
+  /// Vanuatu
+  VANUATU,
+
+  /// Wallis and Futuna
+  WALLIS_AND_FUTUNA,
+
+  /// Samoa
+  SAMOA,
+
+  /// Yemen
+  YEMEN,
+
+  /// Mayotte
+  MAYOTTE,
+
+  /// South Africa
+  SOUTH_AFRICA,
+
+  /// Zambia
+  ZAMBIA,
+
+  /// Zimbabwe
+  ZIMBABWE,
+}
+
+extension OpenFoodFactsCoutryExtension on OpenFoodFactsCountry {
+  static const Map<OpenFoodFactsCountry, String> _ISO_2_CODES = {
+    OpenFoodFactsCountry.ANDORRA: 'ad',
+    OpenFoodFactsCountry.UNITED_ARAB_EMIRATES: 'ae',
+    OpenFoodFactsCountry.AFGHANISTAN: 'af',
+    OpenFoodFactsCountry.ANTIGUA_AND_BARBUDA: 'ag',
+    OpenFoodFactsCountry.ANGUILLA: 'ai',
+    OpenFoodFactsCountry.ALBANIA: 'al',
+    OpenFoodFactsCountry.ARMENIA: 'am',
+    OpenFoodFactsCountry.ANGOLA: 'ao',
+    OpenFoodFactsCountry.ANTARCTICA: 'aq',
+    OpenFoodFactsCountry.ARGENTINA: 'ar',
+    OpenFoodFactsCountry.AMERICAN_SAMOA: 'as',
+    OpenFoodFactsCountry.AUSTRIA: 'at',
+    OpenFoodFactsCountry.AUSTRALIA: 'au',
+    OpenFoodFactsCountry.ARUBA: 'aw',
+    OpenFoodFactsCountry.ALAND_ISLANDS: 'ax',
+    OpenFoodFactsCountry.AZERBAIJAN: 'az',
+    OpenFoodFactsCountry.BOSNIA_AND_HERZEGOVINA: 'ba',
+    OpenFoodFactsCountry.BARBADOS: 'bb',
+    OpenFoodFactsCountry.BANGLADESH: 'bd',
+    OpenFoodFactsCountry.BELGIUM: 'be',
+    OpenFoodFactsCountry.BURKINA_FASO: 'bf',
+    OpenFoodFactsCountry.BULGARIA: 'bg',
+    OpenFoodFactsCountry.BAHRAIN: 'bh',
+    OpenFoodFactsCountry.BURUNDI: 'bi',
+    OpenFoodFactsCountry.BENIN: 'bj',
+    OpenFoodFactsCountry.SAINT_BARTHELEMY: 'bl',
+    OpenFoodFactsCountry.BERMUDA: 'bm',
+    OpenFoodFactsCountry.BRUNEI_DARUSSALAM: 'bn',
+    OpenFoodFactsCountry.BOLIVIA: 'bo',
+    OpenFoodFactsCountry.BONAIRE: 'bq',
+    OpenFoodFactsCountry.BRAZIL: 'br',
+    OpenFoodFactsCountry.BAHAMAS: 'bs',
+    OpenFoodFactsCountry.BHUTAN: 'bt',
+    OpenFoodFactsCountry.BOUVET_ISLAND: 'bv',
+    OpenFoodFactsCountry.BOTSWANA: 'bw',
+    OpenFoodFactsCountry.BELARUS: 'by',
+    OpenFoodFactsCountry.BELIZE: 'bz',
+    OpenFoodFactsCountry.CANADA: 'ca',
+    OpenFoodFactsCountry.COCOS_ISLANDS: 'cc',
+    OpenFoodFactsCountry.DEMOCRATIC_REPUBLIC_OF_THE_CONGO: 'cd',
+    OpenFoodFactsCountry.CENTRAL_AFRICAN_REPUBLIC: 'cf',
+    OpenFoodFactsCountry.CONGO: 'cg',
+    OpenFoodFactsCountry.SWITZERLAND: 'ch',
+    OpenFoodFactsCountry.COTE_D_IVOIRE: 'ci',
+    OpenFoodFactsCountry.COOK_ISLANDS: 'ck',
+    OpenFoodFactsCountry.CHILE: 'cl',
+    OpenFoodFactsCountry.CAMEROON: 'cm',
+    OpenFoodFactsCountry.CHINA: 'cn',
+    OpenFoodFactsCountry.COLOMBIA: 'co',
+    OpenFoodFactsCountry.COSTA_RICA: 'cr',
+    OpenFoodFactsCountry.CUBA: 'cu',
+    OpenFoodFactsCountry.CABO_VERDE: 'cv',
+    OpenFoodFactsCountry.CURACAO: 'cw',
+    OpenFoodFactsCountry.CHRISTMAS_ISLAND: 'cx',
+    OpenFoodFactsCountry.CYPRUS: 'cy',
+    OpenFoodFactsCountry.CZECHIA: 'cz',
+    OpenFoodFactsCountry.GERMANY: 'de',
+    OpenFoodFactsCountry.DJIBOUTI: 'dj',
+    OpenFoodFactsCountry.DENMARK: 'dk',
+    OpenFoodFactsCountry.DOMINICA: 'dm',
+    OpenFoodFactsCountry.DOMINICAN_REPUBLIC: 'do',
+    OpenFoodFactsCountry.ALGERIA: 'dz',
+    OpenFoodFactsCountry.ECUADOR: 'ec',
+    OpenFoodFactsCountry.ESTONIA: 'ee',
+    OpenFoodFactsCountry.EGYPT: 'eg',
+    OpenFoodFactsCountry.WESTERN_SAHARA: 'eh',
+    OpenFoodFactsCountry.ERITREA: 'er',
+    OpenFoodFactsCountry.SPAIN: 'es',
+    OpenFoodFactsCountry.ETHIOPIA: 'et',
+    OpenFoodFactsCountry.FINLAND: 'fi',
+    OpenFoodFactsCountry.FIJI: 'fj',
+    OpenFoodFactsCountry.FALKLAND_ISLANDS: 'fk',
+    OpenFoodFactsCountry.MICRONESIA: 'fm',
+    OpenFoodFactsCountry.FAROE_ISLANDS: 'fo',
+    OpenFoodFactsCountry.FRANCE: 'fr',
+    OpenFoodFactsCountry.GABON: 'ga',
+    OpenFoodFactsCountry.UNITED_KINGDOM: 'gb',
+    OpenFoodFactsCountry.GRENADA: 'gd',
+    OpenFoodFactsCountry.GEORGIA: 'ge',
+    OpenFoodFactsCountry.FRENCH_GUIANA: 'gf',
+    OpenFoodFactsCountry.GUERNSEY: 'gg',
+    OpenFoodFactsCountry.GHANA: 'gh',
+    OpenFoodFactsCountry.GIBRALTAR: 'gi',
+    OpenFoodFactsCountry.GREENLAND: 'gl',
+    OpenFoodFactsCountry.GAMBIA: 'gm',
+    OpenFoodFactsCountry.GUINEA: 'gn',
+    OpenFoodFactsCountry.GUADELOUPE: 'gp',
+    OpenFoodFactsCountry.EQUATORIAL_GUINEA: 'gq',
+    OpenFoodFactsCountry.GREECE: 'gr',
+    OpenFoodFactsCountry.SOUTH_GEORGIA: 'gs',
+    OpenFoodFactsCountry.GUATEMALA: 'gt',
+    OpenFoodFactsCountry.GUAM: 'gu',
+    OpenFoodFactsCountry.GUINEA_BISSAU: 'gw',
+    OpenFoodFactsCountry.GUYANA: 'gy',
+    OpenFoodFactsCountry.HONG_KONG: 'hk',
+    OpenFoodFactsCountry.HEARD_ISLAND: 'hm',
+    OpenFoodFactsCountry.HONDURAS: 'hn',
+    OpenFoodFactsCountry.CROATIA: 'hr',
+    OpenFoodFactsCountry.HAITI: 'ht',
+    OpenFoodFactsCountry.HUNGARY: 'hu',
+    OpenFoodFactsCountry.INDONESIA: 'id',
+    OpenFoodFactsCountry.IRELAND: 'ie',
+    OpenFoodFactsCountry.ISRAEL: 'il',
+    OpenFoodFactsCountry.ISLE_OF_MAN: 'im',
+    OpenFoodFactsCountry.INDIA: 'in',
+    OpenFoodFactsCountry.BRITISH_INDIAN_OCEAN_TERRITORY: 'io',
+    OpenFoodFactsCountry.IRAQ: 'iq',
+    OpenFoodFactsCountry.IRAN: 'ir',
+    OpenFoodFactsCountry.ICELAND: 'is',
+    OpenFoodFactsCountry.ITALY: 'it',
+    OpenFoodFactsCountry.JERSEY: 'je',
+    OpenFoodFactsCountry.JAMAICA: 'jm',
+    OpenFoodFactsCountry.JORDAN: 'jo',
+    OpenFoodFactsCountry.JAPAN: 'jp',
+    OpenFoodFactsCountry.KENYA: 'ke',
+    OpenFoodFactsCountry.KYRGYZSTAN: 'kg',
+    OpenFoodFactsCountry.CAMBODIA: 'kh',
+    OpenFoodFactsCountry.KIRIBATI: 'ki',
+    OpenFoodFactsCountry.COMOROS: 'km',
+    OpenFoodFactsCountry.SAINT_KITTS_AND_NEVIS: 'kn',
+    OpenFoodFactsCountry.NORTH_KOREA: 'kp',
+    OpenFoodFactsCountry.SOUTH_KOREA: 'kr',
+    OpenFoodFactsCountry.KUWAIT: 'kw',
+    OpenFoodFactsCountry.CAYMAN_ISLANDS: 'ky',
+    OpenFoodFactsCountry.KAZAKHSTAN: 'kz',
+    OpenFoodFactsCountry.LAOS: 'la',
+    OpenFoodFactsCountry.LEBANON: 'lb',
+    OpenFoodFactsCountry.SAINT_LUCIA: 'lc',
+    OpenFoodFactsCountry.LIECHTENSTEIN: 'li',
+    OpenFoodFactsCountry.SRI_LANKA: 'lk',
+    OpenFoodFactsCountry.LIBERIA: 'lr',
+    OpenFoodFactsCountry.LESOTHO: 'ls',
+    OpenFoodFactsCountry.LITHUANIA: 'lt',
+    OpenFoodFactsCountry.LUXEMBOURG: 'lu',
+    OpenFoodFactsCountry.LATVIA: 'lv',
+    OpenFoodFactsCountry.LIBYA: 'ly',
+    OpenFoodFactsCountry.MOROCCO: 'ma',
+    OpenFoodFactsCountry.MONACO: 'mc',
+    OpenFoodFactsCountry.MOLDOVA: 'md',
+    OpenFoodFactsCountry.MONTENEGRO: 'me',
+    OpenFoodFactsCountry.SAINT_MARTIN: 'mf',
+    OpenFoodFactsCountry.MADAGASCAR: 'mg',
+    OpenFoodFactsCountry.MARSHALL_ISLANDS: 'mh',
+    OpenFoodFactsCountry.NORTH_MACEDONIA: 'mk',
+    OpenFoodFactsCountry.MALI: 'ml',
+    OpenFoodFactsCountry.MYANMAR: 'mm',
+    OpenFoodFactsCountry.MONGOLIA: 'mn',
+    OpenFoodFactsCountry.MACAO: 'mo',
+    OpenFoodFactsCountry.NORTHERN_MARIANA_ISLANDS: 'mp',
+    OpenFoodFactsCountry.MARTINIQUE: 'mq',
+    OpenFoodFactsCountry.MAURITANIA: 'mr',
+    OpenFoodFactsCountry.MONTSERRAT: 'ms',
+    OpenFoodFactsCountry.MALTA: 'mt',
+    OpenFoodFactsCountry.MAURITIUS: 'mu',
+    OpenFoodFactsCountry.MALDIVES: 'mv',
+    OpenFoodFactsCountry.MALAWI: 'mw',
+    OpenFoodFactsCountry.MEXICO: 'mx',
+    OpenFoodFactsCountry.MALAYSIA: 'my',
+    OpenFoodFactsCountry.MOZAMBIQUE: 'mz',
+    OpenFoodFactsCountry.NAMIBIA: 'na',
+    OpenFoodFactsCountry.NEW_CALEDONIA: 'nc',
+    OpenFoodFactsCountry.NIGER: 'ne',
+    OpenFoodFactsCountry.NORFOLK_ISLAND: 'nf',
+    OpenFoodFactsCountry.NIGERIA: 'ng',
+    OpenFoodFactsCountry.NICARAGUA: 'ni',
+    OpenFoodFactsCountry.NETHERLANDS: 'nl',
+    OpenFoodFactsCountry.NORWAY: 'no',
+    OpenFoodFactsCountry.NEPAL: 'np',
+    OpenFoodFactsCountry.NAURU: 'nr',
+    OpenFoodFactsCountry.NIUE: 'nu',
+    OpenFoodFactsCountry.NEW_ZEALAND: 'nz',
+    OpenFoodFactsCountry.OMAN: 'om',
+    OpenFoodFactsCountry.PANAMA: 'pa',
+    OpenFoodFactsCountry.PERU: 'pe',
+    OpenFoodFactsCountry.FRENCH_POLYNESIA: 'pf',
+    OpenFoodFactsCountry.PAPUA_NEW_GUINEA: 'pg',
+    OpenFoodFactsCountry.PHILIPPINES: 'ph',
+    OpenFoodFactsCountry.PAKISTAN: 'pk',
+    OpenFoodFactsCountry.POLAND: 'pl',
+    OpenFoodFactsCountry.SAINT_PIERRE_AND_MIQUELON: 'pm',
+    OpenFoodFactsCountry.PITCAIRN: 'pn',
+    OpenFoodFactsCountry.PUERTO_RICO: 'pr',
+    OpenFoodFactsCountry.PALESTINE: 'ps',
+    OpenFoodFactsCountry.PORTUGAL: 'pt',
+    OpenFoodFactsCountry.PALAU: 'pw',
+    OpenFoodFactsCountry.PARAGUAY: 'py',
+    OpenFoodFactsCountry.QATAR: 'qa',
+    OpenFoodFactsCountry.REUNION: 're',
+    OpenFoodFactsCountry.ROMANIA: 'ro',
+    OpenFoodFactsCountry.SERBIA: 'rs',
+    OpenFoodFactsCountry.RUSSIA: 'ru',
+    OpenFoodFactsCountry.RWANDA: 'rw',
+    OpenFoodFactsCountry.SAUDI_ARABIA: 'sa',
+    OpenFoodFactsCountry.SOLOMON_ISLANDS: 'sb',
+    OpenFoodFactsCountry.SEYCHELLES: 'sc',
+    OpenFoodFactsCountry.SUDAN: 'sd',
+    OpenFoodFactsCountry.SWEDEN: 'se',
+    OpenFoodFactsCountry.SINGAPORE: 'sg',
+    OpenFoodFactsCountry.SAINT_HELENA: 'sh',
+    OpenFoodFactsCountry.SLOVENIA: 'si',
+    OpenFoodFactsCountry.SVALBARD_AND_JAN_MAYEN: 'sj',
+    OpenFoodFactsCountry.SLOVAKIA: 'sk',
+    OpenFoodFactsCountry.SIERRA_LEONE: 'sl',
+    OpenFoodFactsCountry.SAN_MARINO: 'sm',
+    OpenFoodFactsCountry.SENEGAL: 'sn',
+    OpenFoodFactsCountry.SOMALIA: 'so',
+    OpenFoodFactsCountry.SURINAME: 'sr',
+    OpenFoodFactsCountry.SOUTH_SUDAN: 'ss',
+    OpenFoodFactsCountry.SAO_TOME_AND_PRINCIPE: 'st',
+    OpenFoodFactsCountry.EL_SALVADOR: 'sv',
+    OpenFoodFactsCountry.SINT_MAARTEN: 'sx',
+    OpenFoodFactsCountry.SYRIA: 'sy',
+    OpenFoodFactsCountry.ESWATINI: 'sz',
+    OpenFoodFactsCountry.TURKS_AND_CAICOS_ISLANDS: 'tc',
+    OpenFoodFactsCountry.CHAD: 'td',
+    OpenFoodFactsCountry.FRENCH_SOUTHERN_TERRITORIES: 'tf',
+    OpenFoodFactsCountry.TOGO: 'tg',
+    OpenFoodFactsCountry.THAILAND: 'th',
+    OpenFoodFactsCountry.TAJIKISTAN: 'tj',
+    OpenFoodFactsCountry.TOKELAU: 'tk',
+    OpenFoodFactsCountry.TIMOR_LESTE: 'tl',
+    OpenFoodFactsCountry.TURKMENISTAN: 'tm',
+    OpenFoodFactsCountry.TUNISIA: 'tn',
+    OpenFoodFactsCountry.TONGA: 'to',
+    OpenFoodFactsCountry.TURKEY: 'tr',
+    OpenFoodFactsCountry.TRINIDAD_AND_TOBAGO: 'tt',
+    OpenFoodFactsCountry.TUVALU: 'tv',
+    OpenFoodFactsCountry.TAIWAN: 'tw',
+    OpenFoodFactsCountry.TANZANIA: 'tz',
+    OpenFoodFactsCountry.UKRAINE: 'ua',
+    OpenFoodFactsCountry.UGANDA: 'ug',
+    OpenFoodFactsCountry.UNITED_STATES_MINOR_OUTLYING_ISLANDS: 'um',
+    OpenFoodFactsCountry.USA: 'us',
+    OpenFoodFactsCountry.URUGUAY: 'uy',
+    OpenFoodFactsCountry.UZBEKISTAN: 'uz',
+    OpenFoodFactsCountry.HOLY_SEE: 'va',
+    OpenFoodFactsCountry.SAINT_VINCENT_AND_THE_GRENADINES: 'vc',
+    OpenFoodFactsCountry.VENEZUELA: 've',
+    OpenFoodFactsCountry.BRITISH_VIRGIN_ISLANDS: 'vg',
+    OpenFoodFactsCountry.US_VIRGIN_ISLANDS: 'vi',
+    OpenFoodFactsCountry.VIET_NAM: 'vn',
+    OpenFoodFactsCountry.VANUATU: 'vu',
+    OpenFoodFactsCountry.WALLIS_AND_FUTUNA: 'wf',
+    OpenFoodFactsCountry.SAMOA: 'ws',
+    OpenFoodFactsCountry.YEMEN: 'ye',
+    OpenFoodFactsCountry.MAYOTTE: 'yt',
+    OpenFoodFactsCountry.SOUTH_AFRICA: 'za',
+    OpenFoodFactsCountry.ZAMBIA: 'zm',
+    OpenFoodFactsCountry.ZIMBABWE: 'zw',
+  };
+
+  String get iso2Code => _ISO_2_CODES[this]!;
+}

--- a/lib/utils/OpenFoodAPIConfiguration.dart
+++ b/lib/utils/OpenFoodAPIConfiguration.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/model/UserAgent.dart';
 
+import 'CountryHelper.dart';
 import 'LanguageHelper.dart';
 import 'QueryType.dart';
 
@@ -38,9 +39,38 @@ class OpenFoodAPIConfiguration {
   ///A global way to specify the country code for queries, can be overwritten
   /// for each individual request by specifying the country code in the
   /// individual request configurations
+  // TODO: deprecated from 2021-11-15 (#233); remove when old enough
+  @Deprecated('Use field globalCountry instead')
   static String? globalCC;
+
+  ///A global way to specify the country code for queries, can be overwritten
+  /// for each individual request by specifying the country code in the
+  /// individual request configurations
+  static OpenFoodFactsCountry? globalCountry;
 
   ///Returns the [QueryType] to use, using a default value
   static QueryType getQueryType(final QueryType? queryType) =>
       queryType ?? globalQueryType;
+
+  /// Returns the most relevant country code
+  static String? computeCountryCode(
+    final OpenFoodFactsCountry? country,
+    final String? cc,
+  ) {
+    if (country != null) {
+      return country.iso2Code;
+    }
+    if (globalCountry != null) {
+      return globalCountry!.iso2Code;
+    }
+    if (cc != null) {
+      return cc;
+    }
+    // ignore: deprecated_member_use_from_same_package
+    if (OpenFoodAPIConfiguration.globalCC != null) {
+      // ignore: deprecated_member_use_from_same_package
+      return OpenFoodAPIConfiguration.globalCC;
+    }
+    return null;
+  }
 }

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 
 /// Query Configuration for multiple barcodes
 class ProductListQueryConfiguration extends AbstractQueryConfiguration {
@@ -13,6 +14,7 @@ class ProductListQueryConfiguration extends AbstractQueryConfiguration {
     final List<OpenFoodFactsLanguage> languages = const [],
     final String? lc,
     final String? cc,
+    final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
     int? page,
     int? pageSize,
@@ -23,6 +25,7 @@ class ProductListQueryConfiguration extends AbstractQueryConfiguration {
           languages: languages,
           lc: lc,
           cc: cc,
+          country: country,
           fields: fields,
           additionalParameters:
               _convertToParametersList(page, pageSize, sortOption),

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -12,8 +12,9 @@ class ProductListQueryConfiguration extends AbstractQueryConfiguration {
     this.barcodes, {
     final OpenFoodFactsLanguage? language,
     final List<OpenFoodFactsLanguage> languages = const [],
-    final String? lc,
-    final String? cc,
+    @Deprecated('Use parameters language or languages instead')
+        final String? lc,
+    @Deprecated('Use parameter country instead') final String? cc,
     final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
     int? page,

--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -1,4 +1,5 @@
 import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
 
@@ -14,12 +15,14 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
     final List<OpenFoodFactsLanguage> languages = const [],
     final String? lc,
     final String? cc,
+    final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
   }) : super(
           language: language,
           languages: languages,
           lc: lc,
           cc: cc,
+          country: country,
           fields: fields,
         );
 }

--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -13,8 +13,9 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
     this.barcode, {
     final OpenFoodFactsLanguage? language,
     final List<OpenFoodFactsLanguage> languages = const [],
-    final String? lc,
-    final String? cc,
+    @Deprecated('Use parameters language or languages instead')
+        final String? lc,
+    @Deprecated('Use parameter country instead') final String? cc,
     final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
   }) : super(

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
 
@@ -12,6 +13,7 @@ class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
     final List<OpenFoodFactsLanguage> languages = const [],
     final String? lc,
     final String? cc,
+    final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
     required List<Parameter> parametersList,
   }) : super(
@@ -19,6 +21,7 @@ class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
           languages: languages,
           lc: lc,
           cc: cc,
+          country: country,
           fields: fields,
           additionalParameters: parametersList,
         );

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -11,8 +11,9 @@ class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
   ProductSearchQueryConfiguration({
     final OpenFoodFactsLanguage? language,
     final List<OpenFoodFactsLanguage> languages = const [],
-    final String? lc,
-    final String? cc,
+    @Deprecated('Use parameters language or languages instead')
+        final String? lc,
+    @Deprecated('Use parameter country instead') final String? cc,
     final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
     required List<Parameter> parametersList,

--- a/lib/utils/TaxonomyQueryConfiguration.dart
+++ b/lib/utils/TaxonomyQueryConfiguration.dart
@@ -1,4 +1,5 @@
 import 'package:openfoodfacts/interface/JsonObject.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -28,7 +29,12 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
   final List<OpenFoodFactsLanguage> languages;
 
   /// The country code for this query, if any.
+  // TODO: deprecated from 2021-11-15 (#233); remove when old enough
+  @Deprecated('Use parameter country instead')
   final String? cc;
+
+  /// The country for this query, if any.
+  final OpenFoodFactsCountry? country;
 
   /// The desired taxonomy fields to retrieve. If empty, retrieve all fields.
   final List<F> fields;
@@ -60,6 +66,7 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
     this.tags, {
     List<OpenFoodFactsLanguage>? languages,
     this.cc,
+    this.country,
     this.includeChildren = false,
     this.fields = const [],
     this.additionalParameters = const [],
@@ -72,6 +79,7 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
     this.tagType, {
     List<OpenFoodFactsLanguage>? languages,
     this.cc,
+    this.country,
     this.includeChildren = false,
     this.fields = const [],
     this.additionalParameters = const [],
@@ -101,7 +109,10 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
           () => languages.map<String>((language) => language.code).join(','));
     }
 
-    result.putIfAbsent('cc', () => cc ?? OpenFoodAPIConfiguration.globalCC!);
+    result.putIfAbsent(
+        'cc',
+        // ignore: deprecated_member_use_from_same_package
+        () => OpenFoodAPIConfiguration.computeCountryCode(country, cc)!);
 
     if (fields.isNotEmpty) {
       final Iterable<String> fieldsStrings = convertFieldsToStrings(fields);

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -900,7 +900,8 @@ void main() {
           notify: () => refreshCounter++,
         ),
       );
-      const String languageCode = 'en';
+      const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.ENGLISH;
+      final String languageCode = language.code;
       final String importanceUrl =
           AvailablePreferenceImportances.getUrl(languageCode);
       final String attributeGroupUrl =
@@ -923,7 +924,7 @@ void main() {
       final ProductQueryConfiguration configurations =
           ProductQueryConfiguration(
         barcode,
-        lc: languageCode,
+        language: language,
         fields: [ProductField.NAME, ProductField.ATTRIBUTE_GROUPS],
       );
       final ProductResult result = await OpenFoodAPIClient.getProduct(

--- a/test/api_getTaxonomyAdditives_test.dart
+++ b/test/api_getTaxonomyAdditives_test.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/model/TaxonomyAdditive.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
@@ -9,7 +10,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
-  OpenFoodAPIConfiguration.globalCC = 'fr';
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   late FakeHttpHelper httpHelper;
   final Map<String, dynamic> expectedResponse = <String, dynamic>{
     'en:e436': {

--- a/test/api_getTaxonomyAllergens_test.dart
+++ b/test/api_getTaxonomyAllergens_test.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/model/TaxonomyAllergen.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
@@ -9,7 +10,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
-  OpenFoodAPIConfiguration.globalCC = 'fr';
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   late FakeHttpHelper httpHelper;
 
   setUp(() {

--- a/test/api_getTaxonomyCategories_test.dart
+++ b/test/api_getTaxonomyCategories_test.dart
@@ -1,4 +1,5 @@
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
@@ -8,7 +9,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
-  OpenFoodAPIConfiguration.globalCC = 'fr';
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   late FakeHttpHelper httpHelper;
 
   setUp(() {

--- a/test/api_getTaxonomyCountries_test.dart
+++ b/test/api_getTaxonomyCountries_test.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/model/TaxonomyCountry.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
@@ -9,7 +10,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
-  OpenFoodAPIConfiguration.globalCC = 'fr';
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   late FakeHttpHelper httpHelper;
   final Map<String, dynamic> expectedResponse = <String, dynamic>{
     "en:gambia": {

--- a/test/api_getTaxonomyIngredients_test.dart
+++ b/test/api_getTaxonomyIngredients_test.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/model/TaxonomyIngredient.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
@@ -9,7 +10,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
-  OpenFoodAPIConfiguration.globalCC = 'fr';
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   late FakeHttpHelper httpHelper;
 
   setUp(() {

--- a/test/api_getTaxonomyLabels_test.dart
+++ b/test/api_getTaxonomyLabels_test.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/model/TaxonomyLabel.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
@@ -9,7 +10,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
-  OpenFoodAPIConfiguration.globalCC = 'fr';
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   late FakeHttpHelper httpHelper;
   final Map<String, dynamic> expectedResponse = <String, dynamic>{
     'en:vegetarian': {

--- a/test/api_getTaxonomyLanguages_test.dart
+++ b/test/api_getTaxonomyLanguages_test.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/model/TaxonomyLanguage.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
@@ -9,7 +10,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
-  OpenFoodAPIConfiguration.globalCC = 'fr';
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   late FakeHttpHelper httpHelper;
   final Map<String, dynamic> expectedResponse = <String, dynamic>{
     'en:afrikaans': {

--- a/test/api_getTaxonomy_test.dart
+++ b/test/api_getTaxonomy_test.dart
@@ -1,4 +1,5 @@
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
@@ -8,7 +9,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
-  OpenFoodAPIConfiguration.globalCC = 'fr';
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   late FakeHttpHelper httpHelper;
 
   setUp(() {


### PR DESCRIPTION
New file:
* `CountryHelper.dart`: country enums and their ISO-2-codes

Impacted files:
* `AbstractQueryConfiguration.dart`: deprecated `String? cc` in favor of `OpenFoodFactsCountry? country`
* `api_getTaxonomy_test.dart`: now using `OpenFoodAPIConfiguration.globalCountry`
* `api_getTaxonomyAdditives_test.dart`: now using `OpenFoodAPIConfiguration.globalCountry`
* `api_getTaxonomyAllergens_test.dart`: now using `OpenFoodAPIConfiguration.globalCountry`
* `api_getTaxonomyCategories_test.dart`: now using `OpenFoodAPIConfiguration.globalCountry`
* `api_getTaxonomyCountries_test.dart`: now using `OpenFoodAPIConfiguration.globalCountry`
* `api_getTaxonomyIngredients_test.dart`: now using `OpenFoodAPIConfiguration.globalCountry`
* `api_getTaxonomyLabels_test.dart`: now using `OpenFoodAPIConfiguration.globalCountry`
* `api_getTaxonomyLanguages_test.dart`: now using `OpenFoodAPIConfiguration.globalCountry`
* `OpenFoodAPIConfiguration.dart`: deprecated `String? globalCC` in favor of `OpenFoodFactsCountry? globalCountry`
* `openfoodfacts.dart`: minor refactoring
* `ProductListQueryConfiguration.dart`: added parameter `OpenFoodFactsCountry? country`
* `ProductQueryConfigurations.dart`: added parameter `OpenFoodFactsCountry? country`
* `ProductSearchQueryConfiguration.dart`: added parameter `OpenFoodFactsCountry? country`
* `TaxonomyAdditive.dart`: added parameter `OpenFoodFactsCountry? country`
* `TaxonomyAllergen.dart`: added parameter `OpenFoodFactsCountry? country`
* `TaxonomyCategory.dart`: added parameter `OpenFoodFactsCountry? country`
* `TaxonomyCountry.dart`: added parameter `OpenFoodFactsCountry? country`
* `TaxonomyIngredient.dart`: added parameter `OpenFoodFactsCountry? country`
* `TaxonomyLabel.dart`: added parameter `OpenFoodFactsCountry? country`
* `TaxonomyLanguage.dart`: added parameter `OpenFoodFactsCountry? country`
* `TaxonomyQueryConfiguration.dart`: deprecated `String? cc` in favor of `OpenFoodFactsCountry? country`