### PR TITLE
feat: #349 - added support for Events API

### DIFF
--- a/lib/events.dart
+++ b/lib/events.dart
@@ -1,0 +1,214 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart';
+import 'package:openfoodfacts/model/BadgeBase.dart';
+import 'package:openfoodfacts/model/EventCreate.dart';
+import 'package:openfoodfacts/model/EventsBase.dart';
+import 'package:openfoodfacts/model/LeaderboardEntry.dart';
+import 'package:openfoodfacts/model/User.dart';
+
+import 'utils/HttpHelper.dart';
+import 'utils/QueryType.dart';
+import 'utils/UriHelper.dart';
+
+/// Client calls of the Events API (Open Food Facts).
+///
+/// cf. https://events.openfoodfacts.net/docs
+class EventsAPIClient {
+  EventsAPIClient._();
+
+  /// Returns all the [EventsBase], with optional filters and paging.
+  static Future<List<EventsBase>> getEvents({
+    final String? userId,
+    final String? deviceId,
+    final int? skip,
+    final int? limit,
+    final QueryType? queryType,
+  }) async {
+    final Map<String, String> parameters = <String, String>{};
+    if (userId != null) {
+      parameters['user_id'] = userId;
+    }
+    if (deviceId != null) {
+      parameters['device_id'] = deviceId;
+    }
+    if (skip != null) {
+      parameters['skip'] = skip.toString();
+    }
+    if (limit != null) {
+      parameters['limit'] = limit.toString();
+    }
+    final Response response = await HttpHelper().doGetRequest(
+      UriHelper.getEventsUri(
+        path: '/events',
+        queryParameters: parameters,
+        queryType: queryType,
+      ),
+      queryType: queryType,
+    );
+    _checkResponse(response);
+    final List<EventsBase> result = <EventsBase>[];
+    final List<dynamic> json = jsonDecode(response.body) as List<dynamic>;
+    for (var element in json) {
+      result.add(EventsBase.fromJson(element));
+    }
+    return result;
+  }
+
+  /// Returns all the events counts, with optional filters.
+  static Future<Map<String, int>> getEventsCount({
+    final String? userId,
+    final String? deviceId,
+    final QueryType? queryType,
+  }) async {
+    final Map<String, String> parameters = <String, String>{};
+    if (userId != null) {
+      parameters['user_id'] = userId;
+    }
+    if (deviceId != null) {
+      parameters['device_id'] = deviceId;
+    }
+    final Response response = await HttpHelper().doGetRequest(
+      UriHelper.getEventsUri(
+        path: '/events/count',
+        queryParameters: parameters,
+        queryType: queryType,
+      ),
+      queryType: queryType,
+    );
+    _checkResponse(response);
+    final Map<String, int> result = <String, int>{};
+    final Map<String, dynamic> json =
+        jsonDecode(response.body) as Map<String, dynamic>;
+    for (final String key in json.keys) {
+      result[key] = json[key] as int;
+    }
+    return result;
+  }
+
+  /// Returns the score, with optional filters.
+  static Future<int> getScores({
+    final String? userId,
+    final String? deviceId,
+    final String? eventType,
+    final QueryType? queryType,
+  }) async {
+    final Map<String, String> parameters = <String, String>{};
+    if (userId != null) {
+      parameters['user_id'] = userId;
+    }
+    if (deviceId != null) {
+      parameters['device_id'] = deviceId;
+    }
+    if (eventType != null) {
+      parameters['event_type'] = eventType;
+    }
+    final Response response = await HttpHelper().doGetRequest(
+      UriHelper.getEventsUri(
+        path: '/scores',
+        queryParameters: parameters,
+        queryType: queryType,
+      ),
+      queryType: queryType,
+    );
+    _checkResponse(response);
+    final Map<String, dynamic> json =
+        jsonDecode(response.body) as Map<String, dynamic>;
+    return json['score'] as int;
+  }
+
+  /// Returns all the [BadgeBase], with optional filters.
+  static Future<List<BadgeBase>> getBadges({
+    final String? userId,
+    final String? deviceId,
+    final QueryType? queryType,
+  }) async {
+    final Map<String, String> parameters = <String, String>{};
+    if (userId != null) {
+      parameters['user_id'] = userId;
+    }
+    if (deviceId != null) {
+      parameters['device_id'] = deviceId;
+    }
+    final Response response = await HttpHelper().doGetRequest(
+      UriHelper.getEventsUri(
+        path: '/badges',
+        queryParameters: parameters,
+        queryType: queryType,
+      ),
+      queryType: queryType,
+    );
+    _checkResponse(response);
+    final List<BadgeBase> result = <BadgeBase>[];
+    final List<dynamic> json = jsonDecode(response.body) as List<dynamic>;
+    for (var element in json) {
+      result.add(BadgeBase.fromJson(element));
+    }
+    return result;
+  }
+
+  /// Returns all the [LeaderboardEntry], with optional filters.
+  static Future<List<LeaderboardEntry>> getLeaderboard({
+    final String? eventType,
+    final QueryType? queryType,
+  }) async {
+    final Map<String, String> parameters = <String, String>{};
+    if (eventType != null) {
+      parameters['event_type'] = eventType;
+    }
+    final Response response = await HttpHelper().doGetRequest(
+      UriHelper.getEventsUri(
+        path: '/leaderboard',
+        queryParameters: parameters,
+        queryType: queryType,
+      ),
+      queryType: queryType,
+    );
+    _checkResponse(response);
+    final List<LeaderboardEntry> result = <LeaderboardEntry>[];
+    final List<dynamic> json = jsonDecode(response.body) as List<dynamic>;
+    for (var element in json) {
+      result.add(LeaderboardEntry.fromJson(element));
+    }
+    return result;
+  }
+
+  /// Adds an event.
+  static Future<void> createEvent({
+    required final EventCreate eventCreate,
+    required final User user,
+    final QueryType? queryType,
+  }) async {
+    final Response response = await HttpHelper().doPostRequest(
+      UriHelper.getEventsUri(
+        path: '/events',
+        queryType: queryType,
+      ),
+      eventCreate.toData(),
+      user,
+      queryType: queryType,
+    );
+    _checkResponse(response);
+  }
+
+  /// Throws a detailed exception if relevant. Does nothing if [response] is OK.
+  static void _checkResponse(final Response response) {
+    if (response.statusCode != 200) {
+      // cf. HTTPValidationError
+      String? exception;
+      try {
+        final Map<String, dynamic> json =
+            jsonDecode(response.body) as Map<String, dynamic>;
+        exception = json['detail'];
+      } catch (e) {
+        //
+      }
+      if (exception != null) {
+        throw Exception(exception);
+      }
+      // TODO(monsieurtanuki): have a look at ValidationError in https://events.openfoodfacts.org/docs
+      throw Exception('Wrong status code: ${response.statusCode}');
+    }
+  }
+}

