### PR TITLE
Switch from 'type' to 'tagtype' in the taxonomy API

### DIFF
--- a/lib/utils/TaxonomyQueryConfiguration.dart
+++ b/lib/utils/TaxonomyQueryConfiguration.dart
@@ -94,7 +94,7 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
   Map<String, String> getParametersMap() {
     final Map<String, String> result = {};
 
-    result['type'] = tagType.key;
+    result['tagtype'] = tagType.key;
     if (_isRootConfiguration) {
       result['include_root_entries'] = '1';
     } else {

--- a/test/api_searchProducts_test.dart
+++ b/test/api_searchProducts_test.dart
@@ -1,4 +1,3 @@
-import 'package:openfoodfacts/model/ProductFreshness.dart';
 import 'package:openfoodfacts/model/parameter/PnnsGroup2Filter.dart';
 import 'package:openfoodfacts/model/parameter/SearchTerms.dart';
 import 'package:openfoodfacts/model/parameter/TagFilter.dart';


### PR DESCRIPTION
The taxonomy API changed from specifying the type of taxonomy using "type" to using "tagtype".  This reflects that change in the query configurations.