### PR TITLE
refactor: #414 - refactored query configuration methods

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -24,7 +24,6 @@ import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/ImageHelper.dart';
 import 'package:openfoodfacts/utils/OcrField.dart';
 import 'package:openfoodfacts/utils/PnnsGroupQueryConfiguration.dart';
-import 'package:openfoodfacts/utils/PnnsGroups.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
 import 'package:openfoodfacts/utils/ProductListQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
@@ -219,12 +218,7 @@ class OpenFoodAPIClient {
     final User? user,
     final QueryType? queryType,
   }) async {
-    final Response response = await HttpHelper().doPostRequest(
-      configuration.getUri(queryType: queryType),
-      configuration.getParametersMap(),
-      user,
-      queryType: queryType,
-    );
+    final Response response = await configuration.getResponse(user, queryType);
     return response.body;
   }
 
@@ -298,17 +292,7 @@ class OpenFoodAPIClient {
     ProductSearchQueryConfiguration configuration, {
     QueryType? queryType,
   }) async {
-    var searchUri = UriHelper.getPostUri(
-      path: '/cgi/search.pl',
-      queryType: queryType,
-    );
-
-    Response response = await HttpHelper().doPostRequest(
-      searchUri,
-      configuration.getParametersMap(),
-      user,
-      queryType: queryType,
-    );
+    final Response response = await configuration.getResponse(user, queryType);
     final jsonStr = _replaceQuotes(response.body);
     var result = SearchResult.fromJson(json.decode(jsonStr));
 
@@ -323,17 +307,7 @@ class OpenFoodAPIClient {
     ProductListQueryConfiguration configuration, {
     QueryType? queryType,
   }) async {
-    final Uri uri = UriHelper.getPostUri(
-      path: 'api/v2/search/',
-      queryType: queryType,
-    );
-
-    final Response response = await HttpHelper().doPostRequest(
-      uri,
-      configuration.getParametersMap(),
-      user,
-      queryType: queryType,
-    );
+    final Response response = await configuration.getResponse(user, queryType);
 
     final String jsonStr = _replaceQuotes(response.body);
     final SearchResult result = SearchResult.fromJson(json.decode(jsonStr));
@@ -386,17 +360,7 @@ class OpenFoodAPIClient {
     PnnsGroupQueryConfiguration configuration, {
     QueryType? queryType,
   }) async {
-    var searchUri = UriHelper.getPostUri(
-      path: '/pnns-group-2/${configuration.group.id}/${configuration.page}',
-      queryType: queryType,
-    );
-
-    Response response = await HttpHelper().doPostRequest(
-      searchUri,
-      configuration.getParametersMap(),
-      user,
-      queryType: queryType,
-    );
+    final Response response = await configuration.getResponse(user, queryType);
     final jsonStr = _replaceQuotes(response.body);
     var result = SearchResult.fromJson(json.decode(jsonStr));
 

--- a/lib/utils/AbstractQueryConfiguration.dart
+++ b/lib/utils/AbstractQueryConfiguration.dart
@@ -1,9 +1,15 @@
+import 'package:http/http.dart';
+import 'package:meta/meta.dart';
 import 'package:openfoodfacts/interface/Parameter.dart';
+import 'package:openfoodfacts/model/User.dart';
 import 'package:openfoodfacts/model/parameter/TagFilter.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:openfoodfacts/utils/HttpHelper.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
+import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:openfoodfacts/utils/UriHelper.dart';
 
 /// Abstract Query Configuration, that helps build API URI
 abstract class AbstractQueryConfiguration {
@@ -121,4 +127,21 @@ abstract class AbstractQueryConfiguration {
   String? computeCountryCode() =>
       // ignore: deprecated_member_use_from_same_package
       OpenFoodAPIConfiguration.computeCountryCode(country, cc);
+
+  @protected
+  String getUriPath();
+
+  Future<Response> getResponse(
+    final User? user,
+    final QueryType? queryType,
+  ) async =>
+      await HttpHelper().doPostRequest(
+        UriHelper.getPostUri(
+          path: getUriPath(),
+          queryType: queryType,
+        ),
+        getParametersMap(),
+        user,
+        queryType: queryType,
+      );
 }

--- a/lib/utils/PnnsGroupQueryConfiguration.dart
+++ b/lib/utils/PnnsGroupQueryConfiguration.dart
@@ -44,4 +44,7 @@ class PnnsGroupQueryConfiguration extends AbstractQueryConfiguration {
 
     return result;
   }
+
+  @override
+  String getUriPath() => '/pnns-group-2/${group.id}/$page';
 }

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -55,4 +55,7 @@ class ProductListQueryConfiguration extends AbstractQueryConfiguration {
 
     return result;
   }
+
+  @override
+  String getUriPath() => 'api/v2/search/';
 }

--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -2,8 +2,6 @@ import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
-import 'package:openfoodfacts/utils/QueryType.dart';
-import 'package:openfoodfacts/utils/UriHelper.dart';
 
 /// Query version for single barcode
 class ProductQueryVersion {
@@ -48,9 +46,6 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
           fields: fields,
         );
 
-  Uri getUri({final QueryType? queryType}) => UriHelper.getUri(
-        path: version.getPath(barcode),
-        queryParameters: getParametersMap(),
-        queryType: queryType,
-      );
+  @override
+  String getUriPath() => version.getPath(barcode);
 }

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -45,4 +45,7 @@ class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
     result.putIfAbsent('json', () => '1');
     return result;
   }
+
+  @override
+  String getUriPath() => '/cgi/search.pl';
 }


### PR DESCRIPTION
Impacted files:
* `AbstractQueryConfiguration.dart`: added abstract protected method `getUriPath` and method `getResponse`
* `openfoodfacts.dart`: using new method `AbstractQueryConfiguration.getResponse`
* `PnnsGroupQueryConfiguration.dart`: implemented new method `getUriPath`
* `ProductListQueryConfiguration.dart`: implemented new method `getUriPath`
* `ProductQueryConfigurations.dart`: implemented new method `getUriPath`
* `ProductSearchQueryConfiguration.dart`: implemented new method `getUriPath`

### What
- simple additional refactoring after #415