### PR TITLE
fix: #447 - new class "PageNumber" replacing  ambiguous "Page" parameter

### DIFF
--- a/lib/model/parameter/Page.dart
+++ b/lib/model/parameter/Page.dart
@@ -1,14 +1,9 @@
-import 'package:openfoodfacts/interface/Parameter.dart';
+import 'package:openfoodfacts/model/parameter/PageNumber.dart';
 
-/// "Page number" search API parameter
-class Page extends Parameter {
-  @override
-  String getName() => 'page';
-
-  @override
-  String getValue() => page.toString();
-
-  final int page;
-
-  const Page({required this.page});
+// "Page number" search API parameter
+// The term "Page" is ambiguous (#447) and is in 'package:flutter/material.dart'
+// TODO: deprecated from 2022-04-20 (#447); remove when old enough
+@Deprecated("Use [PageNumber] instead")
+class Page extends PageNumber {
+  const Page({required int page}) : super(page: page);
 }

--- a/lib/model/parameter/PageNumber.dart
+++ b/lib/model/parameter/PageNumber.dart
@@ -1,0 +1,14 @@
+import 'package:openfoodfacts/interface/Parameter.dart';
+
+/// "Page number" search API parameter
+class PageNumber extends Parameter {
+  @override
+  String getName() => 'page';
+
+  @override
+  String getValue() => page.toString();
+
+  final int page;
+
+  const PageNumber({required this.page});
+}

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -74,6 +74,7 @@ export 'model/TaxonomyPackaging.dart';
 export 'model/User.dart';
 export 'model/parameter/OutputFormat.dart';
 export 'model/parameter/Page.dart';
+export 'model/parameter/PageNumber.dart';
 export 'model/parameter/PageSize.dart';
 export 'model/parameter/SearchSimple.dart';
 export 'model/parameter/SortBy.dart';

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -36,7 +36,7 @@ class ProductListQueryConfiguration extends AbstractQueryConfiguration {
       int? page, int? pageSize, SortOption? sortOption) {
     final result = <Parameter>[];
     if (page != null) {
-      result.add(Page(page: page));
+      result.add(PageNumber(page: page));
     }
     if (pageSize != null) {
       result.add(PageSize(size: pageSize));

--- a/test/api_searchProducts_test.dart
+++ b/test/api_searchProducts_test.dart
@@ -40,7 +40,7 @@ void main() {
 
     test('search favorite products', () async {
       final parameters = <Parameter>[
-        const Page(page: 1),
+        const PageNumber(page: 1),
         const PageSize(size: 10),
         const SortBy(option: SortOption.POPULARITY)
       ];
@@ -66,7 +66,7 @@ void main() {
 
     test('search favorite products EN', () async {
       final parameters = <Parameter>[
-        const Page(page: 14),
+        const PageNumber(page: 14),
         const PageSize(size: 3),
         const SortBy(option: SortOption.EDIT)
       ];
@@ -92,7 +92,7 @@ void main() {
 
     test('type bug : ingredient percent int vs String ', () async {
       final parameters = <Parameter>[
-        const Page(page: 16),
+        const PageNumber(page: 16),
         const PageSize(size: 5),
         const SortBy(option: SortOption.POPULARITY)
       ];
@@ -118,7 +118,7 @@ void main() {
 
     test('search products by keywords', () async {
       final List<Parameter> parameters = <Parameter>[
-        const Page(page: 2),
+        const PageNumber(page: 2),
         const PageSize(size: 10),
         const SearchTerms(terms: ['Kiwi'])
       ];
@@ -176,7 +176,7 @@ void main() {
 
     test('search products with filter on tags', () async {
       final parameters = <Parameter>[
-        const Page(page: 5),
+        const PageNumber(page: 5),
         const PageSize(size: 10),
         const SortBy(option: SortOption.PRODUCT_NAME),
         TagFilter.fromType(
@@ -384,7 +384,7 @@ void main() {
       );
 
       final parameters = <Parameter>[
-        const Page(page: 1),
+        const PageNumber(page: 1),
         const SearchTerms(terms: ['Quoted Coca "Cola"']),
       ];
 
@@ -486,7 +486,7 @@ void main() {
         fields: [ProductField.ALL],
         parametersList: [
           PnnsGroup2Filter(pnnsGroup2: PnnsGroup2.POTATOES),
-          Page(page: 3),
+          PageNumber(page: 3),
         ],
       );
 


### PR DESCRIPTION
New file:
* `PageNumber.dart`: "Page number" search API parameter.

Impacted files:
* `api_searchProducts_test.dart`: now using `PageNumber` instead of deprecated `Page`
* `openfoodfacts.dart`: exports new class `PageNumber`
* `Page.dart`: deprecated in favor of less ambiguous new class `PageNumber`
* `ProductListQueryConfiguration.dart`: now using `PageNumber` instead of deprecated `Page`

### What
- in #447 a developer had issues with a class named "Page" being in both openfoodfacts AND in `material.dart`
- there are ways to deal with that kind of issues, but it's fair to prevent bad interactions with capital packages like `material.dart`
- the solution was to create a new class with a less common name (`PageNumber`) and to deprecate the old one (`Page`)

### Fixes bug(s)
- #447