### PR TITLE
feat: #524 - added ingredients analysis tags (vegan, vegetarian, palm oil free)

### DIFF
--- a/lib/model/IngredientsAnalysisTags.dart
+++ b/lib/model/IngredientsAnalysisTags.dart
@@ -5,11 +5,31 @@ enum VeganStatus {
   VEGAN_STATUS_UNKNOWN,
 }
 
+extension VeganStatusExtension on VeganStatus {
+  static const Map<VeganStatus, String> _tags = {
+    VeganStatus.VEGAN: 'en:vegan',
+    VeganStatus.NON_VEGAN: 'en:non-vegan',
+    VeganStatus.MAYBE_VEGAN: 'en:maybe-vegan',
+    VeganStatus.VEGAN_STATUS_UNKNOWN: 'en:vegan-status-unknown',
+  };
+  String get tag => _tags[this]!;
+}
+
 enum VegetarianStatus {
   VEGETARIAN,
   NON_VEGETARIAN,
   MAYBE_VEGETARIAN,
   VEGETARIAN_STATUS_UNKNOWN,
+}
+
+extension VegetarianStatusExtension on VegetarianStatus {
+  static const Map<VegetarianStatus, String> _tags = {
+    VegetarianStatus.VEGETARIAN: 'en:vegetarian',
+    VegetarianStatus.NON_VEGETARIAN: 'en:non-vegetarian',
+    VegetarianStatus.MAYBE_VEGETARIAN: 'en:maybe-vegetarian',
+    VegetarianStatus.VEGETARIAN_STATUS_UNKNOWN: 'en:vegetarian-status-unknown',
+  };
+  String get tag => _tags[this]!;
 }
 
 enum PalmOilFreeStatus {
@@ -19,6 +39,16 @@ enum PalmOilFreeStatus {
   PALM_OIL_CONTENT_UNKNOWN,
 }
 
+extension PalmOilFreeStatusExtension on PalmOilFreeStatus {
+  static const Map<PalmOilFreeStatus, String> _tags = {
+    PalmOilFreeStatus.PALM_OIL_FREE: 'en:palm-oil-free',
+    PalmOilFreeStatus.PALM_OIL: 'en:palm-oil',
+    PalmOilFreeStatus.MAY_CONTAIN_PALM_OIL: 'en:may-contain-palm-oil',
+    PalmOilFreeStatus.PALM_OIL_CONTENT_UNKNOWN: 'en:palm-oil-content-unknown',
+  };
+  String get tag => _tags[this]!;
+}
+
 class IngredientsAnalysisTags {
   IngredientsAnalysisTags(List<dynamic> data) {
     veganStatus = _getVeganStatus(data);
@@ -26,76 +56,31 @@ class IngredientsAnalysisTags {
     palmOilFreeStatus = _getPalmOilFreeStatus(data);
   }
 
-  static const List<String> _VEGAN_TAGS = [
-    'en:vegan',
-    'en:non-vegan',
-    'en:maybe-vegan',
-    'en:vegan-status-unknown',
-  ];
-
-  static const List<VeganStatus> _VEGAN_STATUSES = [
-    VeganStatus.VEGAN,
-    VeganStatus.NON_VEGAN,
-    VeganStatus.MAYBE_VEGAN,
-    VeganStatus.VEGAN_STATUS_UNKNOWN,
-  ];
-
-  static const List<String> _VEGETARIAN_TAGS = [
-    'en:vegetarian',
-    'en:non-vegetarian',
-    'en:maybe-vegetarian',
-    'en:vegetarian-status-unknown',
-  ];
-
-  static const List<VegetarianStatus> _VEGETARIAN_STATUSES = [
-    VegetarianStatus.VEGETARIAN,
-    VegetarianStatus.NON_VEGETARIAN,
-    VegetarianStatus.MAYBE_VEGETARIAN,
-    VegetarianStatus.VEGETARIAN_STATUS_UNKNOWN,
-  ];
-
-  static const List<String> _PALM_OIL_FREE_TAGS = [
-    'en:palm-oil-free',
-    'en:palm-oil',
-    'en:may-contain-palm-oil',
-    'en:palm-oil-content-unknown',
-  ];
-
-  static const List<PalmOilFreeStatus> _PALM_OIL_FREE_STATUSES = [
-    PalmOilFreeStatus.PALM_OIL_FREE,
-    PalmOilFreeStatus.PALM_OIL,
-    PalmOilFreeStatus.MAY_CONTAIN_PALM_OIL,
-    PalmOilFreeStatus.PALM_OIL_CONTENT_UNKNOWN,
-  ];
-
   static VeganStatus? _getVeganStatus(List<dynamic> data) {
-    VeganStatus? result;
-    _VEGAN_TAGS.asMap().forEach((key, value) {
-      if (data.contains(value)) {
-        result = _VEGAN_STATUSES[key];
+    for (final VeganStatus status in VeganStatus.values) {
+      if (data.contains(status.tag)) {
+        return status;
       }
-    });
-    return result;
+    }
+    return null;
   }
 
   static VegetarianStatus? _getVegetarianStatus(List<dynamic> data) {
-    VegetarianStatus? result;
-    _VEGETARIAN_TAGS.asMap().forEach((key, value) {
-      if (data.contains(value)) {
-        result = _VEGETARIAN_STATUSES[key];
+    for (final VegetarianStatus status in VegetarianStatus.values) {
+      if (data.contains(status.tag)) {
+        return status;
       }
-    });
-    return result;
+    }
+    return null;
   }
 
   static PalmOilFreeStatus? _getPalmOilFreeStatus(List<dynamic> data) {
-    PalmOilFreeStatus? result;
-    _PALM_OIL_FREE_TAGS.asMap().forEach((key, value) {
-      if (data.contains(value)) {
-        result = _PALM_OIL_FREE_STATUSES[key];
+    for (final PalmOilFreeStatus status in PalmOilFreeStatus.values) {
+      if (data.contains(status.tag)) {
+        return status;
       }
-    });
-    return result;
+    }
+    return null;
   }
 
   VeganStatus? veganStatus;
@@ -113,23 +98,15 @@ class IngredientsAnalysisTags {
       return result;
     }
 
-    _VEGAN_STATUSES.asMap().forEach((key, value) {
-      if (ingredientsAnalysisTags.veganStatus == value) {
-        result.add(_VEGAN_TAGS[key]);
-      }
-    });
-
-    _VEGETARIAN_STATUSES.asMap().forEach((key, value) {
-      if (ingredientsAnalysisTags.vegetarianStatus == value) {
-        result.add(_VEGETARIAN_TAGS[key]);
-      }
-    });
-
-    _PALM_OIL_FREE_STATUSES.asMap().forEach((key, value) {
-      if (ingredientsAnalysisTags.palmOilFreeStatus == value) {
-        result.add(_PALM_OIL_FREE_TAGS[key]);
-      }
-    });
+    if (ingredientsAnalysisTags.veganStatus != null) {
+      result.add(ingredientsAnalysisTags.veganStatus!.tag);
+    }
+    if (ingredientsAnalysisTags.vegetarianStatus != null) {
+      result.add(ingredientsAnalysisTags.vegetarianStatus!.tag);
+    }
+    if (ingredientsAnalysisTags.palmOilFreeStatus != null) {
+      result.add(ingredientsAnalysisTags.palmOilFreeStatus!.tag);
+    }
 
     return result;
   }

--- a/lib/model/parameter/IngredientsAnalysisParameter.dart
+++ b/lib/model/parameter/IngredientsAnalysisParameter.dart
@@ -1,0 +1,36 @@
+import 'package:openfoodfacts/interface/Parameter.dart';
+import 'package:openfoodfacts/model/IngredientsAnalysisTags.dart';
+
+/// Ingredients Analysis search API parameter.
+class IngredientsAnalysisParameter extends Parameter {
+  @override
+  String getName() => 'ingredients_analysis_tags';
+
+  @override
+  String getValue() {
+    final List<String> result = <String>[];
+    if (veganStatus != null) {
+      result.add(veganStatus!.tag);
+    }
+    if (vegetarianStatus != null) {
+      result.add(vegetarianStatus!.tag);
+    }
+    if (palmOilFreeStatus != null) {
+      result.add(palmOilFreeStatus!.tag);
+    }
+    if (result.isEmpty) {
+      return '';
+    }
+    return result.join(',');
+  }
+
+  final VeganStatus? veganStatus;
+  final VegetarianStatus? vegetarianStatus;
+  final PalmOilFreeStatus? palmOilFreeStatus;
+
+  const IngredientsAnalysisParameter({
+    this.veganStatus,
+    this.vegetarianStatus,
+    this.palmOilFreeStatus,
+  });
+}

--- a/test/api_searchProducts_test.dart
+++ b/test/api_searchProducts_test.dart
@@ -1,3 +1,7 @@
+import 'dart:math';
+
+import 'package:openfoodfacts/model/IngredientsAnalysisTags.dart';
+import 'package:openfoodfacts/model/parameter/IngredientsAnalysisParameter.dart';
 import 'package:openfoodfacts/model/parameter/PnnsGroup2Filter.dart';
 import 'package:openfoodfacts/model/parameter/SearchTerms.dart';
 import 'package:openfoodfacts/model/parameter/TagFilter.dart';
@@ -89,6 +93,150 @@ void main() {
       expect(result.products![0].runtimeType, Product);
       expect(result.count, greaterThan(30000));
     });
+
+    /// Returns the total number of products, and checks if the statuses match.
+    Future<int?> _checkIngredientsAnalysis(
+      final VeganStatus? veganStatus,
+      final VegetarianStatus? vegetarianStatus,
+      final PalmOilFreeStatus? palmOilFreeStatus,
+    ) async {
+      if (veganStatus == null &&
+          vegetarianStatus == null &&
+          palmOilFreeStatus == null) {
+        return null;
+      }
+
+      final List<Parameter> parameters = <Parameter>[
+        const PageNumber(page: 1),
+        const PageSize(size: 100),
+        IngredientsAnalysisParameter(
+          veganStatus: veganStatus,
+          vegetarianStatus: vegetarianStatus,
+          palmOilFreeStatus: palmOilFreeStatus,
+        ),
+      ];
+
+      final ProductSearchQueryConfiguration configuration =
+          ProductSearchQueryConfiguration(
+        parametersList: parameters,
+        fields: [
+          ProductField.BARCODE,
+          ProductField.INGREDIENTS_ANALYSIS_TAGS,
+        ],
+        language: OpenFoodFactsLanguage.FRENCH,
+        country: OpenFoodFactsCountry.FRANCE,
+      );
+
+      final SearchResult result = await OpenFoodAPIClient.searchProducts(
+        TestConstants.PROD_USER,
+        configuration,
+        queryType: QueryType.PROD,
+      );
+
+      expect(result.products, isNotNull);
+      for (final Product product in result.products!) {
+        if (veganStatus != null) {
+          expect(
+            product.ingredientsAnalysisTags!.veganStatus,
+            veganStatus,
+          );
+        }
+        if (vegetarianStatus != null) {
+          expect(
+            product.ingredientsAnalysisTags!.vegetarianStatus,
+            vegetarianStatus,
+          );
+        }
+        if (palmOilFreeStatus != null) {
+          expect(
+            product.ingredientsAnalysisTags!.palmOilFreeStatus,
+            palmOilFreeStatus,
+          );
+        }
+      }
+      return result.count!;
+    }
+
+    test('check vegan search', () async {
+      for (final VeganStatus status in VeganStatus.values) {
+        await _checkIngredientsAnalysis(status, null, null);
+      }
+    },
+        timeout: Timeout(
+          // some tests can be slow here
+          Duration(seconds: 90),
+        ));
+
+    test('check vegetarian search', () async {
+      for (final VegetarianStatus status in VegetarianStatus.values) {
+        await _checkIngredientsAnalysis(null, status, null);
+      }
+    },
+        timeout: Timeout(
+          // some tests can be slow here
+          Duration(seconds: 90),
+        ));
+
+    test('check palm oil search', () async {
+      for (final PalmOilFreeStatus status in PalmOilFreeStatus.values) {
+        await _checkIngredientsAnalysis(null, null, status);
+      }
+    },
+        timeout: Timeout(
+          // some tests can be slow here
+          Duration(seconds: 90),
+        ));
+
+    test('check random vegan+vegetarian+palm oil search', () async {
+      final Random random = Random();
+      final int veganIndex = random.nextInt(VeganStatus.values.length);
+      final int vegetarianIndex =
+          random.nextInt(VegetarianStatus.values.length);
+      final int palmOilFreeIndex =
+          random.nextInt(PalmOilFreeStatus.values.length);
+      await _checkIngredientsAnalysis(
+        VeganStatus.values[veganIndex],
+        VegetarianStatus.values[vegetarianIndex],
+        PalmOilFreeStatus.values[palmOilFreeIndex],
+      );
+    },
+        timeout: Timeout(
+          // some tests can be slow here
+          Duration(seconds: 90),
+        ));
+
+    /// If you know it's not vegetarian, then it can't be vegan at all.
+    test('check vegan/vegetarian consistency', () async {
+      const VegetarianStatus nonVegetarian = VegetarianStatus.NON_VEGETARIAN;
+      expect(
+        await _checkIngredientsAnalysis(
+          VeganStatus.VEGAN,
+          nonVegetarian,
+          null,
+        ),
+        0,
+      );
+      expect(
+        await _checkIngredientsAnalysis(
+          VeganStatus.MAYBE_VEGAN,
+          nonVegetarian,
+          null,
+        ),
+        0,
+      );
+      expect(
+        await _checkIngredientsAnalysis(
+          VeganStatus.VEGAN_STATUS_UNKNOWN,
+          nonVegetarian,
+          null,
+        ),
+        0,
+      );
+    },
+        timeout: Timeout(
+          // some tests can be slow here
+          Duration(seconds: 90),
+        ));
 
     test('type bug : ingredient percent int vs String ', () async {
       final parameters = <Parameter>[


### PR DESCRIPTION
New file:
* `IngredientsAnalysisParameter.dart`: Ingredients Analysis search API parameter.

Impacted files:
* `api_searchProducts_test.dart`: added tests related to new parameter `IngredientsAnalysisParameter`
* `IngredientsAnalysisTags.dart`: refactored with `extension`, needed for reusability.

### What
- Now we have a new parameter, in order to restrict ingredients analysis tags
- E.g. vegan(yes/no/maybe/unknown), vegetarian(yes/no/maybe/unknown), palm oil free (yes/no/maybe/unknown)
- The parameters can be combined. One test is even checking that if a product is "not vegetarian", then it cannot be (yes/maybe/unknown) for vegan (as it must be "not vegan").

### Closes issue
- Closes #524