--- a/lib/model/BadgeBase.dart
+++ b/lib/model/BadgeBase.dart
@@ -1,0 +1,35 @@
+import 'package:json_annotation/json_annotation.dart';
+import '../interface/JsonObject.dart';
+
+part 'BadgeBase.g.dart';
+
+/// Events API: badge.
+@JsonSerializable()
+class BadgeBase extends JsonObject {
+  @JsonKey(name: 'user_id')
+  final String? userId;
+
+  @JsonKey(name: 'badge_name')
+  final String badgeName;
+
+  @JsonKey()
+  final int level;
+
+  BadgeBase({
+    required this.badgeName,
+    required this.level,
+    this.userId,
+  });
+
+  factory BadgeBase.fromJson(Map<String, dynamic> json) =>
+      _$BadgeBaseFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$BadgeBaseToJson(this);
+
+  @override
+  String toString() => 'BadgeBase(badgeName: $badgeName'
+      ', level: $level'
+      '${userId == null ? '' : ', userId: $userId'}'
+      ')';
+}

--- a/lib/model/BadgeBase.g.dart
+++ b/lib/model/BadgeBase.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'BadgeBase.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+BadgeBase _$BadgeBaseFromJson(Map<String, dynamic> json) => BadgeBase(
+      badgeName: json['badge_name'] as String,
+      level: json['level'] as int,
+      userId: json['user_id'] as String?,
+    );
+
+Map<String, dynamic> _$BadgeBaseToJson(BadgeBase instance) => <String, dynamic>{
+      'user_id': instance.userId,
+      'badge_name': instance.badgeName,
+      'level': instance.level,
+    };

