### PR TITLE
feat: Support for source fields in the Knowledge panel API

### DIFF
--- a/lib/model/KnowledgePanelElement.dart
+++ b/lib/model/KnowledgePanelElement.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/model/KnowledgePanel.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'KnowledgePanelElement.g.dart';
@@ -9,7 +10,6 @@ enum KnowledgePanelTextElementType {
   /// The description summarizes the knowledge panel.
   @JsonValue('summary')
   SUMMARY,
-
   @JsonValue('warning')
   WARNING,
 
@@ -33,6 +33,10 @@ enum KnowledgePanelColumnType {
   PERCENT,
 }
 
+Object? test(Map map, String str) {
+  return null;
+}
+
 /// Description element of the Knowledge panel.
 @JsonSerializable()
 class KnowledgePanelTextElement extends JsonObject {
@@ -46,7 +50,29 @@ class KnowledgePanelTextElement extends JsonObject {
       unknownEnumValue: KnowledgePanelTextElementType.DEFAULT)
   final KnowledgePanelTextElementType? type;
 
-  const KnowledgePanelTextElement({required this.html, this.type});
+  /// Human readable source language (eg: "English")
+  @JsonKey(name: 'source_language')
+  final String? sourceLanguage;
+
+  /// Source locale name (eg: "en")
+  @JsonKey(name: 'source_lc')
+  final String? sourceLocale;
+
+  /// Name of the source (eg: "Wikipedia")
+  @JsonKey(name: 'source_text')
+  final String? sourceText;
+
+  /// Link to the source (eg: "https://en.wikipedia.org/wiki/Sodium acetate")
+  @JsonKey(name: 'source_url')
+  final String? sourceUrl;
+
+  const KnowledgePanelTextElement(
+      {required this.html,
+      this.type,
+      this.sourceLanguage,
+      this.sourceLocale,
+      this.sourceText,
+      this.sourceUrl});
 
   factory KnowledgePanelTextElement.fromJson(Map<String, dynamic> json) =>
       _$KnowledgePanelTextElementFromJson(json);
@@ -279,19 +305,14 @@ enum KnowledgePanelElementType {
   /// The description summarizes the knowledge panel.
   @JsonValue('text')
   TEXT,
-
   @JsonValue('image')
   IMAGE,
-
   @JsonValue('panel')
   PANEL,
-
   @JsonValue('panel_group')
   PANEL_GROUP,
-
   @JsonValue('table')
   TABLE,
-
   @JsonValue('map')
   MAP,
   UNKNOWN,

--- a/lib/model/KnowledgePanelElement.dart
+++ b/lib/model/KnowledgePanelElement.dart
@@ -1,6 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/model/KnowledgePanel.dart';
-
 import '../interface/JsonObject.dart';
 
 part 'KnowledgePanelElement.g.dart';
@@ -10,6 +9,7 @@ enum KnowledgePanelTextElementType {
   /// The description summarizes the knowledge panel.
   @JsonValue('summary')
   SUMMARY,
+
   @JsonValue('warning')
   WARNING,
 
@@ -31,10 +31,6 @@ enum KnowledgePanelColumnType {
   /// The column has percentages.
   @JsonValue('percent')
   PERCENT,
-}
-
-Object? test(Map map, String str) {
-  return null;
 }
 
 /// Description element of the Knowledge panel.
@@ -66,13 +62,14 @@ class KnowledgePanelTextElement extends JsonObject {
   @JsonKey(name: 'source_url')
   final String? sourceUrl;
 
-  const KnowledgePanelTextElement(
-      {required this.html,
-      this.type,
-      this.sourceLanguage,
-      this.sourceLocale,
-      this.sourceText,
-      this.sourceUrl});
+  const KnowledgePanelTextElement({
+    required this.html,
+    this.type,
+    this.sourceLanguage,
+    this.sourceLocale,
+    this.sourceText,
+    this.sourceUrl,
+  });
 
   factory KnowledgePanelTextElement.fromJson(Map<String, dynamic> json) =>
       _$KnowledgePanelTextElementFromJson(json);
@@ -305,14 +302,19 @@ enum KnowledgePanelElementType {
   /// The description summarizes the knowledge panel.
   @JsonValue('text')
   TEXT,
+
   @JsonValue('image')
   IMAGE,
+
   @JsonValue('panel')
   PANEL,
+
   @JsonValue('panel_group')
   PANEL_GROUP,
+
   @JsonValue('table')
   TABLE,
+
   @JsonValue('map')
   MAP,
   UNKNOWN,

--- a/lib/model/KnowledgePanelElement.g.dart
+++ b/lib/model/KnowledgePanelElement.g.dart
@@ -13,6 +13,10 @@ KnowledgePanelTextElement _$KnowledgePanelTextElementFromJson(
       type: $enumDecodeNullable(
           _$KnowledgePanelTextElementTypeEnumMap, json['text_type'],
           unknownValue: KnowledgePanelTextElementType.DEFAULT),
+      sourceLanguage: json['source_language'] as String?,
+      sourceLocale: json['source_lc'] as String?,
+      sourceText: json['source_text'] as String?,
+      sourceUrl: json['source_url'] as String?,
     );
 
 Map<String, dynamic> _$KnowledgePanelTextElementToJson(
@@ -20,6 +24,10 @@ Map<String, dynamic> _$KnowledgePanelTextElementToJson(
     <String, dynamic>{
       'html': instance.html,
       'text_type': _$KnowledgePanelTextElementTypeEnumMap[instance.type],
+      'source_language': instance.sourceLanguage,
+      'source_lc': instance.sourceLocale,
+      'source_text': instance.sourceText,
+      'source_url': instance.sourceUrl,
     };
 
 const _$KnowledgePanelTextElementTypeEnumMap = {

--- a/test/knowledge_panels_from_json_test.dart
+++ b/test/knowledge_panels_from_json_test.dart
@@ -439,7 +439,7 @@ void main() {
             'element_type': 'text',
             'text_element': {
               'html':
-              '<strong>Sodium acetate:</strong> Sodium acetate, CH3COONa, also abbreviated NaOAc, is the sodium salt of acetic acid. This colorless deliquescent salt has a wide range of uses.',
+                  '<strong>Sodium acetate:</strong> Sodium acetate, CH3COONa, also abbreviated NaOAc, is the sodium salt of acetic acid. This colorless deliquescent salt has a wide range of uses.',
               'source_language': 'English',
               'source_lc': 'en',
               'source_text': 'Wikipedia',
@@ -470,23 +470,19 @@ void main() {
       isNotNull,
     );
     expect(
-      kp.panelIdToPanelMap[id]!.elements!.first.textElement!
-          .sourceLanguage,
+      kp.panelIdToPanelMap[id]!.elements!.first.textElement!.sourceLanguage,
       equals('English'),
     );
     expect(
-      kp.panelIdToPanelMap[id]!.elements!.first.textElement!
-          .sourceLocale,
+      kp.panelIdToPanelMap[id]!.elements!.first.textElement!.sourceLocale,
       equals('en'),
     );
     expect(
-      kp.panelIdToPanelMap[id]!.elements!.first.textElement!
-          .sourceText,
+      kp.panelIdToPanelMap[id]!.elements!.first.textElement!.sourceText,
       equals('Wikipedia'),
     );
     expect(
-      kp.panelIdToPanelMap[id]!.elements!.first.textElement!
-          .sourceUrl,
+      kp.panelIdToPanelMap[id]!.elements!.first.textElement!.sourceUrl,
       equals('https://en.wikipedia.org/wiki/Sodium acetate'),
     );
   });

--- a/test/knowledge_panels_from_json_test.dart
+++ b/test/knowledge_panels_from_json_test.dart
@@ -172,7 +172,11 @@ void main() {
             'text_element': {
               'html':
                   "\n                    <p>The carbon emission figure comes from ADEME's Agribalyse database, for the category: \n                    <a href='https://agribalyse.ademe.fr/app/aliments/31032'>Chocolate spread with hazelnuts</a>\n                    </p>\n                    ",
-              'text_type': 'summary'
+              'text_type': 'summary',
+              'source_language': 'English',
+              'source_lc': 'en',
+              'source_text': 'Wikipedia',
+              'source_url': 'https://en.wikipedia.org/wiki/Sodium acetate'
             }
           },
           {

--- a/test/knowledge_panels_from_json_test.dart
+++ b/test/knowledge_panels_from_json_test.dart
@@ -1,3 +1,4 @@
+import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:test/test.dart';
 
@@ -425,5 +426,68 @@ void main() {
     };
     KnowledgePanels kp = KnowledgePanels.fromJson(panels);
     expect(kp.panelIdToPanelMap.length, equals(8));
+  });
+
+  // Ensure that a "text_element" with some sources data is well parsed
+  test('Load knowledge panel JSON with a text element', () {
+    final String id = 'additive_en:e262';
+
+    final Map<String, dynamic> jsonData = <String, dynamic>{
+      id: {
+        'elements': [
+          {
+            'element_type': 'text',
+            'text_element': {
+              'html':
+              '<strong>Sodium acetate:</strong> Sodium acetate, CH3COONa, also abbreviated NaOAc, is the sodium salt of acetic acid. This colorless deliquescent salt has a wide range of uses.',
+              'source_language': 'English',
+              'source_lc': 'en',
+              'source_text': 'Wikipedia',
+              'source_url': 'https://en.wikipedia.org/wiki/Sodium acetate'
+            }
+          }
+        ],
+        'level': 'info',
+        'size': 'small',
+        'title_element': {'title': 'E262 - Sodium acetates'},
+        'topics': ['health']
+      },
+    };
+
+    KnowledgePanels kp = KnowledgePanels.fromJson(jsonData);
+    expect(kp.panelIdToPanelMap.length, equals(1));
+
+    expect(
+      kp.panelIdToPanelMap[id]!.elements!.length,
+      equals(1),
+    );
+    expect(
+      kp.panelIdToPanelMap[id]!.elements!.first.elementType,
+      equals(KnowledgePanelElementType.TEXT),
+    );
+    expect(
+      kp.panelIdToPanelMap[id]!.elements!.first.textElement,
+      isNotNull,
+    );
+    expect(
+      kp.panelIdToPanelMap[id]!.elements!.first.textElement!
+          .sourceLanguage,
+      equals('English'),
+    );
+    expect(
+      kp.panelIdToPanelMap[id]!.elements!.first.textElement!
+          .sourceLocale,
+      equals('en'),
+    );
+    expect(
+      kp.panelIdToPanelMap[id]!.elements!.first.textElement!
+          .sourceText,
+      equals('Wikipedia'),
+    );
+    expect(
+      kp.panelIdToPanelMap[id]!.elements!.first.textElement!
+          .sourceUrl,
+      equals('https://en.wikipedia.org/wiki/Sodium acetate'),
+    );
   });
 }


### PR DESCRIPTION
PR related to issue #408

I have included the different fields within the `KnowledgePanelTextElement` class.

I was wondering if a dedicated class like `KnowledgePanelTextElementSource` wouldn't be better in that case.
However, it would force us to create a dedicated parser/serializer.
What would you think about this?
