### PR TITLE
feat: #573 - getRandomRobotoffQuestion with optional insight types

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -585,17 +585,18 @@ class OpenFoodAPIClient {
       count = 1;
     }
 
-    List<String?> typesValues = [];
-    for (var t in types) {
-      typesValues.add(t.value);
+    final List<String> typesValues = [];
+    for (final InsightType t in types) {
+      final String? value = t.value;
+      if (value != null) {
+        typesValues.add(value);
+      }
     }
-
-    String parsedTypes = typesValues.join(',');
 
     final Map<String, String> parameters = <String, String>{
       'lang': lang,
       'count': count.toString(),
-      'insight_types': parsedTypes.toString()
+      if (typesValues.isNotEmpty) 'insight_types': typesValues.join(',')
     };
 
     var robotoffQuestionUri = UriHelper.getRobotoffUri(

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -578,7 +578,7 @@ class OpenFoodAPIClient {
     String lang,
     User user, {
     int? count,
-    required List<InsightType> types,
+    List<InsightType>? types,
     QueryType? queryType,
   }) async {
     if (count == null || count <= 0) {
@@ -586,10 +586,12 @@ class OpenFoodAPIClient {
     }
 
     final List<String> typesValues = [];
-    for (final InsightType t in types) {
-      final String? value = t.value;
-      if (value != null) {
-        typesValues.add(value);
+    if (types != null) {
+      for (final InsightType t in types) {
+        final String? value = t.value;
+        if (value != null) {
+          typesValues.add(value);
+        }
       }
     }
 

--- a/test/api_getRobotoff_test.dart
+++ b/test/api_getRobotoff_test.dart
@@ -82,7 +82,6 @@ void main() {
           await OpenFoodAPIClient.getRandomRobotoffQuestion(
         'fr',
         TestConstants.PROD_USER,
-        types: [],
         count: 2,
         queryType: QueryType.PROD,
       );

--- a/test/api_getRobotoff_test.dart
+++ b/test/api_getRobotoff_test.dart
@@ -59,17 +59,37 @@ void main() {
       }
     });
 
-    test('get 2 random questions', () async {
-      RobotoffQuestionResult result =
+    test('get 2 random questions with types', () async {
+      const InsightType type = InsightType.CATEGORY;
+      final RobotoffQuestionResult result =
           await OpenFoodAPIClient.getRandomRobotoffQuestion(
-              'fr', TestConstants.TEST_USER,
-              types: [InsightType.CATEGORY], count: 2);
+        'fr',
+        TestConstants.PROD_USER,
+        types: [type],
+        count: 2,
+        queryType: QueryType.PROD,
+      );
 
       expect(result.status, isNotNull);
       expect(result.status, 'found');
       expect(result.questions!.length, 2);
-      expect(result.questions![0].insightType, InsightType.CATEGORY);
-      expect(result.questions![1].insightType, InsightType.CATEGORY);
+      expect(result.questions![0].insightType, type);
+      expect(result.questions![1].insightType, type);
+    });
+
+    test('get 2 random questions with no specific type', () async {
+      final RobotoffQuestionResult result =
+          await OpenFoodAPIClient.getRandomRobotoffQuestion(
+        'fr',
+        TestConstants.PROD_USER,
+        types: [],
+        count: 2,
+        queryType: QueryType.PROD,
+      );
+
+      expect(result.status, isNotNull);
+      expect(result.status, 'found');
+      expect(result.questions!.length, 2);
     });
   });
 


### PR DESCRIPTION
Impacted files:
* `api_getRobotoff_test.dart`: added a test for "no `'insight_types'`"; refactored
* `openfoodfacts.dart`: potentially no `'insight_types'` in `getRandomRobotoffQuestion`

### What
- We needed to be able not to specify insight types  in `getRandomRobotoffQuestion`

### Fixes bug(s)
- Closes #573

### Part of 
- https://github.com/openfoodfacts/smooth-app/pull/3102
