### PR TITLE
fix: #592 - KnowledgePanelTextElement - 'type' instead of 'text_type'

### DIFF
--- a/lib/model/KnowledgePanelElement.dart
+++ b/lib/model/KnowledgePanelElement.dart
@@ -41,9 +41,7 @@ class KnowledgePanelTextElement extends JsonObject {
 
   /// Type of the text description, Client may choose to display the description
   /// depending upon the type.
-  @JsonKey(
-      name: 'text_type',
-      unknownEnumValue: KnowledgePanelTextElementType.DEFAULT)
+  @JsonKey(unknownEnumValue: KnowledgePanelTextElementType.DEFAULT)
   final KnowledgePanelTextElementType? type;
 
   /// Human readable source language (eg: "English")

--- a/lib/model/KnowledgePanelElement.g.dart
+++ b/lib/model/KnowledgePanelElement.g.dart
@@ -11,7 +11,7 @@ KnowledgePanelTextElement _$KnowledgePanelTextElementFromJson(
     KnowledgePanelTextElement(
       html: json['html'] as String,
       type: $enumDecodeNullable(
-          _$KnowledgePanelTextElementTypeEnumMap, json['text_type'],
+          _$KnowledgePanelTextElementTypeEnumMap, json['type'],
           unknownValue: KnowledgePanelTextElementType.DEFAULT),
       sourceLanguage: json['source_language'] as String?,
       sourceLocale: json['source_lc'] as String?,
@@ -23,7 +23,7 @@ Map<String, dynamic> _$KnowledgePanelTextElementToJson(
         KnowledgePanelTextElement instance) =>
     <String, dynamic>{
       'html': instance.html,
-      'text_type': _$KnowledgePanelTextElementTypeEnumMap[instance.type],
+      'type': _$KnowledgePanelTextElementTypeEnumMap[instance.type],
       'source_language': instance.sourceLanguage,
       'source_lc': instance.sourceLocale,
       'source_text': instance.sourceText,

--- a/test/knowledge_panels_from_json_test.dart
+++ b/test/knowledge_panels_from_json_test.dart
@@ -71,7 +71,7 @@ void main() {
             'text_element': {
               'html':
                   '\n                    <p>Agribalyse category: \n                    <a href=\'https://www.ecoscore_data.agribalyse.fr/app/aliments/31032\'>Chocolate spread with hazelnuts</a>\n                    </p>\n                    <ul>\n                        <li>\n                            PEF environmental score: 0.74\n                            (the lower the score, the lower the impact)\n                        </li>\n                        <li>\n                            including impact on climate change: 9.87\n                            kg CO2 eq/kg of product\n                        </li>\n                    </ul>\n                    ',
-              'text_type': 'summary'
+              'type': 'summary'
             }
           },
           {
@@ -173,7 +173,7 @@ void main() {
             'text_element': {
               'html':
                   "\n                    <p>The carbon emission figure comes from ADEME's Agribalyse database, for the category: \n                    <a href='https://agribalyse.ademe.fr/app/aliments/31032'>Chocolate spread with hazelnuts</a>\n                    </p>\n                    ",
-              'text_type': 'summary',
+              'type': 'summary',
               'source_language': 'English',
               'source_lc': 'en',
               'source_text': 'Wikipedia',
@@ -365,7 +365,7 @@ void main() {
             'text_element': {
               'html':
                   '\n                    <p>[give more details here]</p> \n                    ',
-              'text_type': 'summary'
+              'type': 'summary'
             }
           }
         ],


### PR DESCRIPTION
Impacted files:
* `knowledge_panels_from_json_test.dart`: `'type'` instead of `'text_type'`
* `KnowledgePanelElement.dart`: `'type'` instead of `'text_type'`
* `KnowledgePanelElement.g.dart`: generated

### What
- A JSON field of `KnowledgePanelTextElement` was misspelt.
- Now we use `'type'` instead of `'text_type'`

### Fixes bug(s)
- Fixes #592