### PR TITLE
feat: new "Barcodes" parameter; deprecated configurations

### DIFF
--- a/lib/model/parameter/AllergensParameter.dart
+++ b/lib/model/parameter/AllergensParameter.dart
@@ -1,31 +1,17 @@
-import 'package:openfoodfacts/interface/Parameter.dart';
 import 'package:openfoodfacts/model/Allergens.dart';
+import 'package:openfoodfacts/model/parameter/BoolMapParameter.dart';
 
 /// List of allergens to filter in and out.
 ///
 /// When we have several items, the results returned use a logical AND.
-class AllergensParameter extends Parameter {
+class AllergensParameter extends BoolMapParameter<AllergensTag> {
   @override
   String getName() => 'allergens_tags';
 
   @override
-  String getValue() {
-    final List<String> result = <String>[];
-    if (include != null) {
-      for (final AllergensTag value in include!) {
-        result.add(value.tag);
-      }
-    }
-    if (exclude != null) {
-      for (final AllergensTag value in exclude!) {
-        result.add('-${value.tag}');
-      }
-    }
-    return result.join(',');
-  }
+  String getTag(final AllergensTag key, final bool value) =>
+      value ? key.tag : '-${key.tag}';
 
-  final Iterable<AllergensTag>? include;
-  final Iterable<AllergensTag>? exclude;
-
-  const AllergensParameter({this.include, this.exclude});
+  const AllergensParameter({required final Map<AllergensTag, bool> map})
+      : super(map: map);
 }

--- a/lib/model/parameter/BarcodeParameter.dart
+++ b/lib/model/parameter/BarcodeParameter.dart
@@ -1,7 +1,7 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
 
 /// "Barcodes" search API parameter.
-class Barcodes extends Parameter {
+class BarcodeParameter extends Parameter {
   @override
   String getName() => 'code';
 
@@ -10,7 +10,7 @@ class Barcodes extends Parameter {
 
   final List<String> codes;
 
-  Barcodes(final String code) : this.list([code]);
+  BarcodeParameter(final String code) : this.list([code]);
 
-  const Barcodes.list(this.codes);
+  const BarcodeParameter.list(this.codes);
 }

--- a/lib/model/parameter/Barcodes.dart
+++ b/lib/model/parameter/Barcodes.dart
@@ -1,0 +1,16 @@
+import 'package:openfoodfacts/interface/Parameter.dart';
+
+/// "Barcodes" search API parameter.
+class Barcodes extends Parameter {
+  @override
+  String getName() => 'code';
+
+  @override
+  String getValue() => codes.join(',');
+
+  final List<String> codes;
+
+  Barcodes(final String code) : this.list([code]);
+
+  const Barcodes.list(this.codes);
+}

--- a/lib/model/parameter/BoolMapParameter.dart
+++ b/lib/model/parameter/BoolMapParameter.dart
@@ -1,0 +1,28 @@
+import 'package:openfoodfacts/interface/Parameter.dart';
+import 'package:meta/meta.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+
+/// Abstract map of [bool] as [Parameter].
+///
+/// Typical use-case with objects that have an on/off quality,
+/// like "with/without gluten".
+/// A query like "I want the products with eggs but without gluten" would be
+/// something like "{'eggs': true, 'gluten': false}".
+abstract class BoolMapParameter<T> extends Parameter {
+  const BoolMapParameter({required this.map});
+
+  final Map<T, bool> map;
+
+  @override
+  String getValue() {
+    final List<String> result = <String>[];
+    for (final MapEntry<T, bool> item in map.entries) {
+      result.add(getTag(item.key, item.value));
+    }
+    return result.join(',');
+  }
+
+  /// Returns the tag as on or off, like "gluten:with" or "gluten:without"
+  @protected
+  String getTag(final T key, final bool value);
+}

--- a/lib/model/parameter/StatesTagsParameter.dart
+++ b/lib/model/parameter/StatesTagsParameter.dart
@@ -1,26 +1,14 @@
-import 'package:openfoodfacts/interface/Parameter.dart';
 import 'package:openfoodfacts/model/State.dart';
+import 'package:openfoodfacts/model/parameter/BoolMapParameter.dart';
 
 /// States Tags as completed or to-be-completed.
-class StatesTagsParameter extends Parameter {
+class StatesTagsParameter extends BoolMapParameter<State> {
   @override
   String getName() => 'states_tags';
 
   @override
-  String getValue() {
-    final List<String> result = <String>[];
-    for (final MapEntry<State, bool> item in completed.entries) {
-      result.add(
-        item.value ? item.key.completedTag : item.key.toBeCompletedTag,
-      );
-    }
-    return result.join(',');
-  }
+  String getTag(final State key, final bool value) =>
+      value ? key.completedTag : key.toBeCompletedTag;
 
-  /// [State]s to be considered as completed (true) or to-be-completed (false).
-  ///
-  /// When we have several items, the results returned use a logical AND.
-  final Map<State, bool> completed;
-
-  StatesTagsParameter({required this.completed});
+  StatesTagsParameter({required final Map<State, bool> map}) : super(map: map);
 }

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -21,12 +21,14 @@ import 'package:openfoodfacts/model/TaxonomyIngredient.dart';
 import 'package:openfoodfacts/model/TaxonomyLabel.dart';
 import 'package:openfoodfacts/model/TaxonomyLanguage.dart';
 import 'package:openfoodfacts/model/TaxonomyPackaging.dart';
+import 'package:openfoodfacts/model/parameter/Barcodes.dart';
 import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/ImageHelper.dart';
 import 'package:openfoodfacts/utils/OcrField.dart';
 import 'package:openfoodfacts/utils/ProductFields.dart';
 import 'package:openfoodfacts/utils/ProductListQueryConfiguration.dart';
+import 'package:openfoodfacts/utils/ProductSearchQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
 import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
@@ -334,8 +336,8 @@ class OpenFoodAPIClient {
   }) async {
     final SearchResult searchResult = await searchProducts(
       user,
-      ProductListQueryConfiguration(
-        barcodes,
+      ProductSearchQueryConfiguration(
+        parametersList: [Barcodes.list(barcodes)],
         language: language,
         country: country,
         fields: [

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -21,7 +21,7 @@ import 'package:openfoodfacts/model/TaxonomyIngredient.dart';
 import 'package:openfoodfacts/model/TaxonomyLabel.dart';
 import 'package:openfoodfacts/model/TaxonomyLanguage.dart';
 import 'package:openfoodfacts/model/TaxonomyPackaging.dart';
-import 'package:openfoodfacts/model/parameter/Barcodes.dart';
+import 'package:openfoodfacts/model/parameter/BarcodeParameter.dart';
 import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/ImageHelper.dart';
@@ -337,7 +337,7 @@ class OpenFoodAPIClient {
     final SearchResult searchResult = await searchProducts(
       user,
       ProductSearchQueryConfiguration(
-        parametersList: [Barcodes.list(barcodes)],
+        parametersList: [BarcodeParameter.list(barcodes)],
         language: language,
         country: country,
         fields: [

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -3,6 +3,8 @@ import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 
 /// Query Configuration for multiple barcodes
+// TODO: deprecated from 2022-08-03; remove when old enough
+@Deprecated('Use ProductSearchQueryConfiguration with Barcodes instead')
 class ProductListQueryConfiguration extends AbstractQueryConfiguration {
   final List<String> barcodes;
 

--- a/lib/utils/ToBeCompletedConfiguration.dart
+++ b/lib/utils/ToBeCompletedConfiguration.dart
@@ -3,6 +3,9 @@ import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 
 /// Query Configuration for all the to-be-completed products.
+// TODO: deprecated from 2022-08-03; remove when old enough
+@Deprecated(
+    'Use ProductSearchQueryConfiguration with StatesTagsParameter instead')
 class ToBeCompletedQueryConfiguration extends AbstractQueryConfiguration {
   ToBeCompletedQueryConfiguration({
     final OpenFoodFactsLanguage? language,

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1502,7 +1502,11 @@ void main() {
         containsAll(someExpectedKeys),
       );
     });
-  });
+  },
+      timeout: Timeout(
+        // some tests can be slow here
+        Duration(seconds: 300),
+      ));
 
   group('$OpenFoodAPIClient test ingredients', () {
     const String barcode = BARCODE_DANISH_BUTTER_COOKIES;

--- a/test/api_getToBeCompletedProducts_test.dart
+++ b/test/api_getToBeCompletedProducts_test.dart
@@ -1,13 +1,14 @@
+import 'package:openfoodfacts/model/State.dart';
+import 'package:openfoodfacts/model/parameter/StatesTagsParameter.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
-import 'package:openfoodfacts/utils/ToBeCompletedConfiguration.dart';
 import 'package:test/test.dart';
 
 import 'test_constants.dart';
 
-/// Integration tests related to [ToBeCompletedQueryConfiguration]
+/// Integration tests related to the "to-be-completed" products
 void main() {
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
@@ -18,13 +19,16 @@ void main() {
       final OpenFoodFactsLanguage language,
     ) async {
       final String reason = '($country, $language)';
-      final ToBeCompletedQueryConfiguration configuration =
-          ToBeCompletedQueryConfiguration(
+      final ProductSearchQueryConfiguration configuration =
+          ProductSearchQueryConfiguration(
         country: country,
         language: language,
         fields: [
           ProductField.BARCODE,
           ProductField.STATES_TAGS,
+        ],
+        parametersList: [
+          StatesTagsParameter(map: {State.COMPLETED: false}),
         ],
       );
 

--- a/test/api_matchedProductV2_test.dart
+++ b/test/api_matchedProductV2_test.dart
@@ -1,6 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:openfoodfacts/model/Attribute.dart';
-import 'package:openfoodfacts/model/parameter/Barcodes.dart';
+import 'package:openfoodfacts/model/parameter/BarcodeParameter.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/personalized_search/available_attribute_groups.dart';
 import 'package:openfoodfacts/personalized_search/available_preference_importances.dart';
@@ -129,7 +129,7 @@ void main() {
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         OpenFoodAPIConfiguration.globalUser,
         ProductSearchQueryConfiguration(
-          parametersList: [Barcodes.list(inputBarcodes)],
+          parametersList: [BarcodeParameter.list(inputBarcodes)],
           language: language,
           fields: [ProductField.BARCODE, ProductField.ATTRIBUTE_GROUPS],
         ),

--- a/test/api_matchedProductV2_test.dart
+++ b/test/api_matchedProductV2_test.dart
@@ -1,5 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:openfoodfacts/model/Attribute.dart';
+import 'package:openfoodfacts/model/parameter/Barcodes.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/personalized_search/available_attribute_groups.dart';
 import 'package:openfoodfacts/personalized_search/available_preference_importances.dart';
@@ -10,7 +11,6 @@ import 'package:openfoodfacts/personalized_search/product_preferences_manager.da
 import 'package:openfoodfacts/personalized_search/product_preferences_selection.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
-import 'package:openfoodfacts/utils/ProductListQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
 
@@ -128,8 +128,8 @@ void main() {
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         OpenFoodAPIConfiguration.globalUser,
-        ProductListQueryConfiguration(
-          inputBarcodes,
+        ProductSearchQueryConfiguration(
+          parametersList: [Barcodes.list(inputBarcodes)],
           language: language,
           fields: [ProductField.BARCODE, ProductField.ATTRIBUTE_GROUPS],
         ),

--- a/test/api_searchProducts_test.dart
+++ b/test/api_searchProducts_test.dart
@@ -4,6 +4,7 @@ import 'package:openfoodfacts/model/Allergens.dart';
 import 'package:openfoodfacts/model/parameter/AllergensParameter.dart';
 import 'package:openfoodfacts/model/State.dart';
 import 'package:openfoodfacts/model/IngredientsAnalysisTags.dart';
+import 'package:openfoodfacts/model/parameter/Barcodes.dart';
 import 'package:openfoodfacts/model/parameter/IngredientsAnalysisParameter.dart';
 import 'package:openfoodfacts/model/parameter/PnnsGroup2Filter.dart';
 import 'package:openfoodfacts/model/parameter/SearchTerms.dart';
@@ -14,7 +15,6 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
-import 'package:openfoodfacts/utils/ProductListQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import 'package:test/test.dart';
 
@@ -320,7 +320,7 @@ void main() {
     },
         timeout: Timeout(
           // some tests can be slow here
-          Duration(seconds: 90),
+          Duration(seconds: 300),
         ));
 
     test('type bug : ingredient percent int vs String ', () async {
@@ -668,9 +668,9 @@ void main() {
         ));
 
     test('multiple products', () async {
-      final ProductListQueryConfiguration configuration =
-          ProductListQueryConfiguration(
-        BARCODES,
+      final ProductSearchQueryConfiguration configuration =
+          ProductSearchQueryConfiguration(
+        parametersList: [Barcodes.list(BARCODES)],
         fields: [ProductField.BARCODE, ProductField.NAME],
         language: OpenFoodFactsLanguage.FRENCH,
       );
@@ -716,13 +716,15 @@ void main() {
       final obtainedBarcodes = <String>[];
       var page = 1;
       while (true) {
-        final configuration = ProductListQueryConfiguration(
-          BARCODES,
+        final configuration = ProductSearchQueryConfiguration(
+          parametersList: [
+            Barcodes.list(BARCODES),
+            PageNumber(page: page),
+            PageSize(size: 5),
+            SortBy(option: SortOption.PRODUCT_NAME),
+          ],
           fields: [ProductField.BARCODE, ProductField.NAME],
           language: OpenFoodFactsLanguage.FRENCH,
-          page: page,
-          pageSize: 5,
-          sortOption: SortOption.PRODUCT_NAME,
         );
 
         final result = await OpenFoodAPIClient.searchProducts(
@@ -774,9 +776,9 @@ void main() {
         manyBarcodes.addAll(BARCODES);
       }
 
-      final ProductListQueryConfiguration configuration =
-          ProductListQueryConfiguration(
-        manyBarcodes,
+      final ProductSearchQueryConfiguration configuration =
+          ProductSearchQueryConfiguration(
+        parametersList: [Barcodes.list(manyBarcodes)],
         fields: [ProductField.BARCODE, ProductField.NAME],
         language: OpenFoodFactsLanguage.FRENCH,
       );
@@ -845,18 +847,13 @@ void main() {
       expect(result.products, isNotNull);
       for (final Product product in result.products!) {
         expect(product.allergens, isNotNull);
-        if (allergensParameter.include != null &&
-            allergensParameter.include!.isNotEmpty) {
-          expect(product.allergens!.ids, isNotNull);
-          for (final AllergensTag tag in allergensParameter.include!) {
-            expect(product.allergens!.ids, contains(tag.tag));
-          }
-        }
-        if (allergensParameter.exclude != null &&
-            allergensParameter.exclude!.isNotEmpty) {
-          expect(product.allergens!.ids, isNotNull);
-          for (final AllergensTag tag in allergensParameter.exclude!) {
-            expect(product.allergens!.ids, isNot(contains(tag.tag)));
+        expect(product.allergens!.ids, isNotNull);
+        for (final MapEntry<AllergensTag, bool> item
+            in allergensParameter.map.entries) {
+          if (item.value) {
+            expect(product.allergens!.ids, contains(item.key.tag));
+          } else {
+            expect(product.allergens!.ids, isNot(contains(item.key.tag)));
           }
         }
       }
@@ -867,7 +864,7 @@ void main() {
     test('check products with allergens', () async {
       for (final AllergensTag tag in AllergensTag.values) {
         final int count = await _checkAllergens(
-          AllergensParameter(include: [tag]),
+          AllergensParameter(map: {tag: true}),
         );
         expect(count, greaterThan(0));
       }
@@ -876,19 +873,9 @@ void main() {
     test('check products without allergens', () async {
       for (final AllergensTag tag in AllergensTag.values) {
         final int count = await _checkAllergens(
-          AllergensParameter(exclude: [tag]),
+          AllergensParameter(map: {tag: false}),
         );
         expect(count, greaterThan(0));
-      }
-    });
-
-    test('check products with and without the same allergens', () async {
-      for (final AllergensTag tag in AllergensTag.values) {
-        final int count = await _checkAllergens(
-          AllergensParameter(include: [tag], exclude: [tag]),
-        );
-        // it's an AND: with both conditions we always get 0 products.
-        expect(count, 0);
       }
     });
 
@@ -897,27 +884,16 @@ void main() {
         count: 2,
         max: AllergensTag.values.length,
       );
+      final AllergensTag tag1 = AllergensTag.values[indices[0]];
+      final AllergensTag tag2 = AllergensTag.values[indices[1]];
       final int count1 = await _checkAllergens(
-        AllergensParameter(
-          include: [
-            AllergensTag.values[indices[0]],
-          ],
-        ),
+        AllergensParameter(map: {tag1: true}),
       );
       final int count2 = await _checkAllergens(
-        AllergensParameter(
-          include: [
-            AllergensTag.values[indices[1]],
-          ],
-        ),
+        AllergensParameter(map: {tag2: true}),
       );
       final int countBoth = await _checkAllergens(
-        AllergensParameter(
-          include: [
-            AllergensTag.values[indices[0]],
-            AllergensTag.values[indices[1]],
-          ],
-        ),
+        AllergensParameter(map: {tag1: true, tag2: true}),
       );
       // it's an AND: with both conditions we always get less results.
       expect(countBoth, lessThanOrEqualTo(count1));
@@ -929,29 +905,16 @@ void main() {
         count: 2,
         max: AllergensTag.values.length,
       );
+      final AllergensTag tag1 = AllergensTag.values[indices[0]];
+      final AllergensTag tag2 = AllergensTag.values[indices[1]];
       final int count1 = await _checkAllergens(
-        AllergensParameter(
-          include: [
-            AllergensTag.values[indices[0]],
-          ],
-        ),
+        AllergensParameter(map: {tag1: true}),
       );
       final int count2 = await _checkAllergens(
-        AllergensParameter(
-          exclude: [
-            AllergensTag.values[indices[1]],
-          ],
-        ),
+        AllergensParameter(map: {tag2: false}),
       );
       final int countBoth = await _checkAllergens(
-        AllergensParameter(
-          include: [
-            AllergensTag.values[indices[0]],
-          ],
-          exclude: [
-            AllergensTag.values[indices[1]],
-          ],
-        ),
+        AllergensParameter(map: {tag1: true, tag2: false}),
       );
       // it's an AND: with both conditions we always get less results.
       expect(countBoth, lessThanOrEqualTo(count1));
@@ -996,7 +959,7 @@ void main() {
       for (final Product product in result.products!) {
         expect(product.statesTags, isNotNull);
         for (final MapEntry<State, bool> item
-            in statesTagsParameter.completed.entries) {
+            in statesTagsParameter.map.entries) {
           if (item.value) {
             expect(product.statesTags, contains(item.key.completedTag));
           } else {
@@ -1011,7 +974,7 @@ void main() {
     test('check products with "completed" states tags', () async {
       for (final State state in State.values) {
         final int count = await _checkStatesTags(
-          StatesTagsParameter(completed: {state: true}),
+          StatesTagsParameter(map: {state: true}),
         );
         expect(count, greaterThan(0));
       }
@@ -1020,7 +983,7 @@ void main() {
     test('check products with "to-be-completed" states tags', () async {
       for (final State state in State.values) {
         final int count = await _checkStatesTags(
-          StatesTagsParameter(completed: {state: false}),
+          StatesTagsParameter(map: {state: false}),
         );
         expect(count, greaterThan(0));
       }
@@ -1037,17 +1000,17 @@ void main() {
       final bool completed1 = random.nextBool();
       final bool completed2 = random.nextBool();
       final int count1 = await _checkStatesTags(
-        StatesTagsParameter(completed: {
+        StatesTagsParameter(map: {
           state1: completed1,
         }),
       );
       final int count2 = await _checkStatesTags(
-        StatesTagsParameter(completed: {
+        StatesTagsParameter(map: {
           state2: completed2,
         }),
       );
       final int countBoth = await _checkStatesTags(
-        StatesTagsParameter(completed: {
+        StatesTagsParameter(map: {
           state1: completed1,
           state2: completed2,
         }),

--- a/test/api_searchProducts_test.dart
+++ b/test/api_searchProducts_test.dart
@@ -4,7 +4,7 @@ import 'package:openfoodfacts/model/Allergens.dart';
 import 'package:openfoodfacts/model/parameter/AllergensParameter.dart';
 import 'package:openfoodfacts/model/State.dart';
 import 'package:openfoodfacts/model/IngredientsAnalysisTags.dart';
-import 'package:openfoodfacts/model/parameter/Barcodes.dart';
+import 'package:openfoodfacts/model/parameter/BarcodeParameter.dart';
 import 'package:openfoodfacts/model/parameter/IngredientsAnalysisParameter.dart';
 import 'package:openfoodfacts/model/parameter/PnnsGroup2Filter.dart';
 import 'package:openfoodfacts/model/parameter/SearchTerms.dart';
@@ -670,7 +670,7 @@ void main() {
     test('multiple products', () async {
       final ProductSearchQueryConfiguration configuration =
           ProductSearchQueryConfiguration(
-        parametersList: [Barcodes.list(BARCODES)],
+        parametersList: [BarcodeParameter.list(BARCODES)],
         fields: [ProductField.BARCODE, ProductField.NAME],
         language: OpenFoodFactsLanguage.FRENCH,
       );
@@ -718,7 +718,7 @@ void main() {
       while (true) {
         final configuration = ProductSearchQueryConfiguration(
           parametersList: [
-            Barcodes.list(BARCODES),
+            BarcodeParameter.list(BARCODES),
             PageNumber(page: page),
             PageSize(size: 5),
             SortBy(option: SortOption.PRODUCT_NAME),
@@ -778,7 +778,7 @@ void main() {
 
       final ProductSearchQueryConfiguration configuration =
           ProductSearchQueryConfiguration(
-        parametersList: [Barcodes.list(manyBarcodes)],
+        parametersList: [BarcodeParameter.list(manyBarcodes)],
         fields: [ProductField.BARCODE, ProductField.NAME],
         language: OpenFoodFactsLanguage.FRENCH,
       );


### PR DESCRIPTION
New files:
* `Barcodes.dart`: "Barcodes" search API parameter.
* `BoolMapParameter.dart`: Abstract map of `bool` as `Parameter`.

Impacted files:
* `AllergensParameter.dart`: refactored as `BoolMapParameter<AllergensTag>`
* `api_getToBeCompletedProducts_test.dart`: minor refactoring around a deprecated class
* `api_matchedProductV2_test.dart`: minor refactoring around a deprecated class
* `api_searchProducts_test.dart`: fixed test duration; refactoring
* `openfoodfacts.dart`: minor refactoring around a deprecated class
* `ProductListQueryConfiguration.dart`: deprecated
* `StatesTagsParameter.dart`: refactored as `BoolMapParameter<State>`
* `ToBeCompletedConfiguration.dart`: deprecated

### What
- New `Barcodes` search parameter
- Deprecated both `ToBeCompletedConfiguration` and `ProductListQueryConfiguration` in favor of `ProductSearchQueryConfiguration` with adapted parameters.
- Refactored `AllergensParameter` and `StatesTagsParameter` around the new `BoolMapParameter`