### PR TITLE
fix: postInsightAnnotation - consistency for QueryType parameter

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -624,7 +624,7 @@ class OpenFoodAPIClient {
     User? user,
     String? deviceId,
     bool update = true,
-    queryType = QueryType.PROD,
+    final QueryType? queryType,
   }) async {
     var insightUri = UriHelper.getRobotoffUri(
       path: 'api/v1/insights/annotate',


### PR DESCRIPTION
Impacted file:
* `openfoodfacts.dart`: removed irrelevant `postInsightAnnotation` default value for `QueryType`

### What
- While reviewing a smoothie PR (https://github.com/openfoodfacts/smooth-app/pull/1352), I noticed an inconsistency in the way we handled `QueryType` parameters in `openfoodfacts.dart`'s methods.
- I fixed that inconsistency.

### Part of 
- https://github.com/openfoodfacts/smooth-app/pull/1352