### PR TITLE
fix: imageHelper - minor fix about Windows; deprecated methods

### DIFF
--- a/lib/utils/ImageHelper.dart
+++ b/lib/utils/ImageHelper.dart
@@ -1,5 +1,4 @@
 import 'package:image/image.dart';
-import 'package:path/path.dart' as path;
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
 import '../model/ProductImage.dart';
@@ -7,9 +6,13 @@ import 'LanguageHelper.dart';
 
 /// Helper class related to product pictures
 class ImageHelper {
+  // TODO: deprecated from 2022-08-18; remove when old enough
+  @Deprecated('Use 2048 instead')
   static const int MAX_IMAGE_SIZE = 2048;
 
   /// Returns a copy of the [image] with its bigger size GTE [maxsize]
+  // TODO: deprecated from 2022-08-18; remove when old enough, and pubspec.yaml's dependency on "image" too
+  @Deprecated('Use copyResize from package image instead')
   static Image resize(Image image, {int maxSize = MAX_IMAGE_SIZE}) {
     // check if the image is already small enough
     if (image.width <= maxSize || image.height <= maxSize) {
@@ -60,10 +63,11 @@ class ImageHelper {
       barcodePath = barcode;
     }
 
-    return path.join(
-        (OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
+    final String root =
+        OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
             ? OpenFoodAPIConfiguration.imageProdUrlBase
-            : OpenFoodAPIConfiguration.imageTestUrlBase),
-        barcodePath);
+            : OpenFoodAPIConfiguration.imageTestUrlBase;
+    final String separator = root.endsWith('/') ? '' : '/';
+    return '$root$separator$barcodePath';
   }
 }


### PR DESCRIPTION
Impacted file:
* `ImageHelper.dart`: deprecated methods that we have no added-value about; fixed a method that wouldn't work on Windows

### What
- It's been a long time since I noticed that we used package `image` for nothing.
- I've deprecated its usage, as it's not what the package is all about.
- I've also fixed an incorrect usage of `path`.