### PR TITLE
fix: actually upload an image on a random product

### DIFF
--- a/lib/utils/ImageHelper.dart
+++ b/lib/utils/ImageHelper.dart
@@ -7,10 +7,6 @@ import 'LanguageHelper.dart';
 /// Helper class related to product pictures
 class ImageHelper {
   static const int MAX_IMAGE_SIZE = 2048;
-  static const String IMAGE_PROD_URL_BASE =
-      'https://static.openfoodfacts.org/images/products/';
-  static const String IMAGE_TEST_URL_BASE =
-      'https://static.openfoodfacts.net/images/products/';
 
   /// Returns a copy of the [image] with its bigger size GTE [maxsize]
   static Image resize(Image image, {int maxSize = MAX_IMAGE_SIZE}) {
@@ -80,7 +76,7 @@ class ImageHelper {
     }
 
     return OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
-        ? IMAGE_PROD_URL_BASE + barcodeUrl
-        : IMAGE_TEST_URL_BASE + barcodeUrl;
+        ? OpenFoodAPIConfiguration.ImageProdUrlBase + barcodeUrl
+        : OpenFoodAPIConfiguration.ImageTestUrlBase + barcodeUrl;
   }
 }

--- a/lib/utils/ImageHelper.dart
+++ b/lib/utils/ImageHelper.dart
@@ -76,7 +76,7 @@ class ImageHelper {
     }
 
     return OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
-        ? OpenFoodAPIConfiguration.ImageProdUrlBase + barcodeUrl
-        : OpenFoodAPIConfiguration.ImageTestUrlBase + barcodeUrl;
+        ? OpenFoodAPIConfiguration.imageProdUrlBase + barcodeUrl
+        : OpenFoodAPIConfiguration.imageTestUrlBase + barcodeUrl;
   }
 }

--- a/lib/utils/ImageHelper.dart
+++ b/lib/utils/ImageHelper.dart
@@ -1,4 +1,5 @@
 import 'package:image/image.dart';
+import 'package:path/path.dart' as path;
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import '../model/ProductImage.dart';
@@ -64,19 +65,21 @@ class ImageHelper {
     final String barcode, {
     final QueryType? queryType,
   }) {
-    final String barcodeUrl;
+    final String barcodePath;
     if (barcode.length >= 9) {
       var p1 = barcode.substring(0, 3);
       var p2 = barcode.substring(3, 6);
       var p3 = barcode.substring(6, 9);
       var p4 = barcode.length >= 10 ? barcode.substring(9) : '';
-      barcodeUrl = p1 + '/' + p2 + '/' + p3 + '/' + p4;
+      barcodePath = p1 + '/' + p2 + '/' + p3 + '/' + p4;
     } else {
-      barcodeUrl = barcode;
+      barcodePath = barcode;
     }
 
-    return OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
-        ? OpenFoodAPIConfiguration.imageProdUrlBase + barcodeUrl
-        : OpenFoodAPIConfiguration.imageTestUrlBase + barcodeUrl;
+    return path.join(
+        (OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
+            ? OpenFoodAPIConfiguration.imageProdUrlBase
+            : OpenFoodAPIConfiguration.imageTestUrlBase),
+        barcodePath);
   }
 }

