### PR TITLE
refactor: used OffTagged and removed deprecated fields

### DIFF
--- a/lib/model/TaxonomyAdditive.dart
+++ b/lib/model/TaxonomyAdditive.dart
@@ -338,7 +338,6 @@ class TaxonomyAdditiveQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyAdditiveQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages,
-    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyAdditiveField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -346,7 +345,6 @@ class TaxonomyAdditiveQueryConfiguration extends TaxonomyQueryConfiguration<
           TagType.ADDITIVES,
           tags,
           languages: languages,
-          cc: cc,
           country: country,
           includeChildren: false,
           fields: fields,

--- a/lib/model/TaxonomyAllergen.dart
+++ b/lib/model/TaxonomyAllergen.dart
@@ -82,7 +82,6 @@ class TaxonomyAllergenQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyAllergenQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages,
-    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyAllergenField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -90,7 +89,6 @@ class TaxonomyAllergenQueryConfiguration extends TaxonomyQueryConfiguration<
           TagType.ALLERGENS,
           tags,
           languages: languages,
-          cc: cc,
           country: country,
           fields: fields,
           additionalParameters: additionalParameters,

--- a/lib/model/TaxonomyCategory.dart
+++ b/lib/model/TaxonomyCategory.dart
@@ -335,7 +335,6 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyCategoryQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages,
-    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     bool includeChildren = false,
     List<TaxonomyCategoryField> fields = const [],
@@ -344,7 +343,6 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
           TagType.CATEGORIES,
           tags,
           languages: languages,
-          cc: cc,
           country: country,
           includeChildren: includeChildren,
           fields: fields,
@@ -353,7 +351,6 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
 
   TaxonomyCategoryQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages,
-    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     bool includeChildren = false,
     List<TaxonomyCategoryField> fields = const [],
@@ -361,7 +358,6 @@ class TaxonomyCategoryQueryConfiguration extends TaxonomyQueryConfiguration<
   }) : super.roots(
           TagType.CATEGORIES,
           languages: languages,
-          cc: cc,
           country: country,
           includeChildren: includeChildren,
           fields: fields,

--- a/lib/model/TaxonomyCountry.dart
+++ b/lib/model/TaxonomyCountry.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
+import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
@@ -8,31 +9,24 @@ import 'package:openfoodfacts/utils/TagType.dart';
 part 'TaxonomyCountry.g.dart';
 
 /// Fields of an [TaxonomyCountry]
-enum TaxonomyCountryField {
-  ALL,
-  COUNTRY_CODE_2,
-  COUNTRY_CODE_3,
-  LANGUAGES,
-  NAME,
-  OFFICIAL_COUNTRY_CODE_2,
-  SYNONYMS,
-  WIKIDATA,
-}
+enum TaxonomyCountryField implements OffTagged {
+  ALL(offTag: 'all'),
+  COUNTRY_CODE_2(offTag: 'country_code_2'),
+  COUNTRY_CODE_3(offTag: 'country_code_3'),
+  LANGUAGES(offTag: 'languages'),
+  NAME(offTag: 'name'),
+  OFFICIAL_COUNTRY_CODE_2(offTag: 'official_country_code_2'),
+  SYNONYMS(offTag: 'synonyms'),
+  WIKIDATA(offTag: 'wikidata');
 
-extension TaxonomyCountryFieldExtension on TaxonomyCountryField {
-  static const Map<TaxonomyCountryField, String> _KEYS = {
-    TaxonomyCountryField.ALL: 'all',
-    TaxonomyCountryField.COUNTRY_CODE_2: 'country_code_2',
-    TaxonomyCountryField.COUNTRY_CODE_3: 'country_code_3',
-    TaxonomyCountryField.LANGUAGES: 'languages',
-    TaxonomyCountryField.NAME: 'name',
-    TaxonomyCountryField.OFFICIAL_COUNTRY_CODE_2: 'official_country_code_2',
-    TaxonomyCountryField.SYNONYMS: 'synonyms',
-    TaxonomyCountryField.WIKIDATA: 'wikidata',
-  };
+  const TaxonomyCountryField({required this.offTag});
 
-  /// Returns the key of the Country field
-  String get key => _KEYS[this] ?? '';
+  @override
+  final String offTag;
+
+  // TODO: deprecated from 2022-11-06; remove when old enough
+  @Deprecated('Use offTag instead')
+  String get key => offTag;
 }
 
 /// A JSON-serializable version of a Country taxonomy result.
@@ -102,7 +96,6 @@ class TaxonomyCountryQueryConfiguration
   TaxonomyCountryQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages,
-    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyCountryField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -110,7 +103,6 @@ class TaxonomyCountryQueryConfiguration
           TagType.COUNTRIES,
           tags,
           languages: languages,
-          cc: cc,
           country: country,
           includeChildren: false,
           fields: fields,
@@ -155,6 +147,6 @@ class TaxonomyCountryQueryConfiguration
       Iterable<TaxonomyCountryField> fields) {
     return fields
         .where((TaxonomyCountryField field) => !ignoredFields.contains(field))
-        .map<String>((TaxonomyCountryField field) => field.key);
+        .map<String>((TaxonomyCountryField field) => field.offTag);
   }
 }

