### PR TITLE
feat: #410 - refactored TaxonomyCountry with simplified fields

### DIFF
--- a/lib/model/Product.g.dart
+++ b/lib/model/Product.g.dart
@@ -225,6 +225,7 @@ const _$OpenFoodFactsLanguageEnumMap = {
   OpenFoodFactsLanguage.MALAY: 'MALAY',
   OpenFoodFactsLanguage.TAGALOG: 'TAGALOG',
   OpenFoodFactsLanguage.MOLDOVAN: 'MOLDOVAN',
+  OpenFoodFactsLanguage.MONGOLIAN: 'MONGOLIAN',
   OpenFoodFactsLanguage.KOREAN: 'KOREAN',
   OpenFoodFactsLanguage.LUBA_KATANGA_LANGUAGE: 'LUBA_KATANGA_LANGUAGE',
   OpenFoodFactsLanguage.KAZAKH: 'KAZAKH',

--- a/lib/model/TaxonomyCountry.dart
+++ b/lib/model/TaxonomyCountry.dart
@@ -15,6 +15,8 @@ enum TaxonomyCountryField {
   LANGUAGES,
   NAME,
   OFFICIAL_COUNTRY_CODE_2,
+  SYNONYMS,
+  WIKIDATA,
 }
 
 extension TaxonomyCountryFieldExtension on TaxonomyCountryField {
@@ -25,6 +27,8 @@ extension TaxonomyCountryFieldExtension on TaxonomyCountryField {
     TaxonomyCountryField.LANGUAGES: 'languages',
     TaxonomyCountryField.NAME: 'name',
     TaxonomyCountryField.OFFICIAL_COUNTRY_CODE_2: 'official_country_code_2',
+    TaxonomyCountryField.SYNONYMS: 'synonyms',
+    TaxonomyCountryField.WIKIDATA: 'wikidata',
   };
 
   /// Returns the key of the Country field
@@ -37,15 +41,7 @@ extension TaxonomyCountryFieldExtension on TaxonomyCountryField {
 /// of these.
 @JsonSerializable()
 class TaxonomyCountry extends JsonObject {
-  TaxonomyCountry(
-    this.children,
-    this.countryCode2,
-    this.countryCode3,
-    this.languages,
-    this.name,
-    this.officialCountryCode2,
-    this.parents,
-  );
+  TaxonomyCountry();
 
   factory TaxonomyCountry.fromJson(Map<String, dynamic> json) {
     return _$TaxonomyCountryFromJson(json);
@@ -56,45 +52,45 @@ class TaxonomyCountry extends JsonObject {
     return _$TaxonomyCountryToJson(this);
   }
 
-  @JsonKey(name: 'children', includeIfNull: false)
-  List<String>? children;
   @JsonKey(
     name: 'country_code_2',
-    fromJson: LanguageHelper.fromJsonStringMap,
-    toJson: LanguageHelper.toJsonStringMap,
+    fromJson: LanguageHelper.fromJsonStringMapIsoUnique,
     includeIfNull: false,
   )
-  Map<OpenFoodFactsLanguage, String>? countryCode2;
+  String? countryCode2;
   @JsonKey(
     name: 'country_code_3',
-    fromJson: LanguageHelper.fromJsonStringMap,
-    toJson: LanguageHelper.toJsonStringMap,
+    fromJson: LanguageHelper.fromJsonStringMapIsoUnique,
     includeIfNull: false,
   )
-  Map<OpenFoodFactsLanguage, String>? countryCode3;
+  String? countryCode3;
   @JsonKey(
-    name: 'languages',
-    fromJson: LanguageHelper.fromJsonStringMap,
-    toJson: LanguageHelper.toJsonStringMap,
+    name: 'language_codes',
+    fromJson: LanguageHelper.fromJsonStringMapIsoList,
     includeIfNull: false,
   )
-  Map<OpenFoodFactsLanguage, String>? languages;
+  List<OpenFoodFactsLanguage>? languages;
   @JsonKey(
-    name: 'name',
     fromJson: LanguageHelper.fromJsonStringMap,
-    toJson: LanguageHelper.toJsonStringMap,
     includeIfNull: false,
   )
   Map<OpenFoodFactsLanguage, String>? name;
   @JsonKey(
-    name: 'official_country_code_2',
-    fromJson: LanguageHelper.fromJsonStringMap,
-    toJson: LanguageHelper.toJsonStringMap,
+    fromJson: LanguageHelper.fromJsonStringMapList,
     includeIfNull: false,
   )
-  Map<OpenFoodFactsLanguage, String>? officialCountryCode2;
-  @JsonKey(name: 'parents', includeIfNull: false)
-  List<String>? parents;
+  Map<OpenFoodFactsLanguage, List<String>>? synonyms;
+  @JsonKey(
+    fromJson: LanguageHelper.fromJsonStringMapIsoUnique,
+    includeIfNull: false,
+  )
+  String? wikidata;
+  @JsonKey(
+    name: 'official_country_code_2',
+    fromJson: LanguageHelper.fromJsonStringMapIsoUnique,
+    includeIfNull: false,
+  )
+  String? officialCountryCode2;
   @override
   String toString() => toJson().toString();
 }

--- a/lib/model/TaxonomyCountry.g.dart
+++ b/lib/model/TaxonomyCountry.g.dart
@@ -7,15 +7,18 @@ part of 'TaxonomyCountry.dart';
 // **************************************************************************
 
 TaxonomyCountry _$TaxonomyCountryFromJson(Map<String, dynamic> json) =>
-    TaxonomyCountry(
-      (json['children'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      LanguageHelper.fromJsonStringMap(json['country_code_2']),
-      LanguageHelper.fromJsonStringMap(json['country_code_3']),
-      LanguageHelper.fromJsonStringMap(json['languages']),
-      LanguageHelper.fromJsonStringMap(json['name']),
-      LanguageHelper.fromJsonStringMap(json['official_country_code_2']),
-      (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
-    );
+    TaxonomyCountry()
+      ..countryCode2 =
+          LanguageHelper.fromJsonStringMapIsoUnique(json['country_code_2'])
+      ..countryCode3 =
+          LanguageHelper.fromJsonStringMapIsoUnique(json['country_code_3'])
+      ..languages =
+          LanguageHelper.fromJsonStringMapIsoList(json['language_codes'])
+      ..name = LanguageHelper.fromJsonStringMap(json['name'])
+      ..synonyms = LanguageHelper.fromJsonStringMapList(json['synonyms'])
+      ..wikidata = LanguageHelper.fromJsonStringMapIsoUnique(json['wikidata'])
+      ..officialCountryCode2 = LanguageHelper.fromJsonStringMapIsoUnique(
+          json['official_country_code_2']);
 
 Map<String, dynamic> _$TaxonomyCountryToJson(TaxonomyCountry instance) {
   final val = <String, dynamic>{};
@@ -26,15 +29,212 @@ Map<String, dynamic> _$TaxonomyCountryToJson(TaxonomyCountry instance) {
     }
   }
 
-  writeNotNull('children', instance.children);
+  writeNotNull('country_code_2', instance.countryCode2);
+  writeNotNull('country_code_3', instance.countryCode3);
   writeNotNull(
-      'country_code_2', LanguageHelper.toJsonStringMap(instance.countryCode2));
+      'language_codes',
+      instance.languages
+          ?.map((e) => _$OpenFoodFactsLanguageEnumMap[e])
+          .toList());
   writeNotNull(
-      'country_code_3', LanguageHelper.toJsonStringMap(instance.countryCode3));
-  writeNotNull('languages', LanguageHelper.toJsonStringMap(instance.languages));
-  writeNotNull('name', LanguageHelper.toJsonStringMap(instance.name));
-  writeNotNull('official_country_code_2',
-      LanguageHelper.toJsonStringMap(instance.officialCountryCode2));
-  writeNotNull('parents', instance.parents);
+      'name',
+      instance.name
+          ?.map((k, e) => MapEntry(_$OpenFoodFactsLanguageEnumMap[k], e)));
+  writeNotNull(
+      'synonyms',
+      instance.synonyms
+          ?.map((k, e) => MapEntry(_$OpenFoodFactsLanguageEnumMap[k], e)));
+  writeNotNull('wikidata', instance.wikidata);
+  writeNotNull('official_country_code_2', instance.officialCountryCode2);
   return val;
 }
+
+const _$OpenFoodFactsLanguageEnumMap = {
+  OpenFoodFactsLanguage.ENGLISH: 'ENGLISH',
+  OpenFoodFactsLanguage.OLD_CHURCH_SLAVONIC: 'OLD_CHURCH_SLAVONIC',
+  OpenFoodFactsLanguage.DZONGKHA_LANGUAGE: 'DZONGKHA_LANGUAGE',
+  OpenFoodFactsLanguage.JAPANESE: 'JAPANESE',
+  OpenFoodFactsLanguage.MALAY: 'MALAY',
+  OpenFoodFactsLanguage.TAGALOG: 'TAGALOG',
+  OpenFoodFactsLanguage.MOLDOVAN: 'MOLDOVAN',
+  OpenFoodFactsLanguage.MONGOLIAN: 'MONGOLIAN',
+  OpenFoodFactsLanguage.KOREAN: 'KOREAN',
+  OpenFoodFactsLanguage.LUBA_KATANGA_LANGUAGE: 'LUBA_KATANGA_LANGUAGE',
+  OpenFoodFactsLanguage.KAZAKH: 'KAZAKH',
+  OpenFoodFactsLanguage.QUECHUA_LANGUAGES: 'QUECHUA_LANGUAGES',
+  OpenFoodFactsLanguage.UKRAINIAN: 'UKRAINIAN',
+  OpenFoodFactsLanguage.OCCITAN: 'OCCITAN',
+  OpenFoodFactsLanguage.BIHARI_LANGUAGES: 'BIHARI_LANGUAGES',
+  OpenFoodFactsLanguage.SOUTHERN_NDEBELE: 'SOUTHERN_NDEBELE',
+  OpenFoodFactsLanguage.BOKMAL: 'BOKMAL',
+  OpenFoodFactsLanguage.KOMI: 'KOMI',
+  OpenFoodFactsLanguage.MODERN_GREEK: 'MODERN_GREEK',
+  OpenFoodFactsLanguage.FIJIAN_LANGUAGE: 'FIJIAN_LANGUAGE',
+  OpenFoodFactsLanguage.ZULU: 'ZULU',
+  OpenFoodFactsLanguage.IDO: 'IDO',
+  OpenFoodFactsLanguage.KHMER: 'KHMER',
+  OpenFoodFactsLanguage.SANSKRIT: 'SANSKRIT',
+  OpenFoodFactsLanguage.MACEDONIAN: 'MACEDONIAN',
+  OpenFoodFactsLanguage.SOTHO: 'SOTHO',
+  OpenFoodFactsLanguage.SCOTTISH_GAELIC: 'SCOTTISH_GAELIC',
+  OpenFoodFactsLanguage.MARATHI: 'MARATHI',
+  OpenFoodFactsLanguage.NAURUAN: 'NAURUAN',
+  OpenFoodFactsLanguage.OROMO: 'OROMO',
+  OpenFoodFactsLanguage.WELSH: 'WELSH',
+  OpenFoodFactsLanguage.VIETNAMESE: 'VIETNAMESE',
+  OpenFoodFactsLanguage.BISLAMA: 'BISLAMA',
+  OpenFoodFactsLanguage.SOMALI: 'SOMALI',
+  OpenFoodFactsLanguage.LITHUANIAN: 'LITHUANIAN',
+  OpenFoodFactsLanguage.HAITIAN_CREOLE: 'HAITIAN_CREOLE',
+  OpenFoodFactsLanguage.MALAGASY: 'MALAGASY',
+  OpenFoodFactsLanguage.SPANISH: 'SPANISH',
+  OpenFoodFactsLanguage.DANISH: 'DANISH',
+  OpenFoodFactsLanguage.SLOVENE: 'SLOVENE',
+  OpenFoodFactsLanguage.ICELANDIC: 'ICELANDIC',
+  OpenFoodFactsLanguage.ESTONIAN: 'ESTONIAN',
+  OpenFoodFactsLanguage.WOLOF: 'WOLOF',
+  OpenFoodFactsLanguage.HIRI_MOTU: 'HIRI_MOTU',
+  OpenFoodFactsLanguage.TAMIL: 'TAMIL',
+  OpenFoodFactsLanguage.SLOVAK: 'SLOVAK',
+  OpenFoodFactsLanguage.HERERO: 'HERERO',
+  OpenFoodFactsLanguage.ITALIAN: 'ITALIAN',
+  OpenFoodFactsLanguage.IRISH: 'IRISH',
+  OpenFoodFactsLanguage.SHONA: 'SHONA',
+  OpenFoodFactsLanguage.MARSHALLESE: 'MARSHALLESE',
+  OpenFoodFactsLanguage.FRENCH: 'FRENCH',
+  OpenFoodFactsLanguage.AYMARA: 'AYMARA',
+  OpenFoodFactsLanguage.HEBREW: 'HEBREW',
+  OpenFoodFactsLanguage.NORTHERN_SAMI: 'NORTHERN_SAMI',
+  OpenFoodFactsLanguage.BENGALI: 'BENGALI',
+  OpenFoodFactsLanguage.ODIA: 'ODIA',
+  OpenFoodFactsLanguage.MALAYALAM: 'MALAYALAM',
+  OpenFoodFactsLanguage.DUTCH: 'DUTCH',
+  OpenFoodFactsLanguage.UYGHUR: 'UYGHUR',
+  OpenFoodFactsLanguage.SERBIAN: 'SERBIAN',
+  OpenFoodFactsLanguage.TIBETAN_LANGUAGE: 'TIBETAN_LANGUAGE',
+  OpenFoodFactsLanguage.BELARUSIAN: 'BELARUSIAN',
+  OpenFoodFactsLanguage.SAMOAN: 'SAMOAN',
+  OpenFoodFactsLanguage.PUNJABI: 'PUNJABI',
+  OpenFoodFactsLanguage.RUSSIAN: 'RUSSIAN',
+  OpenFoodFactsLanguage.TAHITIAN: 'TAHITIAN',
+  OpenFoodFactsLanguage.INTERLINGUA: 'INTERLINGUA',
+  OpenFoodFactsLanguage.AFAR: 'AFAR',
+  OpenFoodFactsLanguage.GREENLANDIC: 'GREENLANDIC',
+  OpenFoodFactsLanguage.LATIN: 'LATIN',
+  OpenFoodFactsLanguage.CHINESE: 'CHINESE',
+  OpenFoodFactsLanguage.TURKMEN: 'TURKMEN',
+  OpenFoodFactsLanguage.WEST_FRISIAN: 'WEST_FRISIAN',
+  OpenFoodFactsLanguage.TSONGA: 'TSONGA',
+  OpenFoodFactsLanguage.ROMANSH: 'ROMANSH',
+  OpenFoodFactsLanguage.INUPIAT_LANGUAGE: 'INUPIAT_LANGUAGE',
+  OpenFoodFactsLanguage.TAJIK: 'TAJIK',
+  OpenFoodFactsLanguage.BURMESE: 'BURMESE',
+  OpenFoodFactsLanguage.JAVANESE: 'JAVANESE',
+  OpenFoodFactsLanguage.CHECHEN: 'CHECHEN',
+  OpenFoodFactsLanguage.ASSAMESE: 'ASSAMESE',
+  OpenFoodFactsLanguage.UNKNOWN_LANGUAGE: 'UNKNOWN_LANGUAGE',
+  OpenFoodFactsLanguage.ARABIC: 'ARABIC',
+  OpenFoodFactsLanguage.KINYARWANDA: 'KINYARWANDA',
+  OpenFoodFactsLanguage.TONGAN_LANGUAGE: 'TONGAN_LANGUAGE',
+  OpenFoodFactsLanguage.CHURCH_SLAVONIC: 'CHURCH_SLAVONIC',
+  OpenFoodFactsLanguage.SINHALA: 'SINHALA',
+  OpenFoodFactsLanguage.ARMENIAN: 'ARMENIAN',
+  OpenFoodFactsLanguage.KURDISH: 'KURDISH',
+  OpenFoodFactsLanguage.THAI: 'THAI',
+  OpenFoodFactsLanguage.CREE: 'CREE',
+  OpenFoodFactsLanguage.SWAHILI: 'SWAHILI',
+  OpenFoodFactsLanguage.GUJARATI: 'GUJARATI',
+  OpenFoodFactsLanguage.PERSIAN: 'PERSIAN',
+  OpenFoodFactsLanguage.BOSNIAN: 'BOSNIAN',
+  OpenFoodFactsLanguage.AMHARIC: 'AMHARIC',
+  OpenFoodFactsLanguage.ARAGONESE: 'ARAGONESE',
+  OpenFoodFactsLanguage.CROATIAN: 'CROATIAN',
+  OpenFoodFactsLanguage.CHEWA: 'CHEWA',
+  OpenFoodFactsLanguage.ZHUANG_LANGUAGES: 'ZHUANG_LANGUAGES',
+  OpenFoodFactsLanguage.LINGALA_LANGUAGE: 'LINGALA_LANGUAGE',
+  OpenFoodFactsLanguage.BAMBARA: 'BAMBARA',
+  OpenFoodFactsLanguage.LIMBURGISH_LANGUAGE: 'LIMBURGISH_LANGUAGE',
+  OpenFoodFactsLanguage.NUOSU_LANGUAGE: 'NUOSU_LANGUAGE',
+  OpenFoodFactsLanguage.KWANYAMA: 'KWANYAMA',
+  OpenFoodFactsLanguage.KIRUNDI: 'KIRUNDI',
+  OpenFoodFactsLanguage.EWE: 'EWE',
+  OpenFoodFactsLanguage.FAROESE: 'FAROESE',
+  OpenFoodFactsLanguage.SINDHI: 'SINDHI',
+  OpenFoodFactsLanguage.CORSICAN: 'CORSICAN',
+  OpenFoodFactsLanguage.KANNADA: 'KANNADA',
+  OpenFoodFactsLanguage.NORWEGIAN: 'NORWEGIAN',
+  OpenFoodFactsLanguage.SUNDANESE_LANGUAGE: 'SUNDANESE_LANGUAGE',
+  OpenFoodFactsLanguage.GEORGIAN: 'GEORGIAN',
+  OpenFoodFactsLanguage.HAUSA: 'HAUSA',
+  OpenFoodFactsLanguage.TSWANA: 'TSWANA',
+  OpenFoodFactsLanguage.CATALAN: 'CATALAN',
+  OpenFoodFactsLanguage.NDONGA_DIALECT: 'NDONGA_DIALECT',
+  OpenFoodFactsLanguage.IGBO_LANGUAGE: 'IGBO_LANGUAGE',
+  OpenFoodFactsLanguage.AFRIKAANS: 'AFRIKAANS',
+  OpenFoodFactsLanguage.POLISH: 'POLISH',
+  OpenFoodFactsLanguage.KASHMIRI: 'KASHMIRI',
+  OpenFoodFactsLanguage.MAORI: 'MAORI',
+  OpenFoodFactsLanguage.HUNGARIAN: 'HUNGARIAN',
+  OpenFoodFactsLanguage.BRETON: 'BRETON',
+  OpenFoodFactsLanguage.PORTUGUESE: 'PORTUGUESE',
+  OpenFoodFactsLanguage.BULGARIAN: 'BULGARIAN',
+  OpenFoodFactsLanguage.AVESTAN: 'AVESTAN',
+  OpenFoodFactsLanguage.NEPALI: 'NEPALI',
+  OpenFoodFactsLanguage.TWI: 'TWI',
+  OpenFoodFactsLanguage.UZBEK: 'UZBEK',
+  OpenFoodFactsLanguage.CHAMORRO: 'CHAMORRO',
+  OpenFoodFactsLanguage.GUARANI: 'GUARANI',
+  OpenFoodFactsLanguage.NYNORSK: 'NYNORSK',
+  OpenFoodFactsLanguage.AZERBAIJANI: 'AZERBAIJANI',
+  OpenFoodFactsLanguage.CZECH: 'CZECH',
+  OpenFoodFactsLanguage.NAVAJO: 'NAVAJO',
+  OpenFoodFactsLanguage.FINNISH: 'FINNISH',
+  OpenFoodFactsLanguage.LUXEMBOURGISH: 'LUXEMBOURGISH',
+  OpenFoodFactsLanguage.SWEDISH: 'SWEDISH',
+  OpenFoodFactsLanguage.YIDDISH: 'YIDDISH',
+  OpenFoodFactsLanguage.INUKTITUT: 'INUKTITUT',
+  OpenFoodFactsLanguage.LAO: 'LAO',
+  OpenFoodFactsLanguage.CHUVASH: 'CHUVASH',
+  OpenFoodFactsLanguage.MALTESE: 'MALTESE',
+  OpenFoodFactsLanguage.MALDIVIAN_LANGUAGE: 'MALDIVIAN_LANGUAGE',
+  OpenFoodFactsLanguage.INTERLINGUE: 'INTERLINGUE',
+  OpenFoodFactsLanguage.OSSETIAN: 'OSSETIAN',
+  OpenFoodFactsLanguage.BASHKIR: 'BASHKIR',
+  OpenFoodFactsLanguage.OJIBWE: 'OJIBWE',
+  OpenFoodFactsLanguage.KANURI: 'KANURI',
+  OpenFoodFactsLanguage.INDONESIAN: 'INDONESIAN',
+  OpenFoodFactsLanguage.SARDINIAN_LANGUAGE: 'SARDINIAN_LANGUAGE',
+  OpenFoodFactsLanguage.AKAN: 'AKAN',
+  OpenFoodFactsLanguage.MANX: 'MANX',
+  OpenFoodFactsLanguage.TURKISH: 'TURKISH',
+  OpenFoodFactsLanguage.ESPERANTO: 'ESPERANTO',
+  OpenFoodFactsLanguage.PASHTO: 'PASHTO',
+  OpenFoodFactsLanguage.KYRGYZ: 'KYRGYZ',
+  OpenFoodFactsLanguage.VOLAPUK: 'VOLAPUK',
+  OpenFoodFactsLanguage.AVAR: 'AVAR',
+  OpenFoodFactsLanguage.SANGO: 'SANGO',
+  OpenFoodFactsLanguage.VENDA: 'VENDA',
+  OpenFoodFactsLanguage.ALBANIAN: 'ALBANIAN',
+  OpenFoodFactsLanguage.BASQUE: 'BASQUE',
+  OpenFoodFactsLanguage.FULA_LANGUAGE: 'FULA_LANGUAGE',
+  OpenFoodFactsLanguage.GERMAN: 'GERMAN',
+  OpenFoodFactsLanguage.LATVIAN: 'LATVIAN',
+  OpenFoodFactsLanguage.CORNISH: 'CORNISH',
+  OpenFoodFactsLanguage.PALI: 'PALI',
+  OpenFoodFactsLanguage.TATAR: 'TATAR',
+  OpenFoodFactsLanguage.ROMANIAN: 'ROMANIAN',
+  OpenFoodFactsLanguage.GIKUYU: 'GIKUYU',
+  OpenFoodFactsLanguage.TIGRINYA: 'TIGRINYA',
+  OpenFoodFactsLanguage.GALICIAN: 'GALICIAN',
+  OpenFoodFactsLanguage.TELUGU: 'TELUGU',
+  OpenFoodFactsLanguage.HINDI: 'HINDI',
+  OpenFoodFactsLanguage.KONGO_LANGUAGE: 'KONGO_LANGUAGE',
+  OpenFoodFactsLanguage.XHOSA: 'XHOSA',
+  OpenFoodFactsLanguage.SWAZI: 'SWAZI',
+  OpenFoodFactsLanguage.LUGANDA: 'LUGANDA',
+  OpenFoodFactsLanguage.URDU: 'URDU',
+  OpenFoodFactsLanguage.NORTHERN_NDEBELE_LANGUAGE: 'NORTHERN_NDEBELE_LANGUAGE',
+  OpenFoodFactsLanguage.YORUBA: 'YORUBA',
+  OpenFoodFactsLanguage.WORLD: 'WORLD',
+  OpenFoodFactsLanguage.UNDEFINED: 'UNDEFINED',
+};

--- a/lib/utils/LanguageHelper.dart
+++ b/lib/utils/LanguageHelper.dart
@@ -21,6 +21,9 @@ enum OpenFoodFactsLanguage {
   /// Moldovan
   MOLDOVAN,
 
+  /// Mongolian
+  MONGOLIAN,
+
   /// Korean
   KOREAN,
 
@@ -569,6 +572,7 @@ extension OpenFoodFactsLanguageExtension on OpenFoodFactsLanguage? {
     OpenFoodFactsLanguage.MALAY: 'ms',
     OpenFoodFactsLanguage.TAGALOG: 'tl',
     OpenFoodFactsLanguage.MOLDOVAN: 'mo',
+    OpenFoodFactsLanguage.MONGOLIAN: 'mn',
     OpenFoodFactsLanguage.KOREAN: 'ko',
     OpenFoodFactsLanguage.LUBA_KATANGA_LANGUAGE: 'lu',
     OpenFoodFactsLanguage.KAZAKH: 'kk',
@@ -797,6 +801,69 @@ class LanguageHelper {
     final result = <OpenFoodFactsLanguage, String>{};
     for (final key in map.keys) {
       result[LanguageHelper.fromJson(key)] = map[key]! as String;
+    }
+    return result;
+  }
+
+  /// From a `Map<String, String>` in `dynamic`'s clothing (JsonKey annotation)
+  static Map<OpenFoodFactsLanguage, List<String>>? fromJsonStringMapList(
+      dynamic map) {
+    if (map == null) {
+      return null;
+    }
+    if (map is! Map<String, dynamic>) {
+      throw Exception('Expected type: Map<String, List<String>>: $map');
+    }
+    final result = <OpenFoodFactsLanguage, List<String>>{};
+    for (final key in map.keys) {
+      final List<String> list = <String>[];
+      for (final item in map[key]! as List<dynamic>) {
+        list.add(item as String);
+      }
+      result[LanguageHelper.fromJson(key)] = list;
+    }
+    return result;
+  }
+
+  /// Special case for ISO codes that should be unique for all languages.
+  ///
+  /// e.g. "country_code_2": {"en": "BY"} will return 'BY'.
+  /// From a `Map<String, String>` in `dynamic`'s clothing (JsonKey annotation)
+  static String? fromJsonStringMapIsoUnique(dynamic map) {
+    if (map == null) {
+      return null;
+    }
+    if (map is! Map<String, dynamic>) {
+      throw Exception('Expected type: Map<String, String>');
+    }
+    for (final value in map.values) {
+      return value! as String;
+    }
+    return null;
+  }
+
+  /// Special case for ISO codes that should be unique for all languages.
+  ///
+  /// e.g. "language_codes": {"en":"nl,fr"} will return
+  /// [OpenFoodFactsLanguage.DUTCH, OpenFoodFactsLanguage.FRENCH]
+  /// From a `Map<String, String>` in `dynamic`'s clothing (JsonKey annotation)
+  static List<OpenFoodFactsLanguage>? fromJsonStringMapIsoList(dynamic map) {
+    if (map == null) {
+      return null;
+    }
+    if (map is! Map<String, dynamic>) {
+      throw Exception('Expected type: Map<String, String>');
+    }
+    final result = <OpenFoodFactsLanguage>[];
+    for (final value in map.values) {
+      final String list = value! as String;
+      if (list.isEmpty) {
+        continue;
+      }
+      final List<String> languages = list.split(',');
+      for (final String language in languages) {
+        result.add(LanguageHelper.fromJson(language));
+      }
     }
     return result;
   }

--- a/test/api_getTaxonomyCountries_test.dart
+++ b/test/api_getTaxonomyCountries_test.dart
@@ -12,15 +12,29 @@ void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   late FakeHttpHelper httpHelper;
+
+  const String _knownTag = 'en:gambia';
+  const String _expectedCountryCode2 = 'GM';
+  const String _expectedCountryCode3 = 'GMB';
+  const List<OpenFoodFactsLanguage> _expectedLanguages =
+      <OpenFoodFactsLanguage>[OpenFoodFactsLanguage.ENGLISH];
+  const String _expectedNameFrench = 'Gambie';
+  const String _expectedNameEnglish = 'Gambia';
+  const String _unknownTag = 'en:some_nonexistent_country';
+
   final Map<String, dynamic> expectedResponse = <String, dynamic>{
-    "en:gambia": {
+    _knownTag: {
       "name": {
-        "en": "Gambia",
-        "fr": "Gambie",
+        "en": _expectedNameEnglish,
+        "fr": _expectedNameFrench,
       },
-      "country_code_3": {"en": "GMB"},
-      "languages": {"en": "en"},
-      "country_code_2": {"en": "GM"}
+      "synonyms": {
+        "en": ["Gambia", "Republic of the Gambia", "the Gambia", "GM", "GMB"],
+        "fr": ["Gambie"]
+      },
+      "country_code_3": {"en": _expectedCountryCode3},
+      "language_codes": {"en": _expectedLanguages[0].code},
+      "country_code_2": {"en": _expectedCountryCode2}
     },
   };
 
@@ -30,8 +44,17 @@ void main() {
   });
 
   group('OpenFoodAPIClient getTaxonomyCountries', () {
+    void _checkGambia(final TaxonomyCountry country, final String tag) {
+      expect(
+          country.name![OpenFoodFactsLanguage.ENGLISH], _expectedNameEnglish);
+      expect(country.name![OpenFoodFactsLanguage.FRENCH], _expectedNameFrench);
+      expect(country.languages, _expectedLanguages);
+      expect(country.countryCode2, _expectedCountryCode2);
+      expect(country.countryCode3, _expectedCountryCode3);
+    }
+
     test('get a country', () async {
-      final String tag = 'en:gambia';
+      final String tag = _knownTag;
       TaxonomyCountryQueryConfiguration configuration =
           TaxonomyCountryQueryConfiguration(
         fields: [
@@ -54,22 +77,11 @@ void main() {
       );
       expect(countries, isNotNull);
       expect(countries!.length, equals(1));
-      TaxonomyCountry country = countries[tag]!;
-      expect(
-          country.name![OpenFoodFactsLanguage.ENGLISH]!,
-          equals(expectedResponse[tag][TaxonomyCountryField.NAME.key]
-              [OpenFoodFactsLanguage.ENGLISH.code]));
-      expect(
-          country.name![OpenFoodFactsLanguage.FRENCH]!,
-          equals(expectedResponse[tag][TaxonomyCountryField.NAME.key]
-              [OpenFoodFactsLanguage.FRENCH.code]));
-      expect(
-          country.languages![OpenFoodFactsLanguage.ENGLISH]!,
-          equals(expectedResponse[tag][TaxonomyCountryField.LANGUAGES.key]
-              [OpenFoodFactsLanguage.ENGLISH.code]));
+      final TaxonomyCountry country = countries[tag]!;
+      _checkGambia(country, tag);
     });
     test("get a country that doesn't exist", () async {
-      final String tag = 'en:some_nonexistent_country';
+      final String tag = _unknownTag;
       Map<String, dynamic> expectedResponse = <String, dynamic>{
         tag: {},
       };
@@ -95,7 +107,7 @@ void main() {
       expect(categories, isNull);
     });
     test("get a country that doesn't exist with one that does", () async {
-      final String tag = 'en:gambia';
+      final String tag = _knownTag;
       TaxonomyCountryQueryConfiguration configuration =
           TaxonomyCountryQueryConfiguration(
         fields: [
@@ -106,7 +118,7 @@ void main() {
           OpenFoodFactsLanguage.ENGLISH,
           OpenFoodFactsLanguage.FRENCH,
         ],
-        tags: <String>['en:some_nonexistent_country', tag],
+        tags: <String>[_unknownTag, tag],
       );
       httpHelper.setResponse(configuration.getUri(),
           response: expectedResponse);
@@ -119,19 +131,8 @@ void main() {
       expect(countries, isNotNull);
 
       expect(countries!.length, equals(1));
-      TaxonomyCountry country = countries[tag]!;
-      expect(
-          country.name![OpenFoodFactsLanguage.ENGLISH]!,
-          equals(expectedResponse[tag][TaxonomyCountryField.NAME.key]
-              [OpenFoodFactsLanguage.ENGLISH.code]));
-      expect(
-          country.name![OpenFoodFactsLanguage.FRENCH]!,
-          equals(expectedResponse[tag][TaxonomyCountryField.NAME.key]
-              [OpenFoodFactsLanguage.FRENCH.code]));
-      expect(
-          country.languages![OpenFoodFactsLanguage.ENGLISH]!,
-          equals(expectedResponse[tag][TaxonomyCountryField.LANGUAGES.key]
-              [OpenFoodFactsLanguage.ENGLISH.code]));
+      final TaxonomyCountry country = countries[tag]!;
+      _checkGambia(country, tag);
     });
   });
 }


### PR DESCRIPTION
Impacted files:
* `api_getTaxonomyCountries_test.dart`: refactored with the simplified fields
* `api_getTaxonomyCountriesServer_test.dart`: refactored with the simplified fields
* `LanguageHelper.dart`: added a language; added 3 json-decode helpers methods
* `Product.g.dart`: generated
* `TaxonomyCountry.dart`: added 2 fields; simplified constructor; simplified fields; removed useless `toJson` methods
* `TaxonomyCountry.g.dart`: generated

### What
- the structure of TaxonomyCountry evolved
  - `parents` and `children` eventually do not mean anything
  - new fields `synonyms` and `wikidata`
  - ISO codes obviously should not depend on input languages

### Part of 
- https://github.com/openfoodfacts/openfoodfacts-dart/issues/410
