### PR TITLE
fix: #507 - no more parameters in product URI

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -248,6 +248,7 @@ class OpenFoodAPIClient {
     final Uri uri = UriHelper.getUri(
       path: 'product/$barcode',
       queryType: queryType,
+      addUserAgentParameters: false,
     );
     if (!replaceSubdomain) {
       return uri;

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1692,6 +1692,8 @@ void main() {
 
   test('get product uri', () async {
     const String barcode = BARCODE_DANISH_BUTTER_COOKIES;
+    OpenFoodAPIConfiguration.uuid = 'Should not appear in the url';
+
     expect(
       OpenFoodAPIClient.getProductUri(
         barcode,
@@ -1741,8 +1743,9 @@ void main() {
         language: OpenFoodFactsLanguage.SPANISH,
         country: OpenFoodFactsCountry.GERMANY,
         replaceSubdomain: true,
-      ).host,
-      'de-es.openfoodfacts.net',
+        queryType: QueryType.PROD,
+      ).toString(),
+      'https://de-es.openfoodfacts.org/product/$barcode',
     );
   });
 


### PR DESCRIPTION
Impacted files:
* `api_getProduct_test.dart`: tested that conf is not passed as parameter
* `openfoodfacts.dart`: removed config parameters from product URI

### What
- By default, when we compute a URI the configuration parameters are passed.
- Which is not a desired feature for product URI.
- Therefore we explicitly remove them for product URI.

### Fixes bug(s)
- Fixes #507