### PR TITLE
fix: Removed deprecated Product field imgSmallUrl

### DIFF
--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -136,11 +136,6 @@ class Product extends JsonObject {
   String? quantity;
 
   // Images
-  @JsonKey(name: 'image_small_url', includeIfNull: false)
-  // TODO: deprecated from 2021-04-06 (#152); remove when old enough
-  @Deprecated('Use imageFrontSmallUrl instead')
-  String? imgSmallUrl;
-
   @JsonKey(name: 'image_front_url', includeIfNull: false)
   String? imageFrontUrl;
   @JsonKey(name: 'image_front_small_url', includeIfNull: false)
@@ -374,7 +369,6 @@ class Product extends JsonObject {
       this.countriesTagsInLanguages,
       this.lang,
       this.quantity,
-      this.imgSmallUrl,
       this.imageFrontUrl,
       this.imageFrontSmallUrl,
       this.imageIngredientsUrl,

--- a/lib/model/Product.g.dart
+++ b/lib/model/Product.g.dart
@@ -24,7 +24,6 @@ Product _$ProductFromJson(Map<String, dynamic> json) => Product(
           json['countries_tags_in_languages']),
       lang: LanguageHelper.fromJson(json['lang'] as String?),
       quantity: json['quantity'] as String?,
-      imgSmallUrl: json['image_small_url'] as String?,
       imageFrontUrl: json['image_front_url'] as String?,
       imageFrontSmallUrl: json['image_front_small_url'] as String?,
       imageIngredientsUrl: json['image_ingredients_url'] as String?,
@@ -140,7 +139,6 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
       LanguageHelper.toJsonStringsListMap(instance.countriesTagsInLanguages));
   writeNotNull('lang', LanguageHelper.toJson(instance.lang));
   writeNotNull('quantity', instance.quantity);
-  writeNotNull('image_small_url', instance.imgSmallUrl);
   writeNotNull('image_front_url', instance.imageFrontUrl);
   writeNotNull('image_front_small_url', instance.imageFrontSmallUrl);
   writeNotNull('image_ingredients_url', instance.imageIngredientsUrl);

--- a/lib/utils/JsonHelper.dart
+++ b/lib/utils/JsonHelper.dart
@@ -84,7 +84,7 @@ class JsonHelper {
           JsonObject.parseInt(fieldObject['angle']),
         );
         final String? coordinatesImageSize =
-            fieldObject['coordinates_image_size']?.toString();
+            fieldObject['coordinates_image_size'];
         final int? x1 = JsonObject.parseInt(fieldObject['x1']);
         final int? y1 = JsonObject.parseInt(fieldObject['y1']);
         final int? x2 = JsonObject.parseInt(fieldObject['x2']);

--- a/lib/utils/JsonHelper.dart
+++ b/lib/utils/JsonHelper.dart
@@ -84,7 +84,7 @@ class JsonHelper {
           JsonObject.parseInt(fieldObject['angle']),
         );
         final String? coordinatesImageSize =
-            fieldObject['coordinates_image_size'];
+            fieldObject['coordinates_image_size']?.toString();
         final int? x1 = JsonObject.parseInt(fieldObject['x1']);
         final int? y1 = JsonObject.parseInt(fieldObject['y1']);
         final int? x2 = JsonObject.parseInt(fieldObject['x2']);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,13 +11,13 @@ dependencies:
   json_annotation: ^4.4.0
   http: ^0.13.3
   path: ^1.8.0
-  image: ^3.0.7
+  image: ^3.1.3
   meta: ^1.7.0
 
 dev_dependencies:
-  analyzer: ">=3.2.0 <5.0.0"
-  build_runner: ^2.1.7
-  json_serializable: ^6.1.4
+  analyzer: ">=4.0.0 <5.0.0"
+  build_runner: ^2.1.10
+  json_serializable: ^6.1.6
   lints: ^1.0.1
-  test: ^1.20.0
+  test: ^1.21.0
   coverage: ^1.2.0


### PR DESCRIPTION
Impacted files:
* `Product.dart`: removed a 1 year old deprecated field
* `Product.g.dart`: generated
* `pubspec.yaml`: upgraded

### What
- `Product` field `imgSmallUrl` has been deprecated for one year; it's fair to remove it now altogether.
- unrelated `pubspec.yaml` upgrade

[Edit: removed an unrelated file change]