### PR TITLE
feat: #382 - added a "packaging" tag type

### DIFF
--- a/lib/utils/TagType.dart
+++ b/lib/utils/TagType.dart
@@ -8,6 +8,7 @@ enum TagType {
   TRACES,
   ADDITIVES,
   ALLERGENS,
+  PACKAGING,
   EMB_CODES
 }
 
@@ -21,6 +22,7 @@ extension TaxonomyTypeExtension on TagType {
     TagType.TRACES: 'traces',
     TagType.ADDITIVES: 'additives',
     TagType.ALLERGENS: 'allergens',
+    TagType.PACKAGING: 'packaging',
     TagType.LANGUAGES: 'languages',
     TagType.EMB_CODES: 'emb_codes',
   };

--- a/test/api_get_autocompleted_suggestions_test.dart
+++ b/test/api_get_autocompleted_suggestions_test.dart
@@ -8,7 +8,7 @@ void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
 
   void _listContains(List<dynamic> result, String match) {
-    assert(result.isNotEmpty);
+    expect(result, isNotEmpty);
     for (dynamic e in result) {
       expect(e.toString().toLowerCase(), contains(match));
     }
@@ -193,6 +193,16 @@ void main() {
       );
 
       _listContains(result, 'fru');
+    });
+    test('Suggestions for packaging', () async {
+      final List<dynamic> result =
+          await OpenFoodAPIClient.getAutocompletedSuggestions(
+        TagType.PACKAGING,
+        language: OpenFoodFactsLanguage.FRENCH,
+        input: 'briq',
+      );
+
+      _listContains(result, 'briq');
     });
     test('Suggestions for emb_code', () async {
       List<dynamic> result =


### PR DESCRIPTION
Impacted files:
* `api_get_autocompleted_suggestions_test.dart`: added a test about packaging
* `TagType.dart`: added a "packaging" tag type

### What
- with the new "packaging" tag type, `getAutocompletedSuggestions` can be called for packaging.