### PR TITLE
fix: #407 - getProductList now works with unlimited number of barcodes

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -324,14 +324,14 @@ class OpenFoodAPIClient {
     QueryType? queryType,
   }) async {
     final Uri uri = UriHelper.getUri(
-      path: 'products/${configuration.barcodes.join(',')}.json',
-      queryParameters: configuration.getParametersMap(),
+      path: 'api/v2/search/',
       queryType: queryType,
     );
 
-    final Response response = await HttpHelper().doGetRequest(
+    final Response response = await HttpHelper().doPostRequest(
       uri,
-      user: user,
+      configuration.getParametersMap(),
+      user,
       queryType: queryType,
     );
 

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -46,4 +46,13 @@ class ProductListQueryConfiguration extends AbstractQueryConfiguration {
     }
     return result;
   }
+
+  @override
+  Map<String, String> getParametersMap() {
+    final Map<String, String> result = super.getParametersMap();
+
+    result['code'] = barcodes.join(',') + '.json';
+
+    return result;
+  }
 }


### PR DESCRIPTION
Impacted files:
* `api_searchProducts_test.dart`: additional test; refactored
* `openfoodfacts.dart`: changed method `getProductList` from GET to POST
* `ProductListQueryConfiguration.dart`: overrode `getParametersMap` in order to add barcodes as POST parameters

### What
- GET has limits (number of characters), POST doesn't.
- For getProductList, there are potentially tons of parameters (the barcodes), therefore we had to play it safe and to switch from GET to POST

### Fixes bug(s)
- #407