--- a/lib/model/EventCreate.dart
+++ b/lib/model/EventCreate.dart
@@ -1,0 +1,51 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:openfoodfacts/utils/JsonHelper.dart';
+import '../interface/JsonObject.dart';
+
+part 'EventCreate.g.dart';
+
+/// Events API: event create.
+@JsonSerializable()
+class EventCreate extends JsonObject {
+  @JsonKey(name: 'event_type')
+  final String eventType;
+
+  @JsonKey(fromJson: JsonHelper.nullableStringTimestampToDate)
+  final DateTime? timestamp;
+
+  @JsonKey(name: 'user_id')
+  final String? userId;
+
+  @JsonKey()
+  final String? barcode;
+
+  @JsonKey()
+  final int? points;
+
+  @JsonKey(name: 'device_id')
+  final String? deviceId;
+
+  EventCreate({
+    required this.eventType,
+    this.timestamp,
+    this.userId,
+    this.barcode,
+    this.points,
+    this.deviceId,
+  });
+
+  factory EventCreate.fromJson(Map<String, dynamic> json) =>
+      _$EventCreateFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$EventCreateToJson(this);
+
+  @override
+  String toString() => 'EventCreate(eventType: $eventType'
+      '${timestamp == null ? '' : ', timestamp: $timestamp'}'
+      '${userId == null ? '' : ', userId: $userId'}'
+      '${barcode == null ? '' : ', barcode: $barcode'}'
+      '${points == null ? '' : ', points: $points'}'
+      '${deviceId == null ? '' : ', deviceId: $deviceId'}'
+      ')';
+}

--- a/lib/model/EventCreate.g.dart
+++ b/lib/model/EventCreate.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'EventCreate.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+EventCreate _$EventCreateFromJson(Map<String, dynamic> json) => EventCreate(
+      eventType: json['event_type'] as String,
+      timestamp: JsonHelper.nullableStringTimestampToDate(json['timestamp']),
+      userId: json['user_id'] as String?,
+      barcode: json['barcode'] as String?,
+      points: json['points'] as int?,
+      deviceId: json['device_id'] as String?,
+    );
+
+Map<String, dynamic> _$EventCreateToJson(EventCreate instance) =>
+    <String, dynamic>{
+      'event_type': instance.eventType,
+      'timestamp': instance.timestamp?.toIso8601String(),
+      'user_id': instance.userId,
+      'barcode': instance.barcode,
+      'points': instance.points,
+      'device_id': instance.deviceId,
+    };

--- a/lib/model/EventsBase.dart
+++ b/lib/model/EventsBase.dart
@@ -1,0 +1,46 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:openfoodfacts/utils/JsonHelper.dart';
+import '../interface/JsonObject.dart';
+
+part 'EventsBase.g.dart';
+
+/// Events API: event.
+@JsonSerializable()
+class EventsBase extends JsonObject {
+  @JsonKey(name: 'event_type')
+  final String eventType;
+
+  @JsonKey(fromJson: JsonHelper.nullableStringTimestampToDate)
+  final DateTime? timestamp;
+
+  @JsonKey(name: 'user_id')
+  final String? userId;
+
+  @JsonKey()
+  final String? barcode;
+
+  @JsonKey()
+  final int? points;
+
+  EventsBase({
+    required this.eventType,
+    this.timestamp,
+    this.userId,
+    this.barcode,
+    this.points,
+  });
+
+  factory EventsBase.fromJson(Map<String, dynamic> json) =>
+      _$EventsBaseFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$EventsBaseToJson(this);
+
+  @override
+  String toString() => 'EventsBase(eventType: $eventType'
+      '${timestamp == null ? '' : ', timestamp: $timestamp'}'
+      '${userId == null ? '' : ', userId: $userId'}'
+      '${barcode == null ? '' : ', barcode: $barcode'}'
+      '${points == null ? '' : ', points: $points'}'
+      ')';
+}

