### PR TITLE
feat: #401 - added packaging taxonomy

### DIFF
--- a/lib/model/TaxonomyPackaging.dart
+++ b/lib/model/TaxonomyPackaging.dart
@@ -1,0 +1,147 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:openfoodfacts/interface/JsonObject.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
+import 'package:openfoodfacts/utils/TagType.dart';
+
+part 'TaxonomyPackaging.g.dart';
+
+/// Fields of an [TaxonomyPackaging]
+enum TaxonomyPackagingField {
+  ALL,
+  NAME,
+  SYNONYMS,
+  WIKIDATA,
+  CHILDREN,
+  PARENTS,
+  //PACKAGING_MATERIALS, only 4/122 found for roots
+  //NON_RECYCLABLE_AND_NOT_BIODEGRADABLE, only 4/122 found for roots
+  //WEIGHT, only 4/122 found for roots
+  //PACKAGING_SHAPE, only 2/122 found for roots
+}
+
+extension TaxonomyPackagingFieldExtension on TaxonomyPackagingField {
+  static const Map<TaxonomyPackagingField, String> _KEYS =
+      <TaxonomyPackagingField, String>{
+    TaxonomyPackagingField.ALL: 'all',
+    TaxonomyPackagingField.NAME: 'name',
+    TaxonomyPackagingField.SYNONYMS: 'synonyms',
+    TaxonomyPackagingField.WIKIDATA: 'wikidata',
+    TaxonomyPackagingField.CHILDREN: 'children',
+    TaxonomyPackagingField.PARENTS: 'parents',
+    //TaxonomyPackagingField.PACKAGING_MATERIALS: 'packaging_materials',
+    //TaxonomyPackagingField.NON_RECYCLABLE_AND_NOT_BIODEGRADABLE:'non_recyclable_and_non_biodegradable',
+    //TaxonomyPackagingField.WEIGHT: 'weight',
+    //TaxonomyPackagingField.PACKAGING_SHAPE:'packaging_shapes',
+  };
+
+  /// Returns the key of the Packaging field
+  String get key => _KEYS[this] ?? '';
+}
+
+/// A JSON-serializable version of a Packaging taxonomy result.
+///
+/// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
+/// of these.
+@JsonSerializable()
+class TaxonomyPackaging extends JsonObject {
+  TaxonomyPackaging();
+
+  factory TaxonomyPackaging.fromJson(Map<String, dynamic> json) =>
+      _$TaxonomyPackagingFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$TaxonomyPackagingToJson(this);
+
+  @JsonKey(
+    name: 'name',
+    fromJson: LanguageHelper.fromJsonStringMap,
+    toJson: LanguageHelper.toJsonStringMap,
+    includeIfNull: false,
+  )
+  Map<OpenFoodFactsLanguage, String>? name;
+  @JsonKey(
+    name: 'synonyms',
+    fromJson: LanguageHelper.fromJsonStringsListMap,
+    toJson: LanguageHelper.toJsonStringsListMap,
+    includeIfNull: false,
+  )
+  Map<OpenFoodFactsLanguage, List<String>>? synonyms;
+  @JsonKey(
+    name: 'wikidata',
+    fromJson: LanguageHelper.fromJsonStringMap,
+    toJson: LanguageHelper.toJsonStringMap,
+    includeIfNull: false,
+  )
+  Map<OpenFoodFactsLanguage, String>? wikidata;
+  @JsonKey(name: 'children', includeIfNull: false)
+  List<String>? children;
+  @JsonKey(name: 'parents', includeIfNull: false)
+  List<String>? parents;
+
+  @override
+  String toString() => toJson().toString();
+}
+
+/// Configuration for packaging API query.
+class TaxonomyPackagingQueryConfiguration extends TaxonomyQueryConfiguration<
+    TaxonomyPackaging, TaxonomyPackagingField> {
+  /// Configuration to get the packagings that match the [tags].
+  TaxonomyPackagingQueryConfiguration({
+    required List<String> tags,
+    List<OpenFoodFactsLanguage>? languages,
+    OpenFoodFactsCountry? country,
+    List<TaxonomyPackagingField> fields = const [],
+    List<Parameter> additionalParameters = const [],
+  }) : super(
+          TagType.PACKAGING,
+          tags,
+          languages: languages,
+          country: country,
+          fields: fields,
+          additionalParameters: additionalParameters,
+        );
+
+  /// Configuration to get the root packagings.
+  TaxonomyPackagingQueryConfiguration.roots({
+    final List<OpenFoodFactsLanguage>? languages,
+    final OpenFoodFactsCountry? country,
+    final List<TaxonomyPackagingField> fields = const [],
+    final List<Parameter> additionalParameters = const [],
+  }) : super.roots(
+          TagType.PACKAGING,
+          languages: languages,
+          country: country,
+          fields: fields,
+          additionalParameters: additionalParameters,
+        );
+
+  @override
+  Map<String, TaxonomyPackaging> convertResults(dynamic jsonData) {
+    if (jsonData is! Map<String, dynamic>) {
+      return const {};
+    }
+    return jsonData
+        .map<String, TaxonomyPackaging>((String key, dynamic taxonomy) {
+      if (taxonomy is! Map<String, dynamic>) {
+        assert(false, 'Received JSON Packaging is not a Map');
+        return MapEntry(key, TaxonomyPackaging.fromJson({}));
+      }
+      return MapEntry(key, TaxonomyPackaging.fromJson(taxonomy));
+    });
+  }
+
+  @override
+  Set<TaxonomyPackagingField> get ignoredFields =>
+      const {TaxonomyPackagingField.ALL};
+
+  @override
+  Iterable<String> convertFieldsToStrings(
+    Iterable<TaxonomyPackagingField> fields,
+  ) =>
+      fields
+          .where(
+              (TaxonomyPackagingField field) => !ignoredFields.contains(field))
+          .map<String>((TaxonomyPackagingField field) => field.key);
+}

