### PR TITLE
feat: #370 - added app_name and app_version to http queries (as parameters)

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -103,6 +103,7 @@ class OpenFoodAPIClient {
     var productUri = UriHelper.getUri(
       path: '/cgi/product_jqm2.pl',
       queryType: queryType,
+      addUserAgentParameters: false,
     );
 
     if (product.nutriments != null) {
@@ -145,6 +146,7 @@ class OpenFoodAPIClient {
     var imageUri = UriHelper.getUri(
       path: '/cgi/product_image_upload.pl',
       queryType: queryType,
+      addUserAgentParameters: false,
     );
 
     return await HttpHelper().doMultipartRequest(
@@ -266,6 +268,7 @@ class OpenFoodAPIClient {
       path: taxonomyTagType.key,
       queryType: queryType,
       queryParameters: {'translate': '1'},
+      addUserAgentParameters: false,
     );
     if (!replaceSubdomain) {
       return uri;
@@ -510,10 +513,10 @@ class OpenFoodAPIClient {
     String? serverDomain,
     QueryType? queryType,
   }) async {
-    final Map<String, String?> parameters = {};
+    final Map<String, String> parameters = {};
 
-    if (type != null) {
-      parameters['type'] = type.value;
+    if (type != null && type.value != null) {
+      parameters['type'] = type.value!;
     }
     if (country != null) {
       parameters['country'] = country;
@@ -649,11 +652,13 @@ class OpenFoodAPIClient {
       queryType: queryType,
     );
 
-    Map<String, String?> annotationData = {
-      'insight_id': insightId,
+    final Map<String, String> annotationData = {
       'annotation': annotation.value.toString(),
       'update': update ? '1' : '0'
     };
+    if (insightId != null) {
+      annotationData['insight_id'] = insightId;
+    }
 
     if (deviceId != null) {
       annotationData['device_id'] = deviceId;
@@ -674,15 +679,15 @@ class OpenFoodAPIClient {
     User? user,
     QueryType? queryType,
   }) async {
-    Map<String, String?> spellingCorrectionParam;
+    Map<String, String> spellingCorrectionParam;
 
     if (ingredientName != null) {
       spellingCorrectionParam = {
         'text': ingredientName,
       };
-    } else if (product != null) {
+    } else if (product != null && product.barcode != null) {
       spellingCorrectionParam = {
-        'barcode': product.barcode,
+        'barcode': product.barcode!,
       };
     } else {
       return null;
@@ -774,6 +779,7 @@ class OpenFoodAPIClient {
     var loginUri = UriHelper.getUri(
       path: '/cgi/auth.pl',
       queryType: queryType,
+      addUserAgentParameters: false,
     );
     Response response = await HttpHelper().doPostRequest(
       loginUri,
@@ -799,6 +805,7 @@ class OpenFoodAPIClient {
     var registerUri = UriHelper.getUri(
       path: '/cgi/user.pl',
       queryType: queryType,
+      addUserAgentParameters: false,
     );
 
     Map<String, String> data = <String, String>{
@@ -859,6 +866,7 @@ class OpenFoodAPIClient {
     var passwordResetUri = UriHelper.getUri(
       path: '/cgi/reset_password.pl',
       queryType: queryType,
+      addUserAgentParameters: false,
     );
 
     Map<String, String> data = <String, String>{

--- a/lib/utils/HttpHelper.dart
+++ b/lib/utils/HttpHelper.dart
@@ -29,6 +29,24 @@ class HttpHelper {
   static const String USER_AGENT = 'Dart API';
   static const String FROM = 'anonymous';
 
+  /// Adds user agent data to parameters, for statistics purpose
+  static Map<String, String>? addUserAgentParameters(
+    Map<String, String>? map,
+  ) {
+    if (OpenFoodAPIConfiguration.userAgent == null) {
+      return map;
+    }
+    if (OpenFoodAPIConfiguration.userAgent!.name != null) {
+      map ??= <String, String>{};
+      map['app_name'] = OpenFoodAPIConfiguration.userAgent!.name!;
+    }
+    if (OpenFoodAPIConfiguration.userAgent!.version != null) {
+      map ??= <String, String>{};
+      map['app_version'] = OpenFoodAPIConfiguration.userAgent!.version!;
+    }
+    return map;
+  }
+
   /// Send a http get request to the specified uri.
   /// The data of the request (if any) has to be provided as parameter within the uri.
   /// The result of the request will be returned as string.
@@ -57,7 +75,7 @@ class HttpHelper {
   /// The result of the request will be returned as string.
   Future<http.Response> doPostRequest(
     Uri uri,
-    Map<String, String?> body,
+    Map<String, String> body,
     User? user, {
     QueryType? queryType,
   }) async {
@@ -69,7 +87,7 @@ class HttpHelper {
               OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
                   ? false
                   : true),
-      body: body,
+      body: addUserAgentParameters(body),
     );
     return response;
   }
@@ -98,7 +116,7 @@ class HttpHelper {
     );
 
     request.headers.addAll({'Content-Type': 'multipart/form-data'});
-    request.fields.addAll(body);
+    request.fields.addAll(addUserAgentParameters(body)!);
 
     // add all file entries to the request
     if (files != null) {

--- a/lib/utils/UriHelper.dart
+++ b/lib/utils/UriHelper.dart
@@ -8,11 +8,16 @@ import 'QueryType.dart';
 class UriHelper {
   UriHelper._();
 
-  ///Returns a OFF uri with the in the [OpenFoodAPIConfiguration] specified settings
+  /// Returns a OFF uri with the [OpenFoodAPIConfiguration] specified settings
+  ///
+  /// Typical use-case of "[addUserAgentParameters] = false" is for other
+  /// request than GET, e.g. POST or MULTIPART, where we add the user agent
+  /// parameters in another part of the code.
   static Uri getUri({
     required final String path,
-    final Map<String, dynamic>? queryParameters,
+    final Map<String, String>? queryParameters,
     final QueryType? queryType,
+    final bool addUserAgentParameters = true,
   }) =>
       Uri(
         scheme: OpenFoodAPIConfiguration.uriScheme,
@@ -20,7 +25,9 @@ class UriHelper {
             ? OpenFoodAPIConfiguration.uriProdHost
             : OpenFoodAPIConfiguration.uriTestHost,
         path: path,
-        queryParameters: queryParameters,
+        queryParameters: addUserAgentParameters
+            ? HttpHelper.addUserAgentParameters(queryParameters)
+            : queryParameters,
       );
 
   ///Returns a OFF-Robotoff uri with the in the [OpenFoodAPIConfiguration] specified settings

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -1,3 +1,4 @@
+import 'package:openfoodfacts/model/UserAgent.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:openfoodfacts/utils/UriHelper.dart';
@@ -7,104 +8,151 @@ void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   test('Get Uri', () {
+    OpenFoodAPIConfiguration.userAgent = null;
     Uri uri = UriHelper.getUri(
       path: '/test/test.pl',
     );
-    expect('https://world.openfoodfacts.org/test/test.pl', uri.toString());
+    expect(
+      uri.toString(),
+      'https://world.openfoodfacts.org/test/test.pl',
+    );
 
     Uri uri1 = UriHelper.getUri(
       path: '/test/test.pl',
-      queryParameters: <String, dynamic>{'test': 'true', 'queryType': 'PROD'},
+      queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
     );
     expect(
-      'https://world.openfoodfacts.org/test/test.pl?test=true&queryType=PROD',
       uri1.toString(),
+      'https://world.openfoodfacts.org/test/test.pl?test=true&queryType=PROD',
+    );
+  });
+
+  test('Get Uri with user agent', () {
+    const String name = 'UserAgentName';
+    const String version = '12';
+    OpenFoodAPIConfiguration.userAgent =
+        UserAgent(name: name, version: version);
+    Uri uri;
+
+    uri = UriHelper.getUri(
+      path: '/test/test.pl',
+    );
+    expect(
+      uri.toString(),
+      'https://world.openfoodfacts.org/test/test.pl?app_name=$name&app_version=$version',
+    );
+
+    uri = UriHelper.getUri(
+      path: '/test/test.pl',
+      queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
+    );
+    expect(
+      uri.toString(),
+      'https://world.openfoodfacts.org/test/test.pl?test=true&queryType=PROD&app_name=$name&app_version=$version',
+    );
+
+    uri = UriHelper.getUri(
+      path: '/test/test.pl',
+      addUserAgentParameters: false,
+    );
+    expect(
+      uri.toString(),
+      'https://world.openfoodfacts.org/test/test.pl',
+    );
+
+    uri = UriHelper.getUri(
+      path: '/test/test.pl',
+      queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
+      addUserAgentParameters: false,
+    );
+    expect(
+      uri.toString(),
+      'https://world.openfoodfacts.org/test/test.pl?test=true&queryType=PROD',
     );
   });
 
   test('Get Test Uri', () {
+    OpenFoodAPIConfiguration.userAgent = null;
     Uri uri = UriHelper.getUri(
       path: '/test/test.pl',
       queryType: QueryType.TEST,
     );
-    expect('https://world.openfoodfacts.net/test/test.pl', uri.toString());
+    expect(
+      uri.toString(),
+      'https://world.openfoodfacts.net/test/test.pl',
+    );
 
     Uri uri1 = UriHelper.getUri(
       path: '/test/test.pl',
       queryType: QueryType.TEST,
-      queryParameters: <String, dynamic>{'test': 'true', 'queryType': 'PROD'},
+      queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
     );
     expect(
-      'https://world.openfoodfacts.net/test/test.pl?test=true&queryType=PROD',
       uri1.toString(),
+      'https://world.openfoodfacts.net/test/test.pl?test=true&queryType=PROD',
     );
   });
 
   test('Get Robotoff Uri', () {
+    OpenFoodAPIConfiguration.userAgent = null;
     Uri uri = UriHelper.getRobotoffUri(
       path: '/test/test.pl',
     );
-    expect('https://robotoff.openfoodfacts.org/test/test.pl', uri.toString());
+    expect(
+      uri.toString(),
+      'https://robotoff.openfoodfacts.org/test/test.pl',
+    );
 
     Uri uri1 = UriHelper.getRobotoffUri(
       path: '/test/test.pl',
       queryParameters: <String, dynamic>{'test': 'true', 'queryType': 'PROD'},
     );
     expect(
-      'https://robotoff.openfoodfacts.org/test/test.pl?test=true&queryType=PROD',
       uri1.toString(),
+      'https://robotoff.openfoodfacts.org/test/test.pl?test=true&queryType=PROD',
     );
   });
 
   test('Get Robotoff Test Uri', () {
+    OpenFoodAPIConfiguration.userAgent = null;
     Uri uri = UriHelper.getRobotoffUri(
       path: '/test/test.pl',
       queryType: QueryType.TEST,
     );
-    expect('https://robotoff.openfoodfacts.net/test/test.pl', uri.toString());
+    expect(
+      uri.toString(),
+      'https://robotoff.openfoodfacts.net/test/test.pl',
+    );
 
     Uri uri1 = UriHelper.getRobotoffUri(
       path: '/test/test.pl',
       queryType: QueryType.TEST,
-      queryParameters: <String, dynamic>{'test': 'true', 'queryType': 'PROD'},
+      queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
     );
     expect(
+      uri1.toString(),
       'https://robotoff.openfoodfacts.net/test/test.pl?test=true&queryType=PROD',
-      uri1.toString(),
     );
   });
 
   test('Get Uri with different uriScheme', () {
+    OpenFoodAPIConfiguration.userAgent = null;
     OpenFoodAPIConfiguration.uriScheme = 'http';
     Uri uri = UriHelper.getUri(
       path: '/test/test.pl',
     );
-    expect('http://world.openfoodfacts.org/test/test.pl', uri.toString());
+    expect(
+      uri.toString(),
+      'http://world.openfoodfacts.org/test/test.pl',
+    );
 
     Uri uri1 = UriHelper.getUri(
       path: '/test/test.pl',
-      queryParameters: <String, dynamic>{'test': 'true', 'queryType': 'PROD'},
+      queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
     );
     expect(
-      'http://world.openfoodfacts.org/test/test.pl?test=true&queryType=PROD',
       uri1.toString(),
-    );
-  });
-
-  test('Get Uri with different uriScheme', () {
-    OpenFoodAPIConfiguration.uriScheme = 'http';
-    Uri uri = UriHelper.getUri(
-      path: '/test/test.pl',
-    );
-    expect('http://world.openfoodfacts.org/test/test.pl', uri.toString());
-
-    Uri uri1 = UriHelper.getUri(
-      path: '/test/test.pl',
-      queryParameters: <String, dynamic>{'test': 'true', 'queryType': 'PROD'},
-    );
-    expect(
       'http://world.openfoodfacts.org/test/test.pl?test=true&queryType=PROD',
-      uri1.toString(),
     );
   });
 }


### PR DESCRIPTION
Impacted files:
* `configuration_test.dart`: added test for user agent; refactored
* `HttpHelper.dart`: new method `addUserAgentParameters`, automatically used for post and multipart requests
* `openfoodfacts.dart`: added `addUserAgentParameters: false` for specific `getUri` calls like post and multipart
* `UriHelper.dart`: new parameter `addUserAgentParameters` for `getUri`