### PR TITLE
feat: #348 - new methods getTaxonomyTranslationUri and getCrowdinUri

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -244,6 +244,37 @@ class OpenFoodAPIClient {
     );
   }
 
+  /// Returns the URI to the translation page for a taxonomy.
+  ///
+  /// If the target website supports different domains for country + language,
+  /// [replaceSubdomain] should be set to true.
+  static Uri getTaxonomyTranslationUri(
+    final TagType taxonomyTagType, {
+    required final OpenFoodFactsLanguage language,
+    final OpenFoodFactsCountry? country,
+    final QueryType? queryType,
+    required final bool replaceSubdomain,
+  }) {
+    // TODO(teolemon): does not work for emb_codes - what is the URI for them?
+    final Uri uri = UriHelper.getUri(
+      path: taxonomyTagType.key,
+      queryType: queryType,
+      queryParameters: {'translate': '1'},
+    );
+    if (!replaceSubdomain) {
+      return uri;
+    }
+    return UriHelper.replaceSubdomain(
+      uri,
+      language: language,
+      country: country,
+    );
+  }
+
+  /// Returns the URI to the crowdin page for a [language].
+  static Uri getCrowdinUri(final OpenFoodFactsLanguage language) =>
+      Uri.parse('https://crowdin.com/project/openfoodfacts/${language.code}');
+
   /// Search the OpenFoodFacts product database with the given parameters.
   /// Returns the list of products as SearchResult.
   /// Query the language specific host from OpenFoodFacts.

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -247,12 +247,11 @@ class OpenFoodAPIClient {
   /// Returns the URI to the translation page for a taxonomy.
   ///
   /// Not supported for EMB_CODES.
-  /// If the target website supports different domains for country + language,
+  /// If the target website supports different subdomains for language,
   /// [replaceSubdomain] should be set to true.
   static Uri getTaxonomyTranslationUri(
     final TagType taxonomyTagType, {
     required final OpenFoodFactsLanguage language,
-    final OpenFoodFactsCountry? country,
     final QueryType? queryType,
     final bool replaceSubdomain = true,
   }) {
@@ -267,10 +266,9 @@ class OpenFoodAPIClient {
     if (!replaceSubdomain) {
       return uri;
     }
-    return UriHelper.replaceSubdomain(
+    return UriHelper.replaceSubdomainWithCodes(
       uri,
-      language: language,
-      country: country,
+      languageCode: language.code,
     );
   }
 

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -246,6 +246,7 @@ class OpenFoodAPIClient {
 
   /// Returns the URI to the translation page for a taxonomy.
   ///
+  /// Not supported for EMB_CODES.
   /// If the target website supports different domains for country + language,
   /// [replaceSubdomain] should be set to true.
   static Uri getTaxonomyTranslationUri(
@@ -253,9 +254,11 @@ class OpenFoodAPIClient {
     required final OpenFoodFactsLanguage language,
     final OpenFoodFactsCountry? country,
     final QueryType? queryType,
-    required final bool replaceSubdomain,
+    final bool replaceSubdomain = true,
   }) {
-    // TODO(teolemon): does not work for emb_codes - what is the URI for them?
+    if (taxonomyTagType == TagType.EMB_CODES) {
+      throw Exception('No taxonomy translation for $taxonomyTagType');
+    }
     final Uri uri = UriHelper.getUri(
       path: taxonomyTagType.key,
       queryType: queryType,

--- a/lib/utils/UriHelper.dart
+++ b/lib/utils/UriHelper.dart
@@ -53,8 +53,9 @@ class UriHelper {
         queryParameters: queryParameters,
       );
 
-  /// Replaces the subdomain of an URI with specific country and language
+  /// Replaces the subdomain of an URI with specific country and language.
   ///
+  /// Default language and country will be used as fallback, if available.
   /// For instance
   /// * https://world.xxx... would be standard
   /// * https://world-fr.xxx... would be "standard country" in French
@@ -64,16 +65,33 @@ class UriHelper {
     final Uri uri, {
     OpenFoodFactsLanguage? language,
     OpenFoodFactsCountry? country,
+  }) =>
+      replaceSubdomainWithCodes(
+        uri,
+        languageCode: language?.code ??
+            (OpenFoodAPIConfiguration.globalLanguages != null &&
+                    OpenFoodAPIConfiguration.globalLanguages!.isNotEmpty
+                ? OpenFoodAPIConfiguration.globalLanguages![0].code
+                : null),
+        countryCode: country?.iso2Code ??
+            OpenFoodAPIConfiguration.globalCountry?.iso2Code,
+      );
+
+  /// Replaces the subdomain of an URI with specific country and language.
+  ///
+  /// No default language nor country: null means no parameter.
+  /// For instance
+  /// * https://world.xxx... would be standard
+  /// * https://world-fr.xxx... would be "no country" in French
+  /// * https://fr.xxx... would be France
+  /// * https://fr-es.xxx... would be France in Spanish
+  static Uri replaceSubdomainWithCodes(
+    final Uri uri, {
+    final String? languageCode,
+    String? countryCode,
   }) {
     final String initialSubdomain = uri.host.split('.')[0];
-    final String countryCode = country?.iso2Code ??
-        OpenFoodAPIConfiguration.globalCountry?.iso2Code ??
-        initialSubdomain;
-    final String? languageCode = language?.code ??
-        (OpenFoodAPIConfiguration.globalLanguages != null &&
-                OpenFoodAPIConfiguration.globalLanguages!.isNotEmpty
-            ? OpenFoodAPIConfiguration.globalLanguages![0].code
-            : null);
+    countryCode = countryCode ?? initialSubdomain;
     final String subdomain;
     if (languageCode != null) {
       subdomain = '$countryCode-$languageCode';

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1680,9 +1680,7 @@ void main() {
             '?translate=1',
           );
         } catch (e) {
-          if (tagType != TagType.EMB_CODES) {
-            rethrow;
-          }
+          expect(tagType, TagType.EMB_CODES);
         }
       }
     }

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -14,6 +14,7 @@ import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/InvalidBarcodes.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:openfoodfacts/utils/TagType.dart';
 import 'package:openfoodfacts/utils/UnitHelper.dart';
 import 'package:test/test.dart';
 
@@ -1648,6 +1649,26 @@ void main() {
         replaceSubdomain: true,
       ).host,
       'de-es.openfoodfacts.net',
+    );
+  });
+
+  test('get crowdin uri', () async {
+    expect(
+      OpenFoodAPIClient.getCrowdinUri(
+        OpenFoodFactsLanguage.SPANISH,
+      ).toString(),
+      'https://crowdin.com/project/openfoodfacts/es',
+    );
+  });
+
+  test('get taxonomy translation uri', () async {
+    expect(
+      OpenFoodAPIClient.getTaxonomyTranslationUri(
+        TagType.CATEGORIES,
+        language: OpenFoodFactsLanguage.FRENCH,
+        replaceSubdomain: true,
+      ).toString(),
+      'https://world-fr.openfoodfacts.net/categories?translate=1',
     );
   });
 

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1680,7 +1680,9 @@ void main() {
             '?translate=1',
           );
         } catch (e) {
-          expect(tagType, TagType.EMB_CODES);
+          if (tagType != TagType.EMB_CODES) {
+            rethrow;
+          }
         }
       }
     }

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1662,14 +1662,28 @@ void main() {
   });
 
   test('get taxonomy translation uri', () async {
-    expect(
-      OpenFoodAPIClient.getTaxonomyTranslationUri(
-        TagType.CATEGORIES,
-        language: OpenFoodFactsLanguage.FRENCH,
-        replaceSubdomain: true,
-      ).toString(),
-      'https://world-fr.openfoodfacts.net/categories?translate=1',
-    );
+    const List<OpenFoodFactsLanguage> languages = <OpenFoodFactsLanguage>[
+      OpenFoodFactsLanguage.FRENCH,
+      OpenFoodFactsLanguage.ENGLISH,
+    ];
+    for (final OpenFoodFactsLanguage language in languages) {
+      for (final TagType tagType in TagType.values) {
+        try {
+          final String url = OpenFoodAPIClient.getTaxonomyTranslationUri(
+            tagType,
+            language: language,
+          ).toString();
+          expect(
+            url,
+            'https://world-${language.code}.openfoodfacts.net/'
+            '${tagType.key}'
+            '?translate=1',
+          );
+        } catch (e) {
+          expect(tagType, TagType.EMB_CODES);
+        }
+      }
+    }
   });
 
   test('get minified product', () async {


### PR DESCRIPTION
@teolemon the URI does not work for EMB_CODES

Impacted files:
* `api_getProduct_test.dart`: tests for new methods `getTaxonomyTranslationUri` and `getCrowdinUri`
* `openfoodfacts.dart`: new methods `getTaxonomyTranslationUri` and `getCrowdinUri`