### PR TITLE
feat: #560 - optionally adding user credentials for POST requests

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -136,6 +136,7 @@ class OpenFoodAPIClient {
       parameterMap,
       user,
       queryType: queryType,
+      addCredentialsToBody: true,
     );
     return Status.fromApiResponse(response.body);
   }
@@ -642,6 +643,7 @@ class OpenFoodAPIClient {
       annotationData,
       user,
       queryType: queryType,
+      addCredentialsToBody: false,
     );
     return Status.fromApiResponse(response.body);
   }
@@ -676,6 +678,7 @@ class OpenFoodAPIClient {
       spellingCorrectionParam,
       user,
       queryType: queryType,
+      addCredentialsToBody: false,
     );
     SpellingCorrection result = SpellingCorrection.fromJson(
         json.decode(utf8.decode(response.bodyBytes)));
@@ -709,6 +712,7 @@ class OpenFoodAPIClient {
       queryParameters,
       user,
       queryType: queryType,
+      addCredentialsToBody: false,
     );
     return OcrIngredientsResult.fromJson(
       json.decode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>,
@@ -738,6 +742,7 @@ class OpenFoodAPIClient {
       queryParameters,
       user,
       queryType: queryType,
+      addCredentialsToBody: false,
     );
     return OcrPackagingResult.fromJson(
       json.decode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>,
@@ -769,6 +774,7 @@ class OpenFoodAPIClient {
       queryParameters,
       null,
       queryType: queryType,
+      addCredentialsToBody: false,
     );
     return json.decode(response.body);
   }
@@ -785,9 +791,10 @@ class OpenFoodAPIClient {
     );
     final Response response = await HttpHelper().doPostRequest(
       loginUri,
-      user.toData(),
+      <String, String>{},
       user,
       queryType: queryType,
+      addCredentialsToBody: true,
     );
     // TODO(monsieurtanuki): refactor as something more refined
     return response.statusCode == 200 && response.body == "";
@@ -983,6 +990,7 @@ class OpenFoodAPIClient {
       queryParameters,
       null,
       queryType: queryType,
+      addCredentialsToBody: false,
     );
     if (response.statusCode != 200) {
       throw Exception('Could not retrieve ordered nutrients!');
@@ -1087,6 +1095,7 @@ class OpenFoodAPIClient {
       queryParameters,
       user,
       queryType: queryType,
+      addCredentialsToBody: true,
     );
     if (response.statusCode != 200) {
       throw Exception(
@@ -1139,6 +1148,7 @@ class OpenFoodAPIClient {
       queryParameters,
       user,
       queryType: queryType,
+      addCredentialsToBody: true,
     );
     if (response.statusCode != 200) {
       throw Exception(

--- a/lib/utils/AbstractQueryConfiguration.dart
+++ b/lib/utils/AbstractQueryConfiguration.dart
@@ -133,5 +133,6 @@ abstract class AbstractQueryConfiguration {
         getParametersMap(),
         user,
         queryType: queryType,
+        addCredentialsToBody: false,
       );
 }

--- a/lib/utils/HttpHelper.dart
+++ b/lib/utils/HttpHelper.dart
@@ -87,9 +87,12 @@ class HttpHelper {
     Map<String, String> body,
     User? user, {
     QueryType? queryType,
+    required bool addCredentialsToBody,
   }) async {
-    if (user != null) {
-      body.addAll(user.toData());
+    if (addCredentialsToBody) {
+      if (user != null) {
+        body.addAll(user.toData());
+      }
     }
 
     http.Response response = await http.post(

--- a/test/api_getRobotoff_test.dart
+++ b/test/api_getRobotoff_test.dart
@@ -93,22 +93,23 @@ void main() {
 
     test('get product insights PROD', () async {
       // TODO(monsieurtanuki): to be removed when we have more a relevant test in QueryType.TEST
-      InsightsResult result = await OpenFoodAPIClient.getProductInsights(
-        '8025386005564',
-        TestConstants.TEST_USER,
+      final String barcode = '4008400402222';
+      final InsightsResult result = await OpenFoodAPIClient.getProductInsights(
+        barcode,
+        TestConstants.PROD_USER,
         queryType: QueryType.PROD,
       );
 
       expect(result.status, isNotNull);
       expect(result.status, 'found');
-      expect(result.insights!.isNotEmpty, true);
-      expect(result.insights![0].id != null, true);
-      expect(result.insights![0].barcode != null, true);
-      expect(result.insights![0].countries != null, true);
-      expect(result.insights![0].lang != null, true);
-      expect(result.insights![0].model != null, true);
-      // Actually, I stumbled across insights without confidence field...
-      //expect(result.insight.confidence != null, true);
+      expect(result.insights!, isNotEmpty);
+      expect(result.insights![0].id, isNotNull);
+      expect(result.insights![0].barcode, isNotNull);
+      expect(result.insights![0].barcode, barcode);
+      expect(result.insights![0].countries, isNotNull);
+      expect(result.insights![0].lang, isNull);
+      expect(result.insights![0].model, isNull);
+      expect(result.insights![0].confidence, isNull);
     });
 
     test('get product insights', () async {

--- a/test/fake_http_helper.dart
+++ b/test/fake_http_helper.dart
@@ -130,8 +130,12 @@ class FakeHttpHelper extends HttpHelper {
   }
 
   Future<http.Response> doPostRequest(
-      Uri uri, Map<String, String?> body, User? user,
-      {QueryType? queryType}) async {
+    Uri uri,
+    Map<String, String?> body,
+    User? user, {
+    QueryType? queryType,
+    required bool addCredentialsToBody,
+  }) async {
     final _Query query = _Query(uri, body: body);
     final http.Response response = _responses[query] ?? http404;
     _logRequest(uri, response: response);


### PR DESCRIPTION
Impacted files:
* `AbstractQueryConfiguration.dart`: populated new parameter `addCredentialsToBody`
* `api_getRobotoff_test.dart`: unrelated fix
* `fake_http_helper.dart`: added new parameter `addCredentialsToBody`
* `HttpHelper.dart`: new parameter `bool addCredentialsToBody` for method `doPostRequest`
* `openfoodfacts.dart`: populated new parameter `addCredentialsToBody`

### What
User credentials for the following methods (and user name in the header):
* saveProduct
* login
* _callProductImageCrop
* unselectProductImage

No user credentials for the following methods (still, user name in the header):
* product search in general
* postInsightAnnotation
* getIngredientSpellingCorrection
* extractIngredients
* extractPackaging
* getAutocompletedSuggestions
* getOrderedNutrientsJsonString

### Fixes bug(s)
- #560