### PR TITLE
feat: new method getProductString, api V0 and V2, new product and ingredient fields

### DIFF
--- a/lib/model/Ingredient.dart
+++ b/lib/model/Ingredient.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:openfoodfacts/utils/JsonHelper.dart';
 import '../interface/JsonObject.dart';
 
 part 'Ingredient.g.dart';
@@ -9,12 +10,21 @@ enum IngredientSpecialPropertyStatus { POSITIVE, NEGATIVE, MAYBE, IGNORE }
 class Ingredient extends JsonObject {
   @JsonKey(includeIfNull: false, fromJson: JsonObject.parseInt)
   int? rank;
+
   @JsonKey(includeIfNull: false)
   String? id;
+
   @JsonKey()
   String? text;
+
   @JsonKey(includeIfNull: false, fromJson: JsonObject.parseDouble)
   double? percent;
+
+  @JsonKey(
+      name: 'percent_estimate',
+      includeIfNull: false,
+      fromJson: JsonObject.parseDouble)
+  double? percentEstimate;
 
   @JsonKey(
       includeIfNull: false,
@@ -35,6 +45,12 @@ class Ingredient extends JsonObject {
       toJson: ingredientSpecialPropertyStatusToJson)
   IngredientSpecialPropertyStatus? fromPalmOil;
 
+  @JsonKey(
+      name: 'ingredients',
+      includeIfNull: false,
+      toJson: JsonHelper.ingredientsToJson)
+  List<Ingredient>? ingredients;
+
   bool? bold;
 
   Ingredient(
@@ -42,9 +58,11 @@ class Ingredient extends JsonObject {
       this.id,
       this.text,
       this.percent,
+      this.percentEstimate,
       this.vegan,
       this.vegetarian,
       this.fromPalmOil,
+      this.ingredients,
       this.bold = false});
 
   factory Ingredient.fromJson(Map<String, dynamic> json) =>
@@ -52,6 +70,20 @@ class Ingredient extends JsonObject {
 
   @override
   Map<String, dynamic> toJson() => _$IngredientToJson(this);
+
+  @override
+  String toString() => 'Ingredient('
+      '${id == null ? '' : 'id=$id'}'
+      '${rank == null ? '' : ',rank=$rank'}'
+      '${text == null ? '' : ',text=$text'}'
+      '${percent == null ? '' : ',percent=$percent'}'
+      '${percentEstimate == null ? '' : ',percentEstimate=$percentEstimate'}'
+      '${vegan == null ? '' : ',vegan=$vegan'}'
+      '${vegetarian == null ? '' : ',vegetarian=$vegetarian'}'
+      '${fromPalmOil == null ? '' : ',fromPalmOil=$fromPalmOil'}'
+      '${bold == null ? '' : ',bold=$bold'}'
+      '${ingredients == null ? '' : ',ingredients=$ingredients'}'
+      ')';
 }
 
 const Map<IngredientSpecialPropertyStatus, String> _MAP = {

--- a/lib/model/Ingredient.g.dart
+++ b/lib/model/Ingredient.g.dart
@@ -11,10 +11,14 @@ Ingredient _$IngredientFromJson(Map<String, dynamic> json) => Ingredient(
       id: json['id'] as String?,
       text: json['text'] as String?,
       percent: JsonObject.parseDouble(json['percent']),
+      percentEstimate: JsonObject.parseDouble(json['percent_estimate']),
       vegan: ingredientSpecialPropertyStatusFromJson(json['vegan']),
       vegetarian: ingredientSpecialPropertyStatusFromJson(json['vegetarian']),
       fromPalmOil:
           ingredientSpecialPropertyStatusFromJson(json['from_palm_oil']),
+      ingredients: (json['ingredients'] as List<dynamic>?)
+          ?.map((e) => Ingredient.fromJson(e as Map<String, dynamic>))
+          .toList(),
       bold: json['bold'] as bool? ?? false,
     );
 
@@ -31,11 +35,14 @@ Map<String, dynamic> _$IngredientToJson(Ingredient instance) {
   writeNotNull('id', instance.id);
   val['text'] = instance.text;
   writeNotNull('percent', instance.percent);
+  writeNotNull('percent_estimate', instance.percentEstimate);
   writeNotNull('vegan', ingredientSpecialPropertyStatusToJson(instance.vegan));
   writeNotNull(
       'vegetarian', ingredientSpecialPropertyStatusToJson(instance.vegetarian));
   writeNotNull('from_palm_oil',
       ingredientSpecialPropertyStatusToJson(instance.fromPalmOil));
+  writeNotNull(
+      'ingredients', JsonHelper.ingredientsToJson(instance.ingredients));
   val['bold'] = instance.bold;
   return val;
 }

--- a/lib/model/KnowledgePanels.dart
+++ b/lib/model/KnowledgePanels.dart
@@ -18,4 +18,24 @@ class KnowledgePanels {
   factory KnowledgePanels.empty() {
     return KnowledgePanels(panelIdToPanelMap: {});
   }
+
+  @override
+  String toString() => 'KnowledgePanels(map: $panelIdToPanelMap)';
+
+  static KnowledgePanels? fromJsonHelper(final Map? json) => json == null
+      ? null
+      : KnowledgePanels.fromJson(json as Map<String, dynamic>);
+
+  static Map<String, dynamic>? toJsonHelper(
+      final KnowledgePanels? knowledgePanels) {
+    final Map<String, dynamic> result = {};
+    if (knowledgePanels == null) {
+      return null;
+    }
+    for (final MapEntry<String, KnowledgePanel> entry
+        in knowledgePanels.panelIdToPanelMap.entries) {
+      result[entry.key] = entry.value.toJson();
+    }
+    return result;
+  }
 }

--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -5,6 +5,7 @@ import 'package:openfoodfacts/model/ProductImage.dart';
 import 'package:openfoodfacts/utils/JsonHelper.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
+import 'package:openfoodfacts/model/KnowledgePanels.dart';
 
 import '../interface/JsonObject.dart';
 import 'Additives.dart';
@@ -333,6 +334,19 @@ class Product extends JsonObject {
       includeIfNull: false,
       toJson: EcoscoreData.toJsonHelper)
   EcoscoreData? ecoscoreData;
+
+  @JsonKey(
+      name: 'knowledge_panels',
+      includeIfNull: false,
+      fromJson: KnowledgePanels.fromJsonHelper,
+      toJson: KnowledgePanels.toJsonHelper)
+  KnowledgePanels? knowledgePanels;
+
+  @JsonKey(
+    name: 'environment_infocard',
+    includeIfNull: false,
+  )
+  String? environmentInfoCard;
 
   Product(
       {this.barcode,

--- a/lib/model/Product.g.dart
+++ b/lib/model/Product.g.dart
@@ -101,14 +101,18 @@ Product _$ProductFromJson(Map<String, dynamic> json) => Product(
           ? null
           : EcoscoreData.fromJson(
               json['ecoscore_data'] as Map<String, dynamic>),
-    )..imagesFreshnessInLanguages =
+    )
+      ..imagesFreshnessInLanguages =
           (json['imagesFreshnessInLanguages'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(
             $enumDecode(_$OpenFoodFactsLanguageEnumMap, k),
             (e as Map<String, dynamic>).map(
               (k, e) => MapEntry($enumDecode(_$ImageFieldEnumMap, k), e as int),
             )),
-      );
+      )
+      ..knowledgePanels =
+          KnowledgePanels.fromJsonHelper(json['knowledge_panels'] as Map?)
+      ..environmentInfoCard = json['environment_infocard'] as String?;
 
 Map<String, dynamic> _$ProductToJson(Product instance) {
   final val = <String, dynamic>{
@@ -195,6 +199,9 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('ecoscore_score', instance.ecoscoreScore);
   writeNotNull(
       'ecoscore_data', EcoscoreData.toJsonHelper(instance.ecoscoreData));
+  writeNotNull('knowledge_panels',
+      KnowledgePanels.toJsonHelper(instance.knowledgePanels));
+  writeNotNull('environment_infocard', instance.environmentInfoCard);
   return val;
 }
 

--- a/lib/utils/ProductFields.dart
+++ b/lib/utils/ProductFields.dart
@@ -62,6 +62,8 @@ enum ProductField {
   ECOSCORE_GRADE,
   ECOSCORE_SCORE,
   ECOSCORE_DATA,
+  KNOWLEDGE_PANELS,
+  ENVIRONMENT_INFOCARD,
   ALL
 }
 
@@ -127,6 +129,8 @@ extension ProductFieldExtension on ProductField {
     ProductField.ECOSCORE_GRADE: 'ecoscore_grade',
     ProductField.ECOSCORE_SCORE: 'ecoscore_score',
     ProductField.ECOSCORE_DATA: 'ecoscore_data',
+    ProductField.KNOWLEDGE_PANELS: 'knowledge_panels',
+    ProductField.ENVIRONMENT_INFOCARD: 'environment_infocard',
   };
 
   /// Returns the key of the product field

--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -2,15 +2,24 @@ import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
+import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:openfoodfacts/utils/UriHelper.dart';
+
+enum ProductQueryVersion {
+  V0,
+  V2,
+}
 
 /// Query Configuration for single barcode
 class ProductQueryConfiguration extends AbstractQueryConfiguration {
   final String barcode;
+  final ProductQueryVersion version;
 
   /// See [AbstractQueryConfiguration.languages] for
   /// parameter's description.
   ProductQueryConfiguration(
     this.barcode, {
+    this.version = ProductQueryVersion.V0,
     final OpenFoodFactsLanguage? language,
     final List<OpenFoodFactsLanguage> languages = const [],
     @Deprecated('Use parameters language or languages instead')
@@ -26,4 +35,19 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
           country: country,
           fields: fields,
         );
+
+  Uri getUri({final QueryType? queryType}) => UriHelper.getUri(
+        path: _getPath(),
+        queryParameters: getParametersMap(),
+        queryType: queryType,
+      );
+
+  String _getPath() {
+    switch (version) {
+      case ProductQueryVersion.V0:
+        return '/api/v0/product/$barcode.json';
+      case ProductQueryVersion.V2:
+        return '/api/v2/product/$barcode/';
+    }
+  }
 }


### PR DESCRIPTION
Impacted files:
* `api_getProduct_test.dart`: refactored the ecoscore html test; added a knowledge panels test; added a group in order to test ingredients in API version V0 and V2
* `Ingredient.dart`: added optional fields `percentEstimate` and `ingredients`
* `Ingredient.g.dart`: generated
* `KnowledgePanels.dart`: added static methods in order to be considered as a `Product` field
* `openfoodfacts.dart`: new method `getProductString`, used from methods `getProductRaw`, `getProduct` and now deprecated methods  `getEcoscoreHtmlDescription`, `getKnowledgePanels`
* `Product.dart`: added optional fields `knowledgePanels` and `environmentInfoCard`
* `Product.g.dart`: generated
* `ProductFields.dart`: added fields about `knowledgePanels` and `environmentInfoCard`
* `ProductQueryConfiguration.dart`: added an API version parameter as enum `ProductQueryVersion` and a `getUri` helper method