### PR TITLE
feat: Barcodes validation for EAN8 & EAN13

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ dart test
 Here is a list of known apps using this SDK:
 
 - **Smoothie**. [GitHub](https://github.com/openfoodfacts/smooth-app) / Will soon be released
-- **Glutten Scan**. [Android](https://play.google.com/store/apps/details?id=com.healthyfood.gluten_free_app) / [iOS](https://apps.apple.com/ch/app/gluten-scanner/id1540660083?l=fr)
-- **Halal & Healthy**. [Android](https://play.google.com/store/apps/details?id=com.healthyfood.gluten_free_app) / [iOS](https://apps.apple.com/ch/app/halal-healthy/id1603051382?l=fr)
+- **Glutten Scan**. [Android](https://play.google.com/store/apps/details?id=com.healthyfood.gluten_free_app) / [iOS](https://apps.apple.com/ch/app/gluten-scanner/id1540660083)
+- **Halal & Healthy**. [Android](https://play.google.com/store/apps/details?id=com.TagIn.Tech.handh) / [iOS](https://apps.apple.com/ch/app/halal-healthy/id1603051382)
 - **Fitness Tracker**. [Android](https://play.google.com/store/apps/details?id=dk.cepk.fitness_tracker)
 
 Feel free to open a PR to add your application in this list.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dart package for the Open Food Facts API. Easily access to more than 1.9 million
 Open Food Facts is powered by contributors from around the world and is constantly growing thanks to them.
 
 ## How to use ?
-You can find the full documentation here : [Documentation](https://github.com/openfoodfacts/openfoodfacts-dart/blob/master/DOCUMENTATION.md).
+You can find the full documentation here: [Documentation](https://github.com/openfoodfacts/openfoodfacts-dart/blob/master/DOCUMENTATION.md).
 You can find automated code documentation here:  [Documentation](https://openfoodfacts.github.io/openfoodfacts-dart/).
 
 ## General principles
@@ -95,6 +95,17 @@ Execute the following command from the root of the repository to run the tests:
 ```
 dart test
 ```
+
+## Applications using this SDK
+
+Here is a list of known apps using this SDK:
+
+- **Smoothie**. [GitHub](https://github.com/openfoodfacts/smooth-app) / Will soon be released
+- **Glutten Scan**. [Android](https://play.google.com/store/apps/details?id=com.healthyfood.gluten_free_app) / [iOS](https://apps.apple.com/ch/app/gluten-scanner/id1540660083?l=fr)
+- **Halal & Healthy**. [Android](https://play.google.com/store/apps/details?id=com.healthyfood.gluten_free_app) / [iOS](https://apps.apple.com/ch/app/halal-healthy/id1603051382?l=fr)
+- **Fitness Tracker**. [Android](https://play.google.com/store/apps/details?id=dk.cepk.fitness_tracker)
+
+Feel free to open a PR to add your application in this list.
 
 ## Authors
 * Alexander Schacht - [Grumpf86](https://github.com/Grumpf86)

--- a/README.md
+++ b/README.md
@@ -98,14 +98,19 @@ dart test
 
 ## Applications using this SDK
 
-Here is a list of known apps using this SDK:
+### Official application
 
-- **Smoothie**. [GitHub](https://github.com/openfoodfacts/smooth-app) / Will soon be released
+**Smoothie** is the official developed by Open Food Facts, which will soon be released on Android and iOS. The source code is also available on [GitHub](https://github.com/openfoodfacts/smooth-app).
+
+### Third party applications
+
+Feel free to open a PR to add your application in this list.
+
 - **Glutten Scan**. [Android](https://play.google.com/store/apps/details?id=com.healthyfood.gluten_free_app) / [iOS](https://apps.apple.com/ch/app/gluten-scanner/id1540660083)
 - **Halal & Healthy**. [Android](https://play.google.com/store/apps/details?id=com.TagIn.Tech.handh) / [iOS](https://apps.apple.com/ch/app/halal-healthy/id1603051382)
 - **Fitness Tracker**. [Android](https://play.google.com/store/apps/details?id=dk.cepk.fitness_tracker)
 
-Feel free to open a PR to add your application in this list.
+
 
 ## Authors
 * Alexander Schacht - [Grumpf86](https://github.com/Grumpf86)

--- a/lib/utils/BarcodesValidator.dart
+++ b/lib/utils/BarcodesValidator.dart
@@ -1,0 +1,87 @@
+class BarcodeValidator {
+  const BarcodeValidator._();
+
+  /// EAN13 and EAN8 are only supported by the OFF API
+  static bool isValid(String? barcode) {
+    if (barcode == null) {
+      return false;
+    }
+
+    return _AbstractBarcodeValidator(barcode).isValid;
+  }
+}
+
+// Code freely inspired from
+// [https://commons.apache.org/proper/commons-validator/jacoco/org.apache.commons.validator.routines.checkdigit/]
+abstract class _AbstractBarcodeValidator {
+  static const int _CHAR_UNIT_ZERO = 48;
+  static const int _CHAR_UNIT_NINE = 57;
+
+  final String barcode;
+  final int modulus;
+
+  factory _AbstractBarcodeValidator(String barcode) {
+    if (_EANValidator.isEAN(barcode)) {
+      return _EANValidator(barcode);
+    }
+
+    throw Exception("Unsupported barcode type!");
+  }
+
+  const _AbstractBarcodeValidator._(this.modulus, this.barcode);
+
+  bool get isValid {
+    return _calculateModulus(barcode) == 0;
+  }
+
+  int _calculateModulus(String code) {
+    int total = 0;
+    for (int i = 0; i < code.length; i++) {
+      int lth = code.length;
+      int leftPos = i + 1;
+      int rightPos = lth - i;
+      int charValue = _charAsInt(code, i);
+      total += _weightedValue(charValue, leftPos, rightPos);
+    }
+
+    if (total == 0) {
+      throw Exception('Invalid code, sum is zero');
+    }
+
+    return total % modulus;
+  }
+
+  int _charAsInt(String code, int position) =>
+      code.codeUnitAt(position) - _CHAR_UNIT_ZERO;
+
+  int _weightedValue(int charValue, int leftPos, int rightPos);
+}
+
+class _EANValidator extends _AbstractBarcodeValidator {
+  static const List<int> _POSITION_WEIGHT = <int>[3, 1];
+  static const int _EAN8_LENGTH = 8;
+  static const int _EAN13_LENGTH = 13;
+
+  const _EANValidator(String barcode) : super._(10, barcode);
+
+  static bool isEAN(String barcode) {
+    return (barcode.length == _EAN8_LENGTH ||
+            barcode.length == _EAN13_LENGTH) &&
+        _isDigitsOnly(barcode);
+  }
+
+  static bool _isDigitsOnly(String str) {
+    for (int char in str.codeUnits) {
+      if (char < _AbstractBarcodeValidator._CHAR_UNIT_ZERO &&
+          char > _AbstractBarcodeValidator._CHAR_UNIT_NINE) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  int _weightedValue(int charValue, int leftPos, int rightPos) {
+    int weight = _POSITION_WEIGHT[rightPos % 2];
+    return charValue * weight;
+  }
+}

--- a/test/barcode_validator_test.dart
+++ b/test/barcode_validator_test.dart
@@ -1,0 +1,28 @@
+import 'package:openfoodfacts/utils/BarcodesValidator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EAN8', () {
+    test('Valid EAN8 barcodes', () {
+      expect(BarcodeValidator.isValid("12345670"), true);
+      expect(BarcodeValidator.isValid("47195127"), true);
+    });
+
+    test('Invalid EAN8 barcodes', () {
+      expect(BarcodeValidator.isValid("12345676"), false);
+      expect(BarcodeValidator.isValid("56987943"), false);
+    });
+  });
+
+  group('EAN13', () {
+    test('Valid EAN13 barcodes', () {
+      expect(BarcodeValidator.isValid("4719512002889"), true);
+      expect(BarcodeValidator.isValid("1234567890128"), true);
+    });
+
+    test('Invalid EAN13 barcodes', () {
+      expect(BarcodeValidator.isValid("4719512002884"), false);
+      expect(BarcodeValidator.isValid("1234567890127"), false);
+    });
+  });
+}


### PR DESCRIPTION
OFF only accepts EAN8 and EAN13 barcodes.
This PR allows to check if a barcode is valid.

My implementation is freely based on https://commons.apache.org/proper/commons-validator/, to allow potential evolutions.

To check if a barcode is valid, just call `BarcodeValidator.isValid("1234")`.

Will fix #439 