--- a/lib/model/EventsBase.g.dart
+++ b/lib/model/EventsBase.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'EventsBase.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+EventsBase _$EventsBaseFromJson(Map<String, dynamic> json) => EventsBase(
+      eventType: json['event_type'] as String,
+      timestamp: JsonHelper.nullableStringTimestampToDate(json['timestamp']),
+      userId: json['user_id'] as String?,
+      barcode: json['barcode'] as String?,
+      points: json['points'] as int?,
+    );
+
+Map<String, dynamic> _$EventsBaseToJson(EventsBase instance) =>
+    <String, dynamic>{
+      'event_type': instance.eventType,
+      'timestamp': instance.timestamp?.toIso8601String(),
+      'user_id': instance.userId,
+      'barcode': instance.barcode,
+      'points': instance.points,
+    };

--- a/lib/model/LeaderboardEntry.dart
+++ b/lib/model/LeaderboardEntry.dart
@@ -1,0 +1,30 @@
+import 'package:json_annotation/json_annotation.dart';
+import '../interface/JsonObject.dart';
+
+part 'LeaderboardEntry.g.dart';
+
+/// Events API: leaderboard entry.
+@JsonSerializable()
+class LeaderboardEntry extends JsonObject {
+  @JsonKey(name: 'user_id')
+  final String? userId;
+
+  @JsonKey()
+  final int score;
+
+  LeaderboardEntry({
+    required this.score,
+    this.userId,
+  });
+
+  factory LeaderboardEntry.fromJson(Map<String, dynamic> json) =>
+      _$LeaderboardEntryFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$LeaderboardEntryToJson(this);
+
+  @override
+  String toString() => 'LeaderboardEntry(score: $score'
+      '${userId == null ? ', no user id' : ', userId: $userId'}'
+      ')';
+}

--- a/lib/model/LeaderboardEntry.g.dart
+++ b/lib/model/LeaderboardEntry.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'LeaderboardEntry.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+LeaderboardEntry _$LeaderboardEntryFromJson(Map<String, dynamic> json) =>
+    LeaderboardEntry(
+      score: json['score'] as int,
+      userId: json['user_id'] as String?,
+    );
+
+Map<String, dynamic> _$LeaderboardEntryToJson(LeaderboardEntry instance) =>
+    <String, dynamic>{
+      'user_id': instance.userId,
+      'score': instance.score,
+    };

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -46,12 +46,17 @@ import 'utils/ProductHelper.dart';
 import 'utils/ProductQueryConfigurations.dart';
 import 'utils/ProductSearchQueryConfiguration.dart';
 
+export 'events.dart';
 export 'folksonomy.dart';
 export 'interface/Parameter.dart';
 export 'model/Additives.dart';
+export 'model/BadgeBase.dart';
+export 'model/EventCreate.dart';
+export 'model/EventsBase.dart';
 export 'model/Ingredient.dart';
 export 'model/Insight.dart';
 export 'model/KeyStats.dart';
+export 'model/LeaderboardEntry.dart';
 export 'model/Product.dart';
 export 'model/ProductFreshness.dart';
 // export 'model/ProductList.dart'; // not needed

--- a/lib/utils/JsonHelper.dart
+++ b/lib/utils/JsonHelper.dart
@@ -197,4 +197,8 @@ class JsonHelper {
   /// Returns a [DateTime] from a JSON-encoded String (e.g. '2021-10-29T11:00:56.177379')
   static DateTime stringTimestampToDate(dynamic json) =>
       DateTime.parse(json as String);
+
+  /// Returns a [DateTime] from a JSON-encoded String (e.g. '2021-10-29T11:00:56.177379')
+  static DateTime? nullableStringTimestampToDate(dynamic json) =>
+      json == null ? null : stringTimestampToDate(json);
 }

