### PR TITLE
feat: #394 - additional "root" and "all" configurations for taxonomies

### DIFF
--- a/lib/model/TaxonomyAdditive.dart
+++ b/lib/model/TaxonomyAdditive.dart
@@ -331,22 +331,40 @@ class TaxonomyAdditive extends JsonObject {
   String toString() => toJson().toString();
 }
 
+/// Configuration to get additives
 class TaxonomyAdditiveQueryConfiguration extends TaxonomyQueryConfiguration<
     TaxonomyAdditive, TaxonomyAdditiveField> {
+  /// Configuration to get additives from their tags
   TaxonomyAdditiveQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages = const [],
+    List<OpenFoodFactsLanguage>? languages,
     @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyAdditiveField> fields = const [],
     List<Parameter> additionalParameters = const [],
   }) : super(
-          TagType.LABELS,
+          TagType.ADDITIVES,
           tags,
           languages: languages,
           cc: cc,
           country: country,
           includeChildren: false,
+          fields: fields,
+          additionalParameters: additionalParameters,
+        );
+
+  /// Configuration to get the root additives
+  TaxonomyAdditiveQueryConfiguration.roots({
+    final List<OpenFoodFactsLanguage>? languages,
+    final OpenFoodFactsCountry? country,
+    final bool includeChildren = false,
+    final List<TaxonomyAdditiveField> fields = const [],
+    final List<Parameter> additionalParameters = const [],
+  }) : super.roots(
+          TagType.ADDITIVES,
+          languages: languages,
+          country: country,
+          includeChildren: includeChildren,
           fields: fields,
           additionalParameters: additionalParameters,
         );

--- a/lib/model/TaxonomyAllergen.dart
+++ b/lib/model/TaxonomyAllergen.dart
@@ -75,11 +75,13 @@ class TaxonomyAllergen extends JsonObject {
   String toString() => toJson().toString();
 }
 
+/// Configuration for allergens API query.
 class TaxonomyAllergenQueryConfiguration extends TaxonomyQueryConfiguration<
     TaxonomyAllergen, TaxonomyAllergenField> {
+  /// Configuration to get the allergens that match the [tags].
   TaxonomyAllergenQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages = const [],
+    List<OpenFoodFactsLanguage>? languages,
     @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyAllergenField> fields = const [],
@@ -90,7 +92,20 @@ class TaxonomyAllergenQueryConfiguration extends TaxonomyQueryConfiguration<
           languages: languages,
           cc: cc,
           country: country,
-          includeChildren: false,
+          fields: fields,
+          additionalParameters: additionalParameters,
+        );
+
+  /// Configuration to get ALL the allergens.
+  TaxonomyAllergenQueryConfiguration.all({
+    final List<OpenFoodFactsLanguage>? languages,
+    final OpenFoodFactsCountry? country,
+    final List<TaxonomyAllergenField> fields = const [],
+    final List<Parameter> additionalParameters = const [],
+  }) : super.roots(
+          TagType.ALLERGENS,
+          languages: languages,
+          country: country,
           fields: fields,
           additionalParameters: additionalParameters,
         );

--- a/lib/model/TaxonomyCategory.dart
+++ b/lib/model/TaxonomyCategory.dart
@@ -334,7 +334,7 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
     TaxonomyCategory, TaxonomyCategoryField> {
   TaxonomyCategoryQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages = const [],
+    List<OpenFoodFactsLanguage>? languages,
     @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     bool includeChildren = false,
@@ -352,7 +352,7 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
         );
 
   TaxonomyCategoryQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages = const [],
+    List<OpenFoodFactsLanguage>? languages,
     @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     bool includeChildren = false,

--- a/lib/model/TaxonomyCountry.dart
+++ b/lib/model/TaxonomyCountry.dart
@@ -99,22 +99,38 @@ class TaxonomyCountry extends JsonObject {
   String toString() => toJson().toString();
 }
 