--- a/lib/model/TaxonomyPackaging.g.dart
+++ b/lib/model/TaxonomyPackaging.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'TaxonomyPackaging.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TaxonomyPackaging _$TaxonomyPackagingFromJson(Map<String, dynamic> json) =>
+    TaxonomyPackaging()
+      ..name = LanguageHelper.fromJsonStringMap(json['name'])
+      ..synonyms = LanguageHelper.fromJsonStringsListMap(json['synonyms'])
+      ..wikidata = LanguageHelper.fromJsonStringMap(json['wikidata'])
+      ..children =
+          (json['children'] as List<dynamic>?)?.map((e) => e as String).toList()
+      ..parents =
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList();
+
+Map<String, dynamic> _$TaxonomyPackagingToJson(TaxonomyPackaging instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('name', LanguageHelper.toJsonStringMap(instance.name));
+  writeNotNull(
+      'synonyms', LanguageHelper.toJsonStringsListMap(instance.synonyms));
+  writeNotNull('wikidata', LanguageHelper.toJsonStringMap(instance.wikidata));
+  writeNotNull('children', instance.children);
+  writeNotNull('parents', instance.parents);
+  return val;
+}

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -18,6 +18,7 @@ import 'package:openfoodfacts/model/TaxonomyCountry.dart';
 import 'package:openfoodfacts/model/TaxonomyIngredient.dart';
 import 'package:openfoodfacts/model/TaxonomyLabel.dart';
 import 'package:openfoodfacts/model/TaxonomyLanguage.dart';
+import 'package:openfoodfacts/model/TaxonomyPackaging.dart';
 import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/ImageHelper.dart';
@@ -71,6 +72,7 @@ export 'model/SpellingCorrections.dart';
 export 'model/Status.dart';
 export 'model/TagI18N.dart';
 export 'model/TaxonomyCategory.dart';
+export 'model/TaxonomyPackaging.dart';
 export 'model/User.dart';
 export 'model/parameter/OutputFormat.dart';
 export 'model/parameter/Page.dart';
@@ -498,6 +500,17 @@ class OpenFoodAPIClient {
     return getTaxonomy<TaxonomyLanguage, TaxonomyLanguageField>(configuration,
         user: user, queryType: queryType);
   }