--- a/lib/model/TaxonomyIngredient.dart
+++ b/lib/model/TaxonomyIngredient.dart
@@ -472,7 +472,6 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyIngredientQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages,
-    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyIngredientField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -481,7 +480,6 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
           TagType.INGREDIENTS,
           tags,
           languages: languages,
-          cc: cc,
           country: country,
           includeChildren: includeChildren,
           fields: fields,
@@ -490,7 +488,6 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
 
   TaxonomyIngredientQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages,
-    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyIngredientField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -498,7 +495,6 @@ class TaxonomyIngredientQueryConfiguration extends TaxonomyQueryConfiguration<
   }) : super.roots(
           TagType.INGREDIENTS,
           languages: languages,
-          cc: cc,
           country: country,
           includeChildren: includeChildren,
           fields: fields,

--- a/lib/model/TaxonomyLabel.dart
+++ b/lib/model/TaxonomyLabel.dart
@@ -280,7 +280,6 @@ class TaxonomyLabelQueryConfiguration
   TaxonomyLabelQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages,
-    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyLabelField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -288,7 +287,6 @@ class TaxonomyLabelQueryConfiguration
           TagType.LABELS,
           tags,
           languages: languages,
-          cc: cc,
           country: country,
           includeChildren: false,
           fields: fields,
@@ -297,14 +295,12 @@ class TaxonomyLabelQueryConfiguration
 
   TaxonomyLabelQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages,
-    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyLabelField> fields = const [],
     List<Parameter> additionalParameters = const [],
   }) : super.roots(
           TagType.LABELS,
           languages: languages,
-          cc: cc,
           country: country,
           includeChildren: false,
           fields: fields,

--- a/lib/model/TaxonomyLanguage.dart
+++ b/lib/model/TaxonomyLanguage.dart
@@ -91,7 +91,6 @@ class TaxonomyLanguageQueryConfiguration extends TaxonomyQueryConfiguration<
   TaxonomyLanguageQueryConfiguration({
     required List<String> tags,
     List<OpenFoodFactsLanguage>? languages,
-    @Deprecated('Use parameter country instead') String? cc,
     OpenFoodFactsCountry? country,
     List<TaxonomyLanguageField> fields = const [],
     List<Parameter> additionalParameters = const [],
@@ -99,7 +98,6 @@ class TaxonomyLanguageQueryConfiguration extends TaxonomyQueryConfiguration<
           TagType.LANGUAGES,
           tags,
           languages: languages,
-          cc: cc,
           country: country,
           fields: fields,
           additionalParameters: additionalParameters,

--- a/lib/model/parameter/TagFilter.dart
+++ b/lib/model/parameter/TagFilter.dart
@@ -1,56 +1,40 @@
 import 'package:openfoodfacts/interface/Parameter.dart';
+import 'package:openfoodfacts/model/OffTagged.dart';
 
 /// Filter types for advanced search parameters
-enum TagFilterType {
-  BRANDS,
-  CATEGORIES,
-  PACKAGING,
-  LABELS,
-  ORIGINS,
-  MANUFACTURING_PLACES,
-  EMB_CODES,
-  PURCHASE_PLACES,
-  STORES,
-  COUNTRIES,
-  ADDITIVES,
-  ALLERGENS,
-  TRACES,
-  NUTRITION_GRADES,
-  STATES,
-  INGREDIENTS,
-  NOVA_GROUPS,
-  LANGUAGES,
-  CREATOR,
-  EDITORS,
-  LANG,
-}
+enum TagFilterType implements OffTagged {
+  BRANDS(offTag: 'brands'),
+  CATEGORIES(offTag: 'categories'),
+  PACKAGING(offTag: 'packaging'),
+  LABELS(offTag: 'labels'),
+  ORIGINS(offTag: 'origins'),
+  MANUFACTURING_PLACES(offTag: 'manufacturing_places'),
+  EMB_CODES(offTag: 'emb_codes'),
+  PURCHASE_PLACES(offTag: 'purchase_places'),
+  STORES(offTag: 'stores'),
+  COUNTRIES(offTag: 'countries'),
+  ADDITIVES(offTag: 'additives'),
+  ALLERGENS(offTag: 'allergens'),
+  TRACES(offTag: 'traces'),
+  NUTRITION_GRADES(offTag: 'nutrition_grades'),
+  STATES(offTag: 'states'),
+  INGREDIENTS(offTag: 'ingredients'),
+  NOVA_GROUPS(offTag: 'nova_groups'),
+  LANGUAGES(offTag: 'languages'),
+  CREATOR(offTag: 'creator'),
+  EDITORS(offTag: 'editors'),
+  LANG(offTag: 'lang');
 
-extension TagFilterTypeExtension on TagFilterType {
-  static const Map<TagFilterType, String> _map = <TagFilterType, String>{
-    TagFilterType.BRANDS: 'brands',
-    TagFilterType.CATEGORIES: 'categories',
-    TagFilterType.PACKAGING: 'packaging',
-    TagFilterType.LABELS: 'labels',
-    TagFilterType.ORIGINS: 'origins',
-    TagFilterType.MANUFACTURING_PLACES: 'manufacturing_places',
-    TagFilterType.EMB_CODES: 'emb_codes',
-    TagFilterType.PURCHASE_PLACES: 'purchase_places',
-    TagFilterType.STORES: 'stores',
-    TagFilterType.COUNTRIES: 'countries',
-    TagFilterType.ADDITIVES: 'additives',
-    TagFilterType.ALLERGENS: 'allergens',
-    TagFilterType.TRACES: 'traces',
-    TagFilterType.NUTRITION_GRADES: 'nutrition_grades',
-    TagFilterType.STATES: 'states',
-    TagFilterType.INGREDIENTS: 'ingredients',
-    TagFilterType.NOVA_GROUPS: 'nova_groups',
-    TagFilterType.LANGUAGES: 'languages',
-    TagFilterType.CREATOR: 'creator',
-    TagFilterType.EDITORS: 'editors',
-    TagFilterType.LANG: 'lang',
-  };
+  const TagFilterType({
+    required this.offTag,
+  });
 
-  String get key => _map[this]!;
+  @override
+  final String offTag;
+
+  // TODO: deprecated from 2022-11-06; remove when old enough
+  @Deprecated('Use offTag instead')
+  String get key => offTag;
 }
 
 /// Tag filter ("LIST contains/without ITEM") search API parameter
@@ -78,18 +62,6 @@ class TagFilter extends Parameter {
   final bool contains;
   final String tagName;
 
-// TODO: deprecated from 2021-12-12 (#307); remove when old enough
-  @Deprecated('Use TagFilter.fromType instead')
-  const TagFilter({
-    required final String tagType,
-    required final bool contains,
-    required final String tagName,
-  }) : this._(
-          tagType: tagType,
-          contains: contains,
-          tagName: tagName,
-        );
-
   const TagFilter._({
     required this.tagType,
     required this.contains,
@@ -101,7 +73,7 @@ class TagFilter extends Parameter {
     required final String tagName,
     final bool contains = true,
   }) : this._(
-          tagType: tagFilterType.key,
+          tagType: tagFilterType.offTag,
           contains: contains,
           tagName: tagName,
         );

--- a/lib/utils/AbstractQueryConfiguration.dart
+++ b/lib/utils/AbstractQueryConfiguration.dart
@@ -32,10 +32,6 @@ abstract class AbstractQueryConfiguration {
   /// for detailed explanation on how to work with multiple languages.
   List<OpenFoodFactsLanguage>? languages;
 
-  // TODO: deprecated from 2021-11-15 (#233); remove when old enough
-  @Deprecated('Use parameter country instead')
-  String? cc;
-
   /// The country for this query, if any.
   final OpenFoodFactsCountry? country;
 
@@ -46,7 +42,6 @@ abstract class AbstractQueryConfiguration {
   AbstractQueryConfiguration({
     this.language,
     this.languages,
-    this.cc,
     this.country,
     this.fields,
     this.additionalParameters = const [],
@@ -115,8 +110,7 @@ abstract class AbstractQueryConfiguration {
   }
 
   String? computeCountryCode() =>
-      // ignore: deprecated_member_use_from_same_package
-      OpenFoodAPIConfiguration.computeCountryCode(country, cc);
+      OpenFoodAPIConfiguration.computeCountryCode(country, null);
 
   @protected
   String getUriPath();

--- a/lib/utils/OpenFoodAPIConfiguration.dart
+++ b/lib/utils/OpenFoodAPIConfiguration.dart
@@ -67,13 +67,6 @@ class OpenFoodAPIConfiguration {
   ///A global way to specify the country code for queries, can be overwritten
   /// for each individual request by specifying the country code in the
   /// individual request configurations
-  // TODO: deprecated from 2021-11-15 (#233); remove when old enough
-  @Deprecated('Use field globalCountry instead')
-  static String? globalCC;
-
-  ///A global way to specify the country code for queries, can be overwritten
-  /// for each individual request by specifying the country code in the
-  /// individual request configurations
   static OpenFoodFactsCountry? globalCountry;
 
   ///Returns the [QueryType] to use, using a default value
@@ -96,11 +89,6 @@ class OpenFoodAPIConfiguration {
     }
     if (cc != null) {
       return cc;
-    }
-    // ignore: deprecated_member_use_from_same_package
-    if (OpenFoodAPIConfiguration.globalCC != null) {
-      // ignore: deprecated_member_use_from_same_package
-      return OpenFoodAPIConfiguration.globalCC;
     }
     return null;
   }

--- a/lib/utils/ProductListQueryConfiguration.dart
+++ b/lib/utils/ProductListQueryConfiguration.dart
@@ -14,7 +14,6 @@ class ProductListQueryConfiguration extends AbstractQueryConfiguration {
     this.barcodes, {
     final OpenFoodFactsLanguage? language,
     final List<OpenFoodFactsLanguage> languages = const [],
-    @Deprecated('Use parameter country instead') final String? cc,
     final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
     int? page,
@@ -24,7 +23,6 @@ class ProductListQueryConfiguration extends AbstractQueryConfiguration {
         super(
           language: language,
           languages: languages,
-          cc: cc,
           country: country,
           fields: fields,
           additionalParameters:

--- a/lib/utils/ProductQueryConfigurations.dart
+++ b/lib/utils/ProductQueryConfigurations.dart
@@ -32,13 +32,11 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
     this.version = ProductQueryVersion.v0,
     final OpenFoodFactsLanguage? language,
     final List<OpenFoodFactsLanguage> languages = const [],
-    @Deprecated('Use parameter country instead') final String? cc,
     final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
   }) : super(
           language: language,
           languages: languages,
-          cc: cc,
           country: country,
           fields: fields,
         );

--- a/lib/utils/ProductSearchQueryConfiguration.dart
+++ b/lib/utils/ProductSearchQueryConfiguration.dart
@@ -11,14 +11,12 @@ class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
   ProductSearchQueryConfiguration({
     final OpenFoodFactsLanguage? language,
     final List<OpenFoodFactsLanguage> languages = const [],
-    @Deprecated('Use parameter country instead') final String? cc,
     final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
     required List<Parameter> parametersList,
   }) : super(
           language: language,
           languages: languages,
-          cc: cc,
           country: country,
           fields: fields,
           additionalParameters: parametersList,

--- a/lib/utils/TaxonomyQueryConfiguration.dart
+++ b/lib/utils/TaxonomyQueryConfiguration.dart
@@ -28,11 +28,6 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
   /// for detailed explanation on how to work with multiple languages.
   final List<OpenFoodFactsLanguage> languages;
 
-  /// The country code for this query, if any.
-  // TODO: deprecated from 2021-11-15 (#233); remove when old enough
-  @Deprecated('Use parameter country instead')
-  final String? cc;
-
   /// The country for this query, if any.
   final OpenFoodFactsCountry? country;
 
@@ -65,7 +60,6 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
     this.tagType,
     this.tags, {
     List<OpenFoodFactsLanguage>? languages,
-    this.cc,
     this.country,
     this.includeChildren = false,
     this.fields = const [],
@@ -78,7 +72,6 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
   TaxonomyQueryConfiguration.roots(
     this.tagType, {
     List<OpenFoodFactsLanguage>? languages,
-    this.cc,
     this.country,
     this.includeChildren = false,
     this.fields = const [],
@@ -109,10 +102,8 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
           () => languages.map<String>((language) => language.code).join(','));
     }
 
-    result.putIfAbsent(
-        'cc',
-        // ignore: deprecated_member_use_from_same_package
-        () => OpenFoodAPIConfiguration.computeCountryCode(country, cc)!);
+    result.putIfAbsent('cc',
+        () => OpenFoodAPIConfiguration.computeCountryCode(country, null)!);
 
     if (fields.isNotEmpty) {
       final Iterable<String> fieldsStrings = convertFieldsToStrings(fields);


### PR DESCRIPTION
Impacted files:
* `AbstractQueryConfiguration.dart`: removed deprecated field `cc`
* `OpenFoodAPIConfiguration.dart`: removed deprecated field `globalCc`
* `ProductListQueryConfiguration.dart`: removed deprecated field `cc`
* `ProductQueryConfigurations.dart`: removed deprecated field `cc`
* `ProductSearchQueryConfiguration.dart`: removed deprecated field `cc`
* `TagFilter.dart`: refactored with `OffTagged`; removed deprecated constructor
* `TaxonomyAdditive.dart`: removed deprecated field `cc`
* `TaxonomyAllergen.dart`: removed deprecated field `cc`
* `TaxonomyCategory.dart`: removed deprecated field `cc`
* `TaxonomyCountry.dart`: removed deprecated field `cc`; refactored with `OffTagged`
* `TaxonomyIngredient.dart`: removed deprecated field `cc`
* `TaxonomyLabel.dart`: removed deprecated field `cc`
* `TaxonomyLanguage.dart`: removed deprecated field `cc`
* `TaxonomyQueryConfiguration.dart`: removed deprecated field `cc`

### What
- While working on #596 I noticed some code simplification due to one year old code deprecation.