### PR TITLE
feat: #602 - added the "website" product field

### DIFF
--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -390,6 +390,10 @@ class Product extends JsonObject {
   @JsonKey(name: 'nova_group', includeIfNull: false)
   int? novaGroup;
 
+  /// Link to the product page on the official site of the producer
+  @JsonKey(name: 'link', includeIfNull: false)
+  String? website;
+
   Product(
       {this.barcode,
       this.productName,

--- a/lib/model/Product.g.dart
+++ b/lib/model/Product.g.dart
@@ -120,7 +120,8 @@ Product _$ProductFromJson(Map<String, dynamic> json) => Product(
       ..embCodes = json['emb_codes'] as String?
       ..manufacturingPlaces = json['manufacturing_places'] as String?
       ..origins = json['origins'] as String?
-      ..novaGroup = json['nova_group'] as int?;
+      ..novaGroup = json['nova_group'] as int?
+      ..website = json['link'] as String?;
 
 Map<String, dynamic> _$ProductToJson(Product instance) {
   final val = <String, dynamic>{
@@ -216,6 +217,7 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('manufacturing_places', instance.manufacturingPlaces);
   writeNotNull('origins', instance.origins);
   writeNotNull('nova_group', instance.novaGroup);
+  writeNotNull('link', instance.website);
   val['no_nutrition_data'] =
       JsonHelper.checkboxToJSON(instance.noNutritionData);
   writeNotNull('nutriments', Nutriments.toJsonHelper(instance.nutriments));

--- a/lib/utils/ProductFields.dart
+++ b/lib/utils/ProductFields.dart
@@ -78,6 +78,7 @@ enum ProductField implements OffTagged {
   MANUFACTURING_PLACES(offTag: 'manufacturing_places'),
   ORIGINS(offTag: 'origins'),
   NOVA_GROUP(offTag: 'nova_group'),
+  WEBSITE(offTag: 'link'),
   ALL(offTag: '');
 
   const ProductField({

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1829,20 +1829,33 @@ void main() {
       ));
 
   test('get new product fields', () async {
-    final ProductQueryConfiguration configuration = ProductQueryConfiguration(
+    late ProductQueryConfiguration configuration;
+    late ProductResult result;
+
+    configuration = ProductQueryConfiguration(
       BARCODE_DANISH_BUTTER_COOKIES,
-      fields: [
-        ProductField.COMPARED_TO_CATEGORY,
-      ],
+      fields: [ProductField.COMPARED_TO_CATEGORY],
     );
-
-    final ProductResult result = await OpenFoodAPIClient.getProduct(
+    result = await OpenFoodAPIClient.getProduct(
       configuration,
+      queryType: QueryType.PROD,
     );
-
     expect(result.status, 1);
     expect(result.product, isNotNull);
     expect(result.product!.comparedToCategory, isNotNull);
+
+    configuration = ProductQueryConfiguration(
+      '7300400481588',
+      fields: [ProductField.WEBSITE],
+    );
+    result = await OpenFoodAPIClient.getProduct(
+      configuration,
+      queryType: QueryType.PROD,
+    );
+    expect(result.status, 1);
+    expect(result.product, isNotNull);
+    expect(result.product!.website, isNotNull);
+    expect(result.product!.website, isNotEmpty);
   });
 
   group('no nutrition data', () {


### PR DESCRIPTION
Impacted files:
* `api_getProduct_test.dart`: added a test on the new "website" product field
* `Product.dart`: added the "website" field
* `Product.g.dart`: generated
* `ProductFields.dart`: added the "website" field

### What
- Just added the "website" product field (offTag: `'link'`)

### Fixes bug(s)
- Closes #602

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/2738
- https://github.com/openfoodfacts/smooth-app/issues/3207
