### PR TITLE
ci: Disable Add to GitHub Projects on forks

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -11,6 +11,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/add-to-project@main
         with:


### PR DESCRIPTION
### What
- Disable when token is not there