### PR TITLE
feat: #526 - new AllergensParameter search filter

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -12,4 +12,4 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v1.5.0
+      - uses: toshimaru/auto-author-assign@v1.5.1

--- a/lib/model/Allergens.dart
+++ b/lib/model/Allergens.dart
@@ -1,6 +1,52 @@
+/// Main allergens.
+enum AllergensTag {
+  GLUTEN,
+  MILK,
+  EGGS,
+  NUTS,
+  PEANUTS,
+  SESAME_SEEDS,
+  SOYBEANS,
+  CELERY,
+  MUSTARD,
+  LUPIN,
+  FISH,
+  CRUSTACEANS,
+  MOLLUSCS,
+  SULPHUR_DIOXIDE_AND_SULPHITES,
+}
+
+extension AllergensTagExtension on AllergensTag {
+  static const Map<AllergensTag, String> _tags = <AllergensTag, String>{
+    AllergensTag.GLUTEN: 'en:gluten',
+    AllergensTag.MILK: 'en:milk',
+    AllergensTag.EGGS: 'en:eggs',
+    AllergensTag.NUTS: 'en:nuts',
+    AllergensTag.PEANUTS: 'en:peanuts',
+    AllergensTag.SESAME_SEEDS: 'en:sesame-seeds',
+    AllergensTag.SOYBEANS: 'en:soybeans',
+    AllergensTag.CELERY: 'en:celery',
+    AllergensTag.MUSTARD: 'en:mustard',
+    AllergensTag.LUPIN: 'en:lupin',
+    AllergensTag.FISH: 'en:fish',
+    AllergensTag.CRUSTACEANS: 'en:crustaceans',
+    AllergensTag.MOLLUSCS: 'en:molluscs',
+    AllergensTag.SULPHUR_DIOXIDE_AND_SULPHITES:
+        'en:sulphur-dioxide-and-sulphites',
+  };
+  String get tag => _tags[this]!;
+}
+
+/// List of known allergens for a [Product].
+///
+/// If we are lucky, we get values that match with [AllergensTag].
+/// If we are less lucky, we have more exotic values.
 class Allergens {
-  List<String> ids; // allergen id formatted as 'en:gluten'
-  List<String> names; // allergen name formatted as 'gluten'
+  /// Allergen id formatted as 'en:gluten', like in [AllergensTag] tag.
+  List<String> ids;
+
+  /// Allergen name formatted as 'gluten'
+  List<String> names;
 
   Allergens(this.ids, this.names);
 

--- a/lib/model/parameter/AllergensParameter.dart
+++ b/lib/model/parameter/AllergensParameter.dart
@@ -1,0 +1,29 @@
+import 'package:openfoodfacts/interface/Parameter.dart';
+import 'package:openfoodfacts/model/Allergens.dart';
+
+/// List of allergens to filter in and out. Filter combo mode is 'AND'.
+class AllergensParameter extends Parameter {
+  @override
+  String getName() => 'allergens_tags';
+
+  @override
+  String getValue() {
+    final List<String> result = <String>[];
+    if (include != null) {
+      for (final AllergensTag value in include!) {
+        result.add(value.tag);
+      }
+    }
+    if (exclude != null) {
+      for (final AllergensTag value in exclude!) {
+        result.add('-${value.tag}');
+      }
+    }
+    return result.join(',');
+  }
+
+  final Iterable<AllergensTag>? include;
+  final Iterable<AllergensTag>? exclude;
+
+  const AllergensParameter({this.include, this.exclude});
+}

--- a/lib/model/parameter/AllergensParameter.dart
+++ b/lib/model/parameter/AllergensParameter.dart
@@ -1,7 +1,9 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 import 'package:openfoodfacts/model/Allergens.dart';
 
-/// List of allergens to filter in and out. Filter combo mode is 'AND'.
+/// List of allergens to filter in and out.
+///
+/// When we have several items, the results returned use a logical AND.
 class AllergensParameter extends Parameter {
   @override
   String getName() => 'allergens_tags';

--- a/test/api_searchProducts_test.dart
+++ b/test/api_searchProducts_test.dart
@@ -1,3 +1,7 @@
+import 'dart:math';
+
+import 'package:openfoodfacts/model/Allergens.dart';
+import 'package:openfoodfacts/model/parameter/AllergensParameter.dart';
 import 'package:openfoodfacts/model/parameter/PnnsGroup2Filter.dart';
 import 'package:openfoodfacts/model/parameter/SearchTerms.dart';
 import 'package:openfoodfacts/model/parameter/TagFilter.dart';
@@ -561,4 +565,172 @@ void main() {
       expect(result.products!.length, BARCODES.length - 1);
     });
   });