+
+  static Future<Map<String, TaxonomyPackaging>?> getTaxonomyPackagings(
+    final TaxonomyPackagingQueryConfiguration configuration, {
+    final User? user,
+    final QueryType? queryType,
+  }) =>
+      getTaxonomy<TaxonomyPackaging, TaxonomyPackagingField>(
+        configuration,
+        user: user,
+        queryType: queryType,
+      );
 
   static void _removeImages(
     final SearchResult searchResult,

--- a/test/api_getTaxonomyPackagingsServer_test.dart
+++ b/test/api_getTaxonomyPackagingsServer_test.dart
@@ -1,0 +1,132 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
+import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
+
+import 'test_constants.dart';
+
+/// Integration test about packagings.
+void main() {
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
+  OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
+  OpenFoodAPIConfiguration.globalLanguages = [
+    OpenFoodFactsLanguage.ENGLISH,
+    OpenFoodFactsLanguage.FRENCH,
+  ];
+
+  const String _knownRootTag = 'en:brick';
+  const String _unknownTag = 'en:some_nonexistent_packaging';
+
+  void _checkKnownPackaging(final TaxonomyPackaging packaging) {
+    expect(packaging.name, isNotNull);
+    expect(packaging.name, isNotEmpty);
+    expect(packaging.synonyms, isNotNull);
+    expect(packaging.synonyms, isNotEmpty);
+    for (final OpenFoodFactsLanguage language
+        in OpenFoodAPIConfiguration.globalLanguages!) {
+      expect(packaging.name![language], isNotEmpty);
+      expect(packaging.synonyms![language], isNotEmpty);
+    }
+  }
+
+  group('OpenFoodAPIClient getTaxonomyPackagings (server)', () {
+    test("get root packagings", () async {
+      final Map<String, TaxonomyPackaging>? packagings =
+          await OpenFoodAPIClient.getTaxonomyPackagings(
+        TaxonomyPackagingQueryConfiguration.roots(),
+      );
+      expect(packagings, isNotNull);
+      expect(packagings, isNotEmpty);
+      expect(packagings!.length, greaterThan(100)); // was 122 on 2022-03-03
+      expect(packagings[_knownRootTag], isNotNull);
+      _checkKnownPackaging(packagings[_knownRootTag]!);
+      for (final TaxonomyPackaging packaging in packagings.values) {
+        // we expect no parents for the roots packaging
+        expect(packaging.parents, isNull);
+      }
+    });
+
+    test('get a packaging', () async {
+      final Map<String, TaxonomyPackaging>? packagings =
+          await OpenFoodAPIClient.getTaxonomyPackagings(
+        TaxonomyPackagingQueryConfiguration(tags: <String>[_knownRootTag]),
+      );
+      expect(packagings, isNotNull);
+      expect(packagings!.length, equals(1));
+      expect(packagings[_knownRootTag], isNotNull);
+      _checkKnownPackaging(packagings[_knownRootTag]!);
+    });
+
+    test("get a packaging that doesn't exist", () async {
+      final Map<String, TaxonomyPackaging>? packagings =
+          await OpenFoodAPIClient.getTaxonomyPackagings(
+        TaxonomyPackagingQueryConfiguration(tags: <String>[_unknownTag]),
+      );
+      expect(packagings, isNull);
+    });
+
+    test("get a packaging that doesn't exist with one that does", () async {
+      final Map<String, TaxonomyPackaging>? packagings =
+          await OpenFoodAPIClient.getTaxonomyPackagings(
+        TaxonomyPackagingQueryConfiguration(
+          tags: <String>[_unknownTag, _knownRootTag],
+        ),
+      );
+      expect(packagings, isNotNull);
+      expect(packagings!.length, equals(1));
+      expect(packagings[_knownRootTag], isNotNull);
+      _checkKnownPackaging(packagings[_knownRootTag]!);
+    });
+
+    /// Recursively gets all the tree.
+    ///
+    /// At the end, [knowItems] will contain everything.
+    Future<int> _recursiveGet(
+      final Map<String, TaxonomyPackaging> soFar,
+      final List<String> children,
+    ) async {
+      final Map<String, TaxonomyPackaging>? sublevel =
+          await OpenFoodAPIClient.getTaxonomyPackagings(
+        TaxonomyPackagingQueryConfiguration(tags: children),
+      );
+      expect(sublevel, isNotNull);
+      expect(sublevel, isNotEmpty);
+      soFar.addAll(sublevel!);
+      final List<String> grandChildren = <String>[];
+      for (final TaxonomyPackaging packaging in sublevel.values) {
+        if (packaging.children != null && packaging.children!.isNotEmpty) {
+          for (final String grandChild in packaging.children!) {
+            if (!soFar.containsKey(grandChild)) {
+              grandChildren.addAll(packaging.children!);
+            }
+          }
+        }
+      }
+      if (grandChildren.isEmpty) {
+        return 1;
+      }
+      return 1 + await _recursiveGet(soFar, grandChildren);
+    }
+
+    test("get recursive packagings", () async {
+      final Map<String, TaxonomyPackaging>? roots =
+          await OpenFoodAPIClient.getTaxonomyPackagings(
+        TaxonomyPackagingQueryConfiguration.roots(),
+      );
+      expect(roots, isNotNull);
+      expect(roots, isNotEmpty);
+      final List<String> children = <String>[];
+      for (final TaxonomyPackaging packaging in roots!.values) {
+        if (packaging.children != null && packaging.children!.isNotEmpty) {
+          children.addAll(packaging.children!);
+        }
+      }
+
+      final int maxLevel = await _recursiveGet(roots, children);
+      expect(maxLevel, lessThanOrEqualTo(5)); // was 3 on 2022-03-03
+      expect(roots.length, greaterThan(150)); // was 187 on 2022-03-03
+    });
+  });
+}


### PR DESCRIPTION
New files:
* `api_getTaxonomyPackagingsServer_test.dart`: Integration test about packagings.
* `TaxonomyPackaging.dart`: A JSON-serializable version of a Packaging taxonomy result.
* `TaxonomyPackaging.g.dart`: generated

Impacted file:
* `openfoodfacts.dart`: new method `getTaxonomyPackagings`; exported new class `TaxonomyPackaging`

### What
- first step towards a potential "download the whole tree" method for selected taxonomies
- in the meanwhile, `TaxonomyPackaging` did not exist before and deserved to be created
