### PR TITLE
feat: new method "getOrderedNutrientsJsonString"

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -940,11 +940,29 @@ class OpenFoodAPIClient {
     required final String cc,
     required final OpenFoodFactsLanguage language,
     final QueryType? queryType,
+  }) async =>
+      OrderedNutrients.fromJson(
+        jsonDecode(
+          await getOrderedNutrientsJsonString(
+            country: CountryHelper.fromJson(cc)!,
+            language: language,
+          ),
+        ),
+      );
+
+  /// Returns the nutrient hierarchy specific to a country, localized, as JSON
+  static Future<String> getOrderedNutrientsJsonString({
+    required final OpenFoodFactsCountry country,
+    required final OpenFoodFactsLanguage language,
+    final QueryType? queryType,
   }) async {
     final Uri uri = UriHelper.getUri(
       path: 'cgi/nutrients.pl',
       queryType: queryType,
-      queryParameters: <String, String>{'cc': cc, 'lc': language.code},
+      queryParameters: <String, String>{
+        'cc': country.iso2Code,
+        'lc': language.code,
+      },
     );
 
     final Response response = await HttpHelper().doGetRequest(
@@ -954,8 +972,7 @@ class OpenFoodAPIClient {
     if (response.statusCode != 200) {
       throw Exception('Could not retrieve ordered nutrients!');
     }
-    final json = jsonDecode(response.body);
-    return OrderedNutrients.fromJson(json);
+    return response.body;
   }
 
   /// Rotates a product image from an already uploaded image.

--- a/test/ordered_nutrient_test.dart
+++ b/test/ordered_nutrient_test.dart
@@ -1,6 +1,8 @@
+import 'dart:convert';
 import 'package:openfoodfacts/model/OrderedNutrient.dart';
 import 'package:openfoodfacts/model/OrderedNutrients.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
@@ -8,6 +10,117 @@ import 'package:test/test.dart';
 /// Tests related to [OrderedNutrient] and [OrderedNutrients]
 void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+
+  // Very long list, experimentally created from the 3 initial URLs.
+  // Don't hesitate to edit this list if you have clear functional ideas
+  // about which nutrients should actually be there.
+  const Set<String> _expectedNutrients = {
+    'alcohol',
+    'alpha-linolenic-acid',
+    'arachidic-acid',
+    'arachidonic-acid',
+    'behenic-acid',
+    'beta-carotene',
+    'bicarbonate',
+    'biotin',
+    'butyric-acid',
+    'caffeine',
+    'calcium',
+    'capric-acid',
+    'caproic-acid',
+    'caprylic-acid',
+    'carbohydrates',
+    'carbon-footprint',
+    'carbon-footprint-from-meat-or-fish',
+    'casein',
+    'cerotic-acid',
+    'chloride',
+    'chlorophyl',
+    'cholesterol',
+    'chromium',
+    'cocoa',
+    'collagen-meat-protein-ratio',
+    'copper',
+    'dihomo-gamma-linolenic-acid',
+    'docosahexaenoic-acid',
+    'eicosapentaenoic-acid',
+    'elaidic-acid',
+    'energy',
+    'energy-from-fat',
+    'energy-kcal',
+    'erucic-acid',
+    'fat',
+    'fiber',
+    'fluoride',
+    'folates',
+    'fructose',
+    'fruits-vegetables-nuts',
+    'fruits-vegetables-nuts-dried',
+    'fruits-vegetables-nuts-estimate',
+    'gamma-linolenic-acid',
+    'glucose',
+    'glycemic-index',
+    'gondoic-acid',
+    'insoluble-fiber',
+    'iodine',
+    'iron',
+    'lactose',
+    'lauric-acid',
+    'lignoceric-acid',
+    'linoleic-acid',
+    'magnesium',
+    'maltodextrins',
+    'maltose',
+    'manganese',
+    'mead-acid',
+    'melissic-acid',
+    'molybdenum',
+    'monounsaturated-fat',
+    'montanic-acid',
+    'myristic-acid',
+    'nervonic-acid',
+    'nucleotides',
+    'nutrition-score-fr',
+    'nutrition-score-uk',
+    'oleic-acid',
+    'omega-3-fat',
+    'omega-6-fat',
+    'omega-9-fat',
+    'palmitic-acid',
+    'pantothenic-acid',
+    'ph',
+    'phosphorus',
+    'polyols',
+    'polyunsaturated-fat',
+    'potassium',
+    'proteins',
+    'salt',
+    'saturated-fat',
+    'selenium',
+    'serum-proteins',
+    'silica',
+    'sodium',
+    'soluble-fiber',
+    'starch',
+    'stearic-acid',
+    'sucrose',
+    'sugars',
+    'taurine',
+    'trans-fat',
+    'vitamin-a',
+    'vitamin-b1',
+    'vitamin-b12',
+    'vitamin-b2',
+    'vitamin-b6',
+    'vitamin-b9',
+    'vitamin-c',
+    'vitamin-d',
+    'vitamin-e',
+    'vitamin-k',
+    'vitamin-pp',
+    'water-hardness',
+    'zinc',
+  };
 
   OrderedNutrient? _findOrderedNutrient(
     final List<OrderedNutrient>? list,
@@ -29,135 +142,47 @@ void main() {
     return null;
   }
 
+  void _checkNutrients(
+    final OrderedNutrients orderedNutrients,
+    final OpenFoodFactsCountry country,
+  ) {
+    for (final String expectedNutrient in _expectedNutrients) {
+      expect(
+        _findOrderedNutrient(orderedNutrients.nutrients, expectedNutrient),
+        isNotNull,
+        reason:
+            'Could not find nutrient $expectedNutrient for country $country',
+      );
+    }
+  }
+
   group('$OpenFoodAPIClient ordered nutrients', () {
     test('find expected nutrients', () async {
-      // Very long list, experimentally created from the 3 initial URLs.
-      // Don't hesitate to edit this list if you have clear functional ideas
-      // about which nutrients should actually be there.
-      const Set<String> expectedNutrients = {
-        'alcohol',
-        'alpha-linolenic-acid',
-        'arachidic-acid',
-        'arachidonic-acid',
-        'behenic-acid',
-        'beta-carotene',
-        'bicarbonate',
-        'biotin',
-        'butyric-acid',
-        'caffeine',
-        'calcium',
-        'capric-acid',
-        'caproic-acid',
-        'caprylic-acid',
-        'carbohydrates',
-        'carbon-footprint',
-        'carbon-footprint-from-meat-or-fish',
-        'casein',
-        'cerotic-acid',
-        'chloride',
-        'chlorophyl',
-        'cholesterol',
-        'chromium',
-        'cocoa',
-        'collagen-meat-protein-ratio',
-        'copper',
-        'dihomo-gamma-linolenic-acid',
-        'docosahexaenoic-acid',
-        'eicosapentaenoic-acid',
-        'elaidic-acid',
-        'energy',
-        'energy-from-fat',
-        'energy-kcal',
-        'erucic-acid',
-        'fat',
-        'fiber',
-        'fluoride',
-        'folates',
-        'fructose',
-        'fruits-vegetables-nuts',
-        'fruits-vegetables-nuts-dried',
-        'fruits-vegetables-nuts-estimate',
-        'gamma-linolenic-acid',
-        'glucose',
-        'glycemic-index',
-        'gondoic-acid',
-        'insoluble-fiber',
-        'iodine',
-        'iron',
-        'lactose',
-        'lauric-acid',
-        'lignoceric-acid',
-        'linoleic-acid',
-        'magnesium',
-        'maltodextrins',
-        'maltose',
-        'manganese',
-        'mead-acid',
-        'melissic-acid',
-        'molybdenum',
-        'monounsaturated-fat',
-        'montanic-acid',
-        'myristic-acid',
-        'nervonic-acid',
-        'nucleotides',
-        'nutrition-score-fr',
-        'nutrition-score-uk',
-        'oleic-acid',
-        'omega-3-fat',
-        'omega-6-fat',
-        'omega-9-fat',
-        'palmitic-acid',
-        'pantothenic-acid',
-        'ph',
-        'phosphorus',
-        'polyols',
-        'polyunsaturated-fat',
-        'potassium',
-        'proteins',
-        'salt',
-        'saturated-fat',
-        'selenium',
-        'serum-proteins',
-        'silica',
-        'sodium',
-        'soluble-fiber',
-        'starch',
-        'stearic-acid',
-        'sucrose',
-        'sugars',
-        'taurine',
-        'trans-fat',
-        'vitamin-a',
-        'vitamin-b1',
-        'vitamin-b12',
-        'vitamin-b2',
-        'vitamin-b6',
-        'vitamin-b9',
-        'vitamin-c',
-        'vitamin-d',
-        'vitamin-e',
-        'vitamin-k',
-        'vitamin-pp',
-        'water-hardness',
-        'zinc',
+      const Set<OpenFoodFactsCountry> countries = {
+        OpenFoodFactsCountry.FRANCE,
+        OpenFoodFactsCountry.BRAZIL,
+        OpenFoodFactsCountry.USA,
       };
-
-      const Set<String> countries = {'fr', 'br', 'us'};
       const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.AFRIKAANS;
-      for (final String country in countries) {
-        final OrderedNutrients orderedNutrients =
-            await OpenFoodAPIClient.getOrderedNutrients(
-          cc: country,
-          language: language,
+      for (final OpenFoodFactsCountry country in countries) {
+        _checkNutrients(
+          await OpenFoodAPIClient.getOrderedNutrients(
+            cc: country.iso2Code,
+            language: language,
+          ),
+          country,
         );
-        for (final String expectedNutrient in expectedNutrients) {
-          expect(
-            _findOrderedNutrient(orderedNutrients.nutrients, expectedNutrient),
-            isNotNull,
-            reason:
-                'Could not find nutrient $expectedNutrient for country $country',
-          );
-        }
+        _checkNutrients(
+          OrderedNutrients.fromJson(
+            jsonDecode(
+              await OpenFoodAPIClient.getOrderedNutrientsJsonString(
+                country: country,
+                language: language,
+              ),
+            ),
+          ),
+          country,
+        );
       }
     });
 


### PR DESCRIPTION
The point (for apps) is to retrieve that string, store it locally, and refresh it from the API when relevant (and not systematically).

Impacted files:
* `openfoodfacts.dart`: new method `getOrderedNutrientsJsonString`; refactored `getOrderedNutrients`
* `ordered_nutrient_test.dart`: added test for new method `getOrderedNutrientsJsonString`