--- a/lib/utils/OpenFoodAPIConfiguration.dart
+++ b/lib/utils/OpenFoodAPIConfiguration.dart
@@ -42,6 +42,12 @@ class OpenFoodAPIConfiguration {
   static String uriTestHostFolksonomy =
       'api.folksonomy.openfoodfacts.net'; // TODO does not work
 
+  ///Uri host of the Events requests to the backend, modify this to direct the request to a self-hosted instance.
+  static String uriProdHostEvents = 'events.openfoodfacts.org';
+
+  ///Uri host of the test requests to Events
+  static String uriTestHostEvents = 'events.openfoodfacts.net';
+
   ///Changes whether the requests sent by this package to the test or main server.
   static QueryType globalQueryType = QueryType.PROD;
 

--- a/lib/utils/UriHelper.dart
+++ b/lib/utils/UriHelper.dart
@@ -60,6 +60,21 @@ class UriHelper {
         queryParameters: queryParameters,
       );
 
+  ///Returns a OFF-Events uri with the in the [OpenFoodAPIConfiguration] specified settings
+  static Uri getEventsUri({
+    required final String path,
+    final Map<String, dynamic>? queryParameters,
+    final QueryType? queryType,
+  }) =>
+      Uri(
+        scheme: OpenFoodAPIConfiguration.uriScheme,
+        host: OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
+            ? OpenFoodAPIConfiguration.uriProdHostEvents
+            : OpenFoodAPIConfiguration.uriTestHostEvents,
+        path: path,
+        queryParameters: queryParameters,
+      );
+
   /// Replaces the subdomain of an URI with specific country and language.
   ///
   /// Default language and country will be used as fallback, if available.

--- a/test/api_events_test.dart
+++ b/test/api_events_test.dart
@@ -1,0 +1,194 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
+import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
+
+/// Tests around Events API.
+void main() {
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+
+  const String _knownUserId = 'ocervell';
+  const String _unknownUserId = "o' * cervell";
+
+  const Set<String> _typicalEventTypes = <String>{
+    'invite_shared',
+    'product_scanned',
+    'product_added',
+    'product_photo_added',
+    'product_duplicate_found',
+    'product_edited',
+    'product_completed',
+    'question_answered',
+    'pr_merged',
+    'translation_added',
+  };
+
+  void _checkEventsBase(final Iterable<EventsBase> list) {
+    expect(list, isNotEmpty);
+    bool withTimestamps = false;
+    bool withBarcodes = false;
+    bool withUserIds = false;
+    bool withPoints = false;
+    for (final EventsBase eventsBase in list) {
+      if (eventsBase.timestamp != null) {
+        withTimestamps = true;
+      }
+      if (eventsBase.barcode != null) {
+        withBarcodes = true;
+      }
+      if (eventsBase.userId != null) {
+        withUserIds = true;
+      }
+      if (eventsBase.points != null) {
+        withPoints = true;
+      }
+    }
+    expect(withTimestamps, isTrue);
+    expect(withBarcodes, isTrue);
+    expect(withUserIds, isTrue);
+    expect(withPoints, isTrue);
+  }
+
+  void _checkEventsCount(final Map<String, int> map, final bool isEmpty) {
+    expect(map, isNotEmpty);
+
+    expect(map.keys.length, _typicalEventTypes.length);
+    bool foundAllKeys = true;
+    for (final String key in map.keys) {
+      if (!_typicalEventTypes.contains(key)) {
+        foundAllKeys = false;
+      }
+    }
+    expect(foundAllKeys, isTrue);
+
+    bool allZeros = true;
+    for (final int value in map.values) {
+      if (value != 0) {
+        allZeros = false;
+      }
+    }
+    expect(allZeros, isEmpty);
+  }
+
+  void _checkBadgeBase(final Iterable<BadgeBase> list) {
+    expect(list, isNotEmpty);
+    bool withUserIds = false;
+    for (final BadgeBase badgeBase in list) {
+      if (badgeBase.userId != null) {
+        withUserIds = true;
+      }
+    }
+    expect(withUserIds, isTrue);
+  }
+
+  int? _getLeaderboardScore(
+    final String? userId,
+    final List<LeaderboardEntry> list,
+  ) {
+    for (final LeaderboardEntry entry in list) {
+      if (entry.userId == userId) {
+        return entry.score;
+      }
+    }
+    return null;
+  }
+
+  group('$OpenFoodAPIClient Events API', () {
+    test('getEvents - all', () async {
+      final List<EventsBase> result = await EventsAPIClient.getEvents();
+      _checkEventsBase(result);
+    });
+
+    test('getEvents - known user', () async {
+      final List<EventsBase> result =
+          await EventsAPIClient.getEvents(userId: _knownUserId);
+      _checkEventsBase(result);
+    });
+
+    test('getEvents - unknown user', () async {
+      final List<EventsBase> result =
+          await EventsAPIClient.getEvents(userId: _unknownUserId);
+      expect(result, isEmpty);
+    });
+
+    test('getEventsCount - all', () async {
+      final Map<String, int> result = await EventsAPIClient.getEventsCount();
+      _checkEventsCount(result, false);
+    });
+
+    test('getEventsCount - known user', () async {
+      final Map<String, int> result =
+          await EventsAPIClient.getEventsCount(userId: _knownUserId);
+      _checkEventsCount(result, false);
+    });
+
+    test('getEventsCount - unknown user', () async {
+      final Map<String, int> result =
+          await EventsAPIClient.getEventsCount(userId: _unknownUserId);
+      _checkEventsCount(result, true);
+    });
+
+    test('getBadges - all', () async {
+      final List<BadgeBase> result = await EventsAPIClient.getBadges();
+      _checkBadgeBase(result);
+    });
+
+    test('getBadges - known user', () async {
+      final List<BadgeBase> result =
+          await EventsAPIClient.getBadges(userId: _knownUserId);
+      _checkBadgeBase(result);
+    });
+
+    test('getBadges - unknown user', () async {
+      final List<BadgeBase> result =
+          await EventsAPIClient.getBadges(userId: _unknownUserId);
+      expect(result, isEmpty);
+    });
+
+    test('getScores', () async {
+      final int unknown =
+          await EventsAPIClient.getScores(userId: _unknownUserId);
+      expect(unknown, 0);
+
+      final int all = await EventsAPIClient.getScores();
+      final int known = await EventsAPIClient.getScores(userId: _knownUserId);
+      expect(known, lessThanOrEqualTo(all));
+      int sum = 0;
+      for (final String eventType in _typicalEventTypes) {
+        final int score = await EventsAPIClient.getScores(eventType: eventType);
+        sum += score;
+      }
+      expect(sum, all);
+    });
+
+    test('getLeaderboard', () async {
+      final List<LeaderboardEntry> result =
+          await EventsAPIClient.getLeaderboard();
+      final int knownTotal = _getLeaderboardScore(_knownUserId, result)!;
+      final int nullTotal = _getLeaderboardScore(null, result)!;
+      expect(_getLeaderboardScore(_unknownUserId, result), isNull);
+      int knownSum = 0;
+      int nullSum = 0;
+      for (final String eventType in _typicalEventTypes) {
+        final List<LeaderboardEntry> result =
+            await EventsAPIClient.getLeaderboard(eventType: eventType);
+        knownSum += _getLeaderboardScore(_knownUserId, result) ?? 0;
+        nullSum += _getLeaderboardScore(null, result) ?? 0;
+        expect(_getLeaderboardScore(_unknownUserId, result), isNull);
+      }
+      expect(knownSum, knownTotal);
+      expect(nullSum, nullTotal);
+    });
+
+    /* TODO(monsieurtanuki): make it work!
+    test('createEvent', () async {
+      await EventsAPIClient.createEvent(
+        user: TestConstants.TEST_USER,
+        eventCreate: EventCreate(
+          eventType: 'product_scanned',
+        ),
+      );
+    });
+    */
+  });
+}


### PR DESCRIPTION
Still missing: couldn't test how to create an event. Are we talking about the same users as in the "official OpenFoodFacts" API? (aka "off off"). Good news is that the TEST env works - which is not the case for Folksonomy.

New files:
* `api_events_test.dart`: Tests around Events API.
* `BadgeBase.dart`: Events API: badge.
* `BadgeBase.g.dart`: generated
* `EventCreate.dart`: Events API: event create.
* `EventCreate.g.dart`: generated
* `events.dart`: Client calls of the Events API (Open Food Facts).
* `EventsBase.dart`: Events API: event.
* `EventsBase.g.dart`: generated
* `LeaderboardEntry.dart`: Events API: leaderboard entry.
* `LeaderboardEntry.g.dart`: generated

Impacted files:
* `JsonHelper.dart`: added a nullable timestamp conversion method.
* `OpenFoodAPIConfiguration.dart`: added host entries for Events API.
* `openfoodfacts.dart`: exported new Events related files.
* `UriHelper.dart`: added Events related method `getEventsUri`.

- Fixes #349 