### PR TITLE
fix: Just send user id in from header

### DIFF
--- a/lib/utils/HttpHelper.dart
+++ b/lib/utils/HttpHelper.dart
@@ -167,7 +167,7 @@ class HttpHelper {
       'Accept': 'application/json',
       'UserAgent':
           OpenFoodAPIConfiguration.userAgent?.toValueString() ?? USER_AGENT,
-      'From': OpenFoodAPIConfiguration.getUser(user)?.toValueString() ?? FROM,
+      'From': OpenFoodAPIConfiguration.getUser(user)?.userId ?? FROM,
     });
 
     if (isTestModeActive) {


### PR DESCRIPTION
### What
- The author is currently not honored for fixes since we send the whole object not just the user id
