### PR TITLE
fix: Also return [LoginStatus] when not logged in

### DIFF
--- a/lib/model/LoginStatus.dart
+++ b/lib/model/LoginStatus.dart
@@ -37,8 +37,8 @@ class LoginStatus {
         status: JsonObject.parseInt(json['status'])!,
         statusVerbose: json['status_verbose'] as String,
         userId: json['user_id'] as String?,
-        userEmail: json['user']['email'] as String?,
-        userName: json['user']['name'] as String?,
+        userEmail: json['user']?['email'] as String?,
+        userName: json['user']?['name'] as String?,
       );
 
   /// Was the login successful?

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -814,10 +814,11 @@ class OpenFoodAPIClient {
       queryType: queryType,
       addCredentialsToBody: true,
     );
-    if (response.statusCode != 200) {
-      return null;
+    if (response.statusCode == 200 || response.statusCode == 403) {
+      return LoginStatus.fromJson(jsonDecode(response.body));
     }
-    return LoginStatus.fromJson(jsonDecode(response.body));
+
+    return null;
   }
 
   /// A username may not exceed 20 characters

--- a/test/user_management_test_test_env.dart
+++ b/test/user_management_test_test_env.dart
@@ -52,6 +52,15 @@ void main() {
       expect(status.userEmail, email);
       print('Creating a account and logging in worked in $counter trie(s)');
     });
+
+    test('Login with invalid credentials', () async {
+      final LoginStatus? status = await OpenFoodAPIClient.login2(
+        User(userId: '123', password: '123'),
+        queryType: user_test_queryType,
+      );
+      expect(status?.successful, false);
+      expect(status?.statusVerbose, 'user not signed-in');
+    });
   });
 }
 


### PR DESCRIPTION
### What
Before we just returned a LoginStatus when the login was succesful (else null), with that approach `success`, `status` and `status_verbose` would have always been the same. Now we return also in case of bad credentials