+/// Configuration for countries API query.
 class TaxonomyCountryQueryConfiguration
     extends TaxonomyQueryConfiguration<TaxonomyCountry, TaxonomyCountryField> {
+  /// Configuration to get the countries that match the [tags].
   TaxonomyCountryQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages = const [],
+    List<OpenFoodFactsLanguage>? languages,
     @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyCountryField> fields = const [],
     List<Parameter> additionalParameters = const [],
   }) : super(
-          TagType.LABELS,
+          TagType.COUNTRIES,
           tags,
           languages: languages,
           cc: cc,
           country: country,
           includeChildren: false,
+          fields: fields,
+          additionalParameters: additionalParameters,
+        );
+
+  /// Configuration to get ALL the countries.
+  TaxonomyCountryQueryConfiguration.all({
+    List<OpenFoodFactsLanguage>? languages,
+    OpenFoodFactsCountry? country,
+    List<TaxonomyCountryField> fields = const [],
+    List<Parameter> additionalParameters = const [],
+  }) : super.roots(
+          TagType.COUNTRIES,
+          languages: languages,
+          country: country,
           fields: fields,
           additionalParameters: additionalParameters,
         );

--- a/lib/model/TaxonomyIngredient.dart
+++ b/lib/model/TaxonomyIngredient.dart
@@ -471,7 +471,7 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
     TaxonomyIngredient, TaxonomyIngredientField> {
   TaxonomyIngredientQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages = const [],
+    List<OpenFoodFactsLanguage>? languages,
     @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyIngredientField> fields = const [],
@@ -489,7 +489,7 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
         );
 
   TaxonomyIngredientQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages = const [],
+    List<OpenFoodFactsLanguage>? languages,
     @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyIngredientField> fields = const [],

--- a/lib/model/TaxonomyLabel.dart
+++ b/lib/model/TaxonomyLabel.dart
@@ -279,7 +279,7 @@ class TaxonomyLabelQueryConfiguration
     extends TaxonomyQueryConfiguration<TaxonomyLabel, TaxonomyLabelField> {
   TaxonomyLabelQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages = const [],
+    List<OpenFoodFactsLanguage>? languages,
     @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyLabelField> fields = const [],
@@ -296,7 +296,7 @@ class TaxonomyLabelQueryConfiguration
         );
 
   TaxonomyLabelQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages = const [],
+    List<OpenFoodFactsLanguage>? languages,
     @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyLabelField> fields = const [],