--- a/lib/utils/OpenFoodAPIConfiguration.dart
+++ b/lib/utils/OpenFoodAPIConfiguration.dart
@@ -29,6 +29,14 @@ class OpenFoodAPIConfiguration {
   ///Uri host of the test requests to the backend
   static String uriTestHost = 'world.openfoodfacts.net';
 
+  ///Url base for images in prod: needs to match the domain of uriProdHost
+  static String ImageProdUrlBase =
+      'https://static.openfoodfacts.org/images/products/';
+
+  ///Url base for images in test: needs to match the domain of uriTestHost
+  static String ImageTestUrlBase =
+      'https://off:off@static.openfoodfacts.net/images/products/';
+
   ///Uri host of the Robotoff requests to the backend, modify this to direct the request to a self-hosted instance.
   static String uriProdHostRobotoff = 'robotoff.openfoodfacts.org';
 

--- a/lib/utils/OpenFoodAPIConfiguration.dart
+++ b/lib/utils/OpenFoodAPIConfiguration.dart
@@ -27,7 +27,7 @@ class OpenFoodAPIConfiguration {
   static String uriProdHost = 'world.openfoodfacts.org';
 
   ///Uri host of the test requests to the backend
-  static String uriTestHost = 'world.openfoodfacts.dev';
+  static String uriTestHost = 'world.openfoodfacts.net';
 
   ///Url base for images in prod: needs to match the domain of uriProdHost
   static String imageProdUrlBase =
@@ -35,7 +35,7 @@ class OpenFoodAPIConfiguration {
 
   ///Url base for images in test: needs to match the domain of uriTestHost
   static String imageTestUrlBase =
-      'https://off:off@static.openfoodfacts.dev/images/products/';
+      'https://off:off@static.openfoodfacts.net/images/products/';
 
   ///Uri host of the Robotoff requests to the backend, modify this to direct the request to a self-hosted instance.
   static String uriProdHostRobotoff = 'robotoff.openfoodfacts.org';

--- a/lib/utils/OpenFoodAPIConfiguration.dart
+++ b/lib/utils/OpenFoodAPIConfiguration.dart
@@ -27,15 +27,15 @@ class OpenFoodAPIConfiguration {
   static String uriProdHost = 'world.openfoodfacts.org';
 
   ///Uri host of the test requests to the backend
-  static String uriTestHost = 'world.openfoodfacts.net';
+  static String uriTestHost = 'world.openfoodfacts.dev';
 
   ///Url base for images in prod: needs to match the domain of uriProdHost
-  static String ImageProdUrlBase =
+  static String imageProdUrlBase =
       'https://static.openfoodfacts.org/images/products/';
 
   ///Url base for images in test: needs to match the domain of uriTestHost
-  static String ImageTestUrlBase =
-      'https://off:off@static.openfoodfacts.net/images/products/';
+  static String imageTestUrlBase =
+      'https://off:off@static.openfoodfacts.dev/images/products/';
 
   ///Uri host of the Robotoff requests to the backend, modify this to direct the request to a self-hosted instance.
   static String uriProdHostRobotoff = 'robotoff.openfoodfacts.org';

--- a/lib/utils/OpenFoodAPIConfiguration.dart
+++ b/lib/utils/OpenFoodAPIConfiguration.dart
@@ -35,7 +35,7 @@ class OpenFoodAPIConfiguration {
 
   ///Url base for images in test: needs to match the domain of uriTestHost
   static String imageTestUrlBase =
-      'https://off:off@static.openfoodfacts.net/images/products/';
+      'https://static.openfoodfacts.net/images/products/';
 
   ///Uri host of the Robotoff requests to the backend, modify this to direct the request to a self-hosted instance.
   static String uriProdHostRobotoff = 'robotoff.openfoodfacts.org';

--- a/test/api_addProductImage_test.dart
+++ b/test/api_addProductImage_test.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'dart:math' as math;
 
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
@@ -17,7 +17,8 @@ void main() {
 
   /// Use a random barcode so that we can create a new product
   /// and really upload images
-  String barcode = (50000000000000 + Random().nextInt(100000000)).toString();
+  String barcode =
+      (50000000000000 + math.Random().nextInt(100000000)).toString();
 
   /// Returns the width and height (pixels) and size (bytes) of JPEG data
   ///

--- a/test/api_addProductImage_test.dart
+++ b/test/api_addProductImage_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
@@ -10,9 +12,13 @@ void main() {
   const User user = TestConstants.TEST_USER;
 
   /// Common constants for several image operations
-  const String barcode = '4250752200784';
   const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.GERMAN;
   const ImageField imageField = ImageField.FRONT;
+
+  /// Use a random barcode so that we can create a new product
+  /// and really upload images
+  var r = Random();
+  String barcode = (50000000000000 + r.nextInt(100000000)).toString();
 
   /// Returns the width and height (pixels) and size (bytes) of JPEG data
   ///
@@ -88,14 +94,28 @@ void main() {
         image,
       );
 
-      expect(status.status, 'status not ok');
-      expect(status.error, 'Dieses Foto wurde schon hochgeladen.');
+      expect(status.status, 'status ok');
     });
 
     test('add ingredients image test', () async {
       SendImage image = SendImage(
         lang: OpenFoodFactsLanguage.ENGLISH,
-        barcode: '0048151623426',
+        barcode: barcode,
+        imageField: ImageField.INGREDIENTS,
+        imageUri: Uri.file('test/test_assets/ingredients_en.jpg'),
+      );
+      Status status = await OpenFoodAPIClient.addProductImage(
+        user,
+        image,
+      );
+
+      expect(status.status, 'status ok');
+    });
+
+    test('add ingredients image test: resend same image', () async {
+      SendImage image = SendImage(
+        lang: OpenFoodFactsLanguage.ENGLISH,
+        barcode: barcode,
         imageField: ImageField.INGREDIENTS,
         imageUri: Uri.file('test/test_assets/ingredients_en.jpg'),
       );
@@ -111,13 +131,18 @@ void main() {
     test('read image', () async {
       //Get product without setting ProductField
       final ProductQueryConfiguration configurations =
-          ProductQueryConfiguration('7622210449283');
+          ProductQueryConfiguration(barcode);
       final ProductResult result = await OpenFoodAPIClient.getProduct(
         configurations,
         user: user,
       );
       expect(result.status, isNotNull);
       expect(result.product!.images, isNotEmpty);
+
+      // Note: product!.images contains only selected images with a ImageField
+      // the openfoodfacts-dart SDK currently does not support accessing
+      // the list of uploaded images with the uploader user id and uploaded_t
+      // timestamp.
     });
   });
 

--- a/test/api_addProductImage_test.dart
+++ b/test/api_addProductImage_test.dart
@@ -17,8 +17,7 @@ void main() {
 
   /// Use a random barcode so that we can create a new product
   /// and really upload images
-  var r = Random();
-  String barcode = (50000000000000 + r.nextInt(100000000)).toString();
+  String barcode = (50000000000000 + Random().nextInt(100000000)).toString();
 
   /// Returns the width and height (pixels) and size (bytes) of JPEG data
   ///


### PR DESCRIPTION
Related to #232 

The current image upload test does not update an image, because the product already has it. This PR uses a random barcode so that we can actually upload the image.
