### PR TITLE
feat: #132 - new method OpenFoodAPIClient.addProductFields

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -141,7 +141,7 @@ class OpenFoodAPIClient {
     QueryType? queryType,
   }) async {
     if (map.isEmpty) {
-      throw Exception('Empty map');
+      throw Exception('Please add at least one AddableProductField');
     }
 
     final Map<String, String> parameterMap = <String, String>{};

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -20,6 +20,7 @@ import 'package:openfoodfacts/model/TaxonomyLabel.dart';
 import 'package:openfoodfacts/model/TaxonomyLanguage.dart';
 import 'package:openfoodfacts/model/TaxonomyPackaging.dart';
 import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
+import 'package:openfoodfacts/utils/AddableProductFields.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/ImageHelper.dart';
 import 'package:openfoodfacts/utils/OcrField.dart';
@@ -124,6 +125,37 @@ class OpenFoodAPIClient {
     parameterMap.remove('nutriments');
     final Response response = await HttpHelper().doPostRequest(
       productUri,
+      parameterMap,
+      user,
+      queryType: queryType,
+    );
+    return Status.fromApiResponse(response.body);
+  }
+
+  /// Add the given product to the database.
+  /// Returns a Status object as result.
+  static Future<Status> addProductFields(
+    final User user,
+    final String barcode,
+    final Map<AddableProductField, String> map, {
+    QueryType? queryType,
+  }) async {
+    if (map.isEmpty) {
+      throw Exception('Empty map');
+    }
+
+    final Map<String, String> parameterMap = <String, String>{};
+    parameterMap.addAll(user.toData());
+    parameterMap['code'] = barcode;
+    for (final MapEntry<AddableProductField, String> entry in map.entries) {
+      parameterMap[entry.key.addableKey] = entry.value;
+    }
+
+    final Response response = await HttpHelper().doPostRequest(
+      UriHelper.getPostUri(
+        path: '/cgi/product_jqm2.pl',
+        queryType: queryType,
+      ),
       parameterMap,
       user,
       queryType: queryType,

--- a/lib/utils/AddableProductFields.dart
+++ b/lib/utils/AddableProductFields.dart
@@ -1,0 +1,17 @@
+/// Fields of a [Product] that can be simply added.
+enum AddableProductField {
+  BRANDS,
+  STORES,
+  COUNTRIES,
+}
+
+extension AddableProductFieldExtension on AddableProductField {
+  static const Map<AddableProductField, String> _KEYS = {
+    AddableProductField.BRANDS: 'add_brands',
+    AddableProductField.STORES: 'add_stores',
+    AddableProductField.COUNTRIES: 'add_countries',
+  };
+
+  /// Returns the key of the product field
+  String get addableKey => _KEYS[this] ?? '';
+}

--- a/lib/utils/AddableProductFields.dart
+++ b/lib/utils/AddableProductFields.dart
@@ -13,5 +13,5 @@ extension AddableProductFieldExtension on AddableProductField {
   };
 
   /// Returns the key of the product field
-  String get addableKey => _KEYS[this] ?? '';
+  String get addableKey => _KEYS[this]!;
 }

--- a/test/api_addProductFields_test.dart
+++ b/test/api_addProductFields_test.dart
@@ -1,0 +1,78 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/AddableProductFields.dart';
+import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
+import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
+import 'test_constants.dart';
+
+/// Unit/Integration tests around OpenFoodAPIClient.addProductFields
+void main() {
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+
+  group('$OpenFoodAPIClient add product fields', () {
+    const String barcode = '0048151623426';
+    const String initialBrand = 'Golden Cookies';
+    const List<String> additionalBrands = <String>['djobi', 'djoba'];
+    const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.ENGLISH;
+
+    test('add brand', () async {
+      late Status status;
+      late Product product;
+      late ProductResult productResult;
+      final ProductQueryConfiguration configurations =
+          ProductQueryConfiguration(
+        barcode,
+        language: language,
+        fields: [ProductField.ALL],
+      );
+
+      // brands from scratch
+      product = Product(
+        barcode: barcode,
+        lang: OpenFoodFactsLanguage.ENGLISH,
+        brands: initialBrand,
+      );
+      status = await OpenFoodAPIClient.saveProduct(
+        TestConstants.TEST_USER,
+        product,
+      );
+      expect(status.status, 1);
+      expect(status.statusVerbose, 'fields saved');
+
+      // cumulative list of brands
+      String expectedBrands = initialBrand;
+
+      productResult = await OpenFoodAPIClient.getProduct(
+        configurations,
+        user: TestConstants.TEST_USER,
+      );
+      expect(productResult.product, isNotNull);
+      expect(productResult.product!.brands, expectedBrands);
+
+      for (final String additionalBrand in additionalBrands) {
+        expectedBrands += ', $additionalBrand';
+
+        status = await OpenFoodAPIClient.addProductFields(
+          TestConstants.TEST_USER,
+          barcode,
+          <AddableProductField, String>{
+            AddableProductField.BRANDS: additionalBrand,
+          },
+        );
+        expect(status.status, 1);
+        expect(status.statusVerbose, 'fields saved');
+
+        productResult = await OpenFoodAPIClient.getProduct(
+          configurations,
+          user: TestConstants.TEST_USER,
+        );
+        expect(productResult.product, isNotNull);
+        expect(productResult.product!.brands, expectedBrands);
+      }
+    });
+  },
+      timeout: Timeout(
+        // some tests can be slow here
+        Duration(seconds: 90),
+      ));
+}


### PR DESCRIPTION
New files:
* `AddableProductFields.dart`: Fields of a `Product` that can be simply added.
* `api_addProductFields_test.dart`: Unit/Integration tests around `OpenFoodAPIClient.addProductFields`

Impacted file:
* `openfoodfacts.dart`: new method `addProductFields`

### What
- new method `OpenFoodAPIClient.addProductFields`

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1515