--- a/lib/model/TaxonomyLanguage.dart
+++ b/lib/model/TaxonomyLanguage.dart
@@ -36,11 +36,9 @@ extension TaxonomyLanguageFieldExtension on TaxonomyLanguageField {
 @JsonSerializable()
 class TaxonomyLanguage extends JsonObject {
   TaxonomyLanguage(
-    this.children,
     this.languageCode2,
     this.languageCode3,
     this.name,
-    this.parents,
     this.wikidata,
   );
 
@@ -53,8 +51,6 @@ class TaxonomyLanguage extends JsonObject {
     return _$TaxonomyLanguageToJson(this);
   }
 
-  @JsonKey(name: 'children', includeIfNull: false)
-  List<String>? children;
   @JsonKey(
     name: 'language_code_2',
     fromJson: LanguageHelper.fromJsonStringMap,
@@ -76,8 +72,6 @@ class TaxonomyLanguage extends JsonObject {
     includeIfNull: false,
   )
   Map<OpenFoodFactsLanguage, String>? name;
-  @JsonKey(name: 'parents', includeIfNull: false)
-  List<String>? parents;
   @JsonKey(
     name: 'wikidata',
     fromJson: LanguageHelper.fromJsonStringMap,
@@ -90,22 +84,37 @@ class TaxonomyLanguage extends JsonObject {
   String toString() => toJson().toString();
 }
 
+/// Configuration for languages API query.
 class TaxonomyLanguageQueryConfiguration extends TaxonomyQueryConfiguration<
     TaxonomyLanguage, TaxonomyLanguageField> {
+  /// Configuration to get the languages that match the [tags].
   TaxonomyLanguageQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages = const [],
+    List<OpenFoodFactsLanguage>? languages,
     @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyLanguageField> fields = const [],
     List<Parameter> additionalParameters = const [],
   }) : super(
-          TagType.LABELS,
+          TagType.LANGUAGES,
           tags,
           languages: languages,
           cc: cc,
           country: country,
-          includeChildren: false,
+          fields: fields,
+          additionalParameters: additionalParameters,
+        );
+
+  /// Configuration to get ALL the languages.
+  TaxonomyLanguageQueryConfiguration.all({
+    List<OpenFoodFactsLanguage>? languages,
+    OpenFoodFactsCountry? country,
+    List<TaxonomyLanguageField> fields = const [],
+    List<Parameter> additionalParameters = const [],
+  }) : super.roots(
+          TagType.LANGUAGES,
+          languages: languages,
+          country: country,
           fields: fields,
           additionalParameters: additionalParameters,
         );

--- a/lib/model/TaxonomyLanguage.g.dart
+++ b/lib/model/TaxonomyLanguage.g.dart
@@ -8,11 +8,9 @@ part of 'TaxonomyLanguage.dart';
 
 TaxonomyLanguage _$TaxonomyLanguageFromJson(Map<String, dynamic> json) =>
     TaxonomyLanguage(
-      (json['children'] as List<dynamic>?)?.map((e) => e as String).toList(),
       LanguageHelper.fromJsonStringMap(json['language_code_2']),
       LanguageHelper.fromJsonStringMap(json['language_code_3']),
       LanguageHelper.fromJsonStringMap(json['name']),
-      (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
       LanguageHelper.fromJsonStringMap(json['wikidata']),
     );
 
@@ -25,13 +23,11 @@ Map<String, dynamic> _$TaxonomyLanguageToJson(TaxonomyLanguage instance) {
     }
   }
 
-  writeNotNull('children', instance.children);
   writeNotNull('language_code_2',
       LanguageHelper.toJsonStringMap(instance.languageCode2));
   writeNotNull('language_code_3',
       LanguageHelper.toJsonStringMap(instance.languageCode3));
   writeNotNull('name', LanguageHelper.toJsonStringMap(instance.name));
-  writeNotNull('parents', instance.parents);
   writeNotNull('wikidata', LanguageHelper.toJsonStringMap(instance.wikidata));
   return val;
 }

--- a/test/api_getTaxonomyAdditivesServer_test.dart
+++ b/test/api_getTaxonomyAdditivesServer_test.dart
@@ -1,0 +1,73 @@
+import 'package:openfoodfacts/model/TaxonomyAdditive.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
+import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
+
+import 'test_constants.dart';
+
+/// Integration test about additives.
+void main() {
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
+  OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
+  OpenFoodAPIConfiguration.globalLanguages = [
+    OpenFoodFactsLanguage.ENGLISH,
+    OpenFoodFactsLanguage.FRENCH,
+  ];
+
+  const String _knownTag = 'en:e436';
+  const String _unknownTag = 'en:some_nonexistent_additive';
+
+  group('OpenFoodAPIClient getTaxonomyAdditives', () {
+    test('get root additives', () async {
+      final Map<String, TaxonomyAdditive>? additives =
+          await OpenFoodAPIClient.getTaxonomyAdditives(
+        TaxonomyAdditiveQueryConfiguration.roots(),
+      );
+      expect(additives, isNotNull);
+      expect(additives!.length, greaterThan(500)); // was 540 on 2022-02-25
+    });
+
+    test('get an additive', () async {
+      final Map<String, TaxonomyAdditive>? additives =
+          await OpenFoodAPIClient.getTaxonomyAdditives(
+        TaxonomyAdditiveQueryConfiguration(
+          tags: <String>[_knownTag],
+        ),
+      );
+      expect(additives, isNotNull);
+      expect(additives!.length, equals(1));
+      final TaxonomyAdditive additive = additives[_knownTag]!;
+      expect(additive.name![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+      expect(additive.name![OpenFoodFactsLanguage.FRENCH]!, isNotEmpty);
+      expect(additive.vegan![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+    });
+
+    test("get an additive that doesn't exist", () async {
+      final Map<String, TaxonomyAdditive>? categories =
+          await OpenFoodAPIClient.getTaxonomyAdditives(
+        TaxonomyAdditiveQueryConfiguration(
+          tags: <String>[_unknownTag],
+        ),
+      );
+      expect(categories, isNull);
+    });
+
+    test("get an additive that doesn't exist with one that does", () async {
+      final Map<String, TaxonomyAdditive>? additives =
+          await OpenFoodAPIClient.getTaxonomyAdditives(
+        TaxonomyAdditiveQueryConfiguration(
+          tags: <String>[_unknownTag, _knownTag],
+        ),
+      );
+      expect(additives, isNotNull);
+      expect(additives!.length, equals(1));
+      final TaxonomyAdditive additive = additives[_knownTag]!;
+      expect(additive.name![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+      expect(additive.name![OpenFoodFactsLanguage.FRENCH]!, isNotEmpty);
+      expect(additive.vegan![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+    });
+  });
+}

--- a/test/api_getTaxonomyAllergensServer_test.dart
+++ b/test/api_getTaxonomyAllergensServer_test.dart
@@ -1,0 +1,34 @@
+import 'package:openfoodfacts/model/TaxonomyAllergen.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
+import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
+
+import 'test_constants.dart';
+
+/// Integration test about allergens.
+void main() {
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
+  OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
+  OpenFoodAPIConfiguration.globalLanguages = [
+    OpenFoodFactsLanguage.ENGLISH,
+    OpenFoodFactsLanguage.FRENCH,
+  ];
+
+  group('OpenFoodAPIClient getTaxonomyAllergens', () {
+    test('get all allergens', () async {
+      final Map<String, TaxonomyAllergen>? allergens =
+          await OpenFoodAPIClient.getTaxonomyAllergens(
+        TaxonomyAllergenQueryConfiguration.all(),
+      );
+      expect(allergens, isNotNull);
+      expect(allergens!.length, greaterThan(10)); // was 15 on 2022-02-25
+      for (final TaxonomyAllergen allergen in allergens.values) {
+        expect(allergen.name, isNotEmpty);
+        expect(allergen.synonyms, isNotEmpty);
+      }
+    });
+  });
+}

--- a/test/api_getTaxonomyCountriesServer_test.dart
+++ b/test/api_getTaxonomyCountriesServer_test.dart
@@ -1,0 +1,71 @@
+import 'package:openfoodfacts/model/TaxonomyCountry.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
+import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
+
+import 'test_constants.dart';
+
+/// Integration test about countries.
+void main() {
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
+  OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
+  OpenFoodAPIConfiguration.globalLanguages = [
+    OpenFoodFactsLanguage.ENGLISH,
+    OpenFoodFactsLanguage.FRENCH,
+  ];
+
+  const String _knownTag = 'en:gambia';
+  const String _unknownTag = 'en:some_nonexistent_country';
+
+  group('OpenFoodAPIClient getTaxonomyCountries', () {
+    test('get all countries', () async {
+      final Map<String, TaxonomyCountry>? countries =
+          await OpenFoodAPIClient.getTaxonomyCountries(
+        TaxonomyCountryQueryConfiguration.all(),
+      );
+      expect(countries, isNotNull);
+      expect(countries!.length, greaterThan(100));
+    },
+        skip:
+            'to be fixed on the server side'); // TODO(stephanegigandet): to be fixed on the server side
+
+    test('get a country', () async {
+      final Map<String, TaxonomyCountry>? countries =
+          await OpenFoodAPIClient.getTaxonomyCountries(
+        TaxonomyCountryQueryConfiguration(tags: <String>[_knownTag]),
+      );
+      expect(countries, isNotNull);
+      expect(countries!.length, equals(1));
+      final TaxonomyCountry country = countries[_knownTag]!;
+      expect(country.name![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+      expect(country.name![OpenFoodFactsLanguage.FRENCH]!, isNotEmpty);
+      expect(country.languages![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+    });
+
+    test("get a country that doesn't exist", () async {
+      final Map<String, TaxonomyCountry>? categories =
+          await OpenFoodAPIClient.getTaxonomyCountries(
+        TaxonomyCountryQueryConfiguration(tags: <String>[_unknownTag]),
+      );
+      expect(categories, isNull);
+    });
+
+    test("get a country that doesn't exist with one that does", () async {
+      final Map<String, TaxonomyCountry>? countries =
+          await OpenFoodAPIClient.getTaxonomyCountries(
+        TaxonomyCountryQueryConfiguration(
+          tags: <String>[_unknownTag, _knownTag],
+        ),
+      );
+      expect(countries, isNotNull);
+      expect(countries!.length, equals(1));
+      final TaxonomyCountry country = countries[_knownTag]!;
+      expect(country.name![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+      expect(country.name![OpenFoodFactsLanguage.FRENCH]!, isNotEmpty);
+      expect(country.languages![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+    });
+  });
+}

--- a/test/api_getTaxonomyLanguagesServer_test.dart
+++ b/test/api_getTaxonomyLanguagesServer_test.dart
@@ -1,0 +1,70 @@
+import 'package:openfoodfacts/model/TaxonomyLanguage.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
+import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
+
+import 'test_constants.dart';
+
+/// Integration test about languages.
+void main() {
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
+  OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
+  OpenFoodAPIConfiguration.globalLanguages = [
+    OpenFoodFactsLanguage.ENGLISH,
+    OpenFoodFactsLanguage.FRENCH,
+  ];
+
+  const String _knownTag = 'en:afrikaans';
+  const String _unknownTag = 'en:some_nonexistent_language';
+
+  group('OpenFoodAPIClient getTaxonomyLanguages (server)', () {
+    test("get all languages", () async {
+      final Map<String, TaxonomyLanguage>? languages =
+          await OpenFoodAPIClient.getTaxonomyLanguages(
+        TaxonomyLanguageQueryConfiguration.all(),
+      );
+      expect(languages, isNotNull);
+      expect(languages!.length, greaterThan(150)); // was 186 on 2022-02-25
+      expect(languages[_knownTag], isNotNull);
+    });
+
+    test('get a language', () async {
+      final Map<String, TaxonomyLanguage>? languages =
+          await OpenFoodAPIClient.getTaxonomyLanguages(
+        TaxonomyLanguageQueryConfiguration(tags: <String>[_knownTag]),
+      );
+      expect(languages, isNotNull);
+      expect(languages!.length, equals(1));
+      final TaxonomyLanguage language = languages[_knownTag]!;
+      expect(language.name![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+      expect(language.name![OpenFoodFactsLanguage.FRENCH]!, isNotEmpty);
+      expect(language.wikidata![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+    });
+
+    test("get a language that doesn't exist", () async {
+      final Map<String, TaxonomyLanguage>? categories =
+          await OpenFoodAPIClient.getTaxonomyLanguages(
+        TaxonomyLanguageQueryConfiguration(tags: <String>[_unknownTag]),
+      );
+      expect(categories, isNull);
+    });
+
+    test("get a language that doesn't exist with one that does", () async {
+      final Map<String, TaxonomyLanguage>? languages =
+          await OpenFoodAPIClient.getTaxonomyLanguages(
+        TaxonomyLanguageQueryConfiguration(
+          tags: <String>[_unknownTag, _knownTag],
+        ),
+      );
+      expect(languages, isNotNull);
+      expect(languages!.length, equals(1));
+      final TaxonomyLanguage language = languages[_knownTag]!;
+      expect(language.name![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+      expect(language.name![OpenFoodFactsLanguage.FRENCH]!, isNotEmpty);
+      expect(language.wikidata![OpenFoodFactsLanguage.ENGLISH]!, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
New files:
* `api_getTaxonomyAdditivesServer_test.dart`: integration test about additives.
* `api_getTaxonomyAllergensServer_test.dart`: integration test about allergens.
* `api_getTaxonomyCountriesServer_test.dart`: integration test about countries.
* `api_getTaxonomyLanguagesServer_test.dart`: integration test about languages.

Impacted files:
* `TaxonomyAdditive.dart`: fixed the tag type; created a "root" query; refactored around default languages.
* `TaxonomyAllergen.dart`: created an "all" query; refactored around default languages.
* `TaxonomyCategory.dart`: refactored around default languages.
* `TaxonomyCountry.dart`: fixed the tag type; created an "all" query (that fails on the server side); refactored around default languages.
* `TaxonomyIngredient.dart`: refactored around default languages.
* `TaxonomyLabel.dart`: refactored around default languages.
* `TaxonomyLanguage.dart`: removed the empty non-sense about parents and children; fixed the tag type; created an "all" query; refactored around default languages.
* `TaxonomyLanguage.g.dart`: generated

### What
- description of the PR

### Screenshot
(Insert a screenshot to provide visual record of your changes, if visible)
### Fixes bug(s)
- #1, #2 and #3 (change by appropriate issues)
### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1
(please be as granular as possible)