+
+  group('$OpenFoodAPIClient search products with/without allergens', () {
+    /// Returns the total number of products, and checks the allergens.
+    Future<int> _checkAllergens(
+      final AllergensParameter allergensParameter,
+    ) async {
+      final List<Parameter> parameters = <Parameter>[
+        const PageNumber(page: 1),
+        const PageSize(size: 100),
+        allergensParameter,
+      ];
+
+      final ProductSearchQueryConfiguration configuration =
+          ProductSearchQueryConfiguration(
+        parametersList: parameters,
+        fields: [ProductField.BARCODE, ProductField.ALLERGENS],
+        language: OpenFoodFactsLanguage.FRENCH,
+        country: OpenFoodFactsCountry.FRANCE,
+      );
+
+      final SearchResult result = await OpenFoodAPIClient.searchProducts(
+        TestConstants.PROD_USER,
+        configuration,
+        queryType: QueryType.PROD,
+      );
+
+      expect(result.count, isNotNull);
+
+      expect(result.products, isNotNull);
+      for (final Product product in result.products!) {
+        expect(product.allergens, isNotNull);
+        if (allergensParameter.include != null &&
+            allergensParameter.include!.isNotEmpty) {
+          expect(product.allergens!.ids, isNotNull);
+          for (final AllergensTag tag in allergensParameter.include!) {
+            expect(product.allergens!.ids, contains(tag.tag));
+          }
+        }
+        if (allergensParameter.exclude != null &&
+            allergensParameter.exclude!.isNotEmpty) {
+          expect(product.allergens!.ids, isNotNull);
+          for (final AllergensTag tag in allergensParameter.exclude!) {
+            expect(product.allergens!.ids, isNot(contains(tag.tag)));
+          }
+        }
+      }
+
+      return result.count!;
+    }
+
+    /// Returns random and different int's.
+    List<int> _getRandomInts({
+      required int count,
+      required final int max,
+    }) {
+      final Random random = Random();
+      final List<int> result = <int>[];
+      if (count > max) {
+        count = max;
+      }
+      for (int i = 0; i < count; i++) {
+        int index = random.nextInt(max);
+        while (result.contains(index)) {
+          index = (index + 1) % max;
+        }
+        result.add(index);
+      }
+      return result;
+    }
+
+    test('check products with allergens', () async {
+      for (final AllergensTag tag in AllergensTag.values) {
+        final int count = await _checkAllergens(
+          AllergensParameter(include: [tag]),
+        );
+        expect(count, greaterThan(0));
+      }
+    });
+
+    test('check products without allergens', () async {
+      for (final AllergensTag tag in AllergensTag.values) {
+        final int count = await _checkAllergens(
+          AllergensParameter(exclude: [tag]),
+        );
+        expect(count, greaterThan(0));
+      }
+    });
+
+    test('check products with and without the same allergens', () async {
+      for (final AllergensTag tag in AllergensTag.values) {
+        final int count = await _checkAllergens(
+          AllergensParameter(include: [tag], exclude: [tag]),
+        );
+        // it's an AND: with both conditions we always get 0 products.
+        expect(count, 0);
+      }
+    });
+
+    test('check products with random 2 allergens', () async {
+      final List<int> indices = _getRandomInts(
+        count: 2,
+        max: AllergensTag.values.length,
+      );
+      final int count1 = await _checkAllergens(
+        AllergensParameter(
+          include: [
+            AllergensTag.values[indices[0]],
+          ],
+        ),
+      );
+      final int count2 = await _checkAllergens(
+        AllergensParameter(
+          include: [
+            AllergensTag.values[indices[1]],
+          ],
+        ),
+      );
+      final int countBoth = await _checkAllergens(
+        AllergensParameter(
+          include: [
+            AllergensTag.values[indices[0]],
+            AllergensTag.values[indices[1]],
+          ],
+        ),
+      );
+      // it's an AND: with both conditions we always get less results.
+      expect(countBoth, lessThanOrEqualTo(count1));
+      expect(countBoth, lessThanOrEqualTo(count2));
+    });
+
+    test('check products with and without random 2 allergens', () async {
+      final List<int> indices = _getRandomInts(
+        count: 2,
+        max: AllergensTag.values.length,
+      );
+      final int count1 = await _checkAllergens(
+        AllergensParameter(
+          include: [
+            AllergensTag.values[indices[0]],
+          ],
+        ),
+      );
+      final int count2 = await _checkAllergens(
+        AllergensParameter(
+          exclude: [
+            AllergensTag.values[indices[1]],
+          ],
+        ),
+      );
+      final int countBoth = await _checkAllergens(
+        AllergensParameter(
+          include: [
+            AllergensTag.values[indices[0]],
+          ],
+          exclude: [
+            AllergensTag.values[indices[1]],
+          ],
+        ),
+      );
+      // it's an AND: with both conditions we always get less results.
+      expect(countBoth, lessThanOrEqualTo(count1));
+      expect(countBoth, lessThanOrEqualTo(count2));
+    });
+  },
+      timeout: Timeout(
+        // some tests can be slow here
+        Duration(seconds: 240),
+      ));
 }


### PR DESCRIPTION
New file:
* `AllergensParameter.dart`: List of allergens to filter in and out. Filter combo mode is 'AND'.

Impacted files:
* `Allergens.dart`: added `AllergensTag` for the 14 main allergens.
* `api_searchProducts_test.dart`: added a group and 5 tests around the new `AllergensParameter` API parameter.

### What
- New class `AllergensParameter` for the search API.
- With that we can restrict to products with and/or without allergens among the 14 main allergens.

### Closes issue
- #526
