### PR TITLE
feat: #614 - taxonomy - support of packaging recycling

### DIFF
--- a/lib/model/TaxonomyPackagingRecycling.dart
+++ b/lib/model/TaxonomyPackagingRecycling.dart
@@ -1,0 +1,132 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:openfoodfacts/interface/JsonObject.dart';
+import 'package:openfoodfacts/model/OffTagged.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
+import 'package:openfoodfacts/utils/TagType.dart';
+
+part 'TaxonomyPackagingRecycling.g.dart';
+
+/// Fields of a [TaxonomyPackagingRecycling]
+enum TaxonomyPackagingRecyclingField implements OffTagged {
+  ALL(offTag: 'all'),
+  NAME(offTag: 'name'),
+  SYNONYMS(offTag: 'synonyms'),
+  SHAPE(offTag: 'packaging_shapes'),
+  MATERIAL(offTag: 'packaging_materials'),
+  CHILDREN(offTag: 'children'),
+  PARENTS(offTag: 'parents');
+
+  const TaxonomyPackagingRecyclingField({required this.offTag});
+
+  @override
+  final String offTag;
+}
+
+/// A JSON-serializable version of a Packaging Recycling taxonomy result.
+///
+/// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
+/// of these.
+@JsonSerializable()
+class TaxonomyPackagingRecycling extends JsonObject {
+  TaxonomyPackagingRecycling();
+
+  factory TaxonomyPackagingRecycling.fromJson(Map<String, dynamic> json) =>
+      _$TaxonomyPackagingRecyclingFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$TaxonomyPackagingRecyclingToJson(this);
+
+  /// Standard localized name.
+  @JsonKey(fromJson: LanguageHelper.fromJsonStringMap, includeIfNull: false)
+  Map<OpenFoodFactsLanguage, String>? name;
+
+  /// Localized synonyms of the name.
+  @JsonKey(fromJson: LanguageHelper.fromJsonStringMapList, includeIfNull: false)
+  Map<OpenFoodFactsLanguage, List<String>>? synonyms;
+
+  /// Shape.
+  @JsonKey(fromJson: LanguageHelper.fromJsonStringMap, includeIfNull: false)
+  Map<OpenFoodFactsLanguage, String>? shape;
+
+  /// Material.
+  @JsonKey(fromJson: LanguageHelper.fromJsonStringMap, includeIfNull: false)
+  Map<OpenFoodFactsLanguage, String>? material;
+
+  /// Children.
+  @JsonKey(includeIfNull: false)
+  List<String>? children;
+
+  /// Parents.
+  @JsonKey(includeIfNull: false)
+  List<String>? parents;
+
+  @override
+  String toString() => toJson().toString();
+}
+
+/// Configuration for packaging recycling API query.
+class TaxonomyPackagingRecyclingQueryConfiguration
+    extends TaxonomyQueryConfiguration<TaxonomyPackagingRecycling,
+        TaxonomyPackagingRecyclingField> {
+  /// Configuration to get the packaging recycling that match the [tags].
+  TaxonomyPackagingRecyclingQueryConfiguration({
+    required List<String> tags,
+    List<OpenFoodFactsLanguage>? languages,
+    OpenFoodFactsCountry? country,
+    List<TaxonomyPackagingRecyclingField> fields = const [],
+    List<Parameter> additionalParameters = const [],
+    bool includeChildren = false,
+  }) : super(
+          TagType.PACKAGING_RECYCLING,
+          tags,
+          languages: languages,
+          country: country,
+          includeChildren: includeChildren,
+          fields: fields,
+          additionalParameters: additionalParameters,
+        );
+
+  TaxonomyPackagingRecyclingQueryConfiguration.roots({
+    List<OpenFoodFactsLanguage>? languages,
+    OpenFoodFactsCountry? country,
+    List<TaxonomyPackagingRecyclingField> fields = const [],
+    List<Parameter> additionalParameters = const [],
+    bool includeChildren = false,
+  }) : super.roots(
+          TagType.PACKAGING_RECYCLING,
+          languages: languages,
+          country: country,
+          includeChildren: includeChildren,
+          fields: fields,
+          additionalParameters: additionalParameters,
+        );
+
+  @override
+  Map<String, TaxonomyPackagingRecycling> convertResults(dynamic jsonData) {
+    if (jsonData is! Map<String, dynamic>) {
+      return const {};
+    }
+    return jsonData.map<String, TaxonomyPackagingRecycling>(
+        (String key, dynamic taxonomy) {
+      if (taxonomy is! Map<String, dynamic>) {
+        assert(false, 'Received JSON Packaging Recycling is not a Map');
+        return MapEntry(key, TaxonomyPackagingRecycling.fromJson({}));
+      }
+      return MapEntry(key, TaxonomyPackagingRecycling.fromJson(taxonomy));
+    });
+  }
+
+  @override
+  Set<TaxonomyPackagingRecyclingField> get ignoredFields =>
+      const {TaxonomyPackagingRecyclingField.ALL};
+
+  @override
+  Iterable<String> convertFieldsToStrings(
+          Iterable<TaxonomyPackagingRecyclingField> fields) =>
+      fields
+          .where((TaxonomyPackagingRecyclingField field) =>
+              !ignoredFields.contains(field))
+          .map<String>((TaxonomyPackagingRecyclingField field) => field.offTag);
+}

--- a/lib/model/TaxonomyPackagingRecycling.g.dart
+++ b/lib/model/TaxonomyPackagingRecycling.g.dart
@@ -1,0 +1,240 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'TaxonomyPackagingRecycling.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TaxonomyPackagingRecycling _$TaxonomyPackagingRecyclingFromJson(
+        Map<String, dynamic> json) =>
+    TaxonomyPackagingRecycling()
+      ..name = LanguageHelper.fromJsonStringMap(json['name'])
+      ..synonyms = LanguageHelper.fromJsonStringMapList(json['synonyms'])
+      ..shape = LanguageHelper.fromJsonStringMap(json['shape'])
+      ..material = LanguageHelper.fromJsonStringMap(json['material'])
+      ..children =
+          (json['children'] as List<dynamic>?)?.map((e) => e as String).toList()
+      ..parents =
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList();
+
+Map<String, dynamic> _$TaxonomyPackagingRecyclingToJson(
+    TaxonomyPackagingRecycling instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull(
+      'name',
+      instance.name
+          ?.map((k, e) => MapEntry(_$OpenFoodFactsLanguageEnumMap[k]!, e)));
+  writeNotNull(
+      'synonyms',
+      instance.synonyms
+          ?.map((k, e) => MapEntry(_$OpenFoodFactsLanguageEnumMap[k]!, e)));
+  writeNotNull(
+      'shape',
+      instance.shape
+          ?.map((k, e) => MapEntry(_$OpenFoodFactsLanguageEnumMap[k]!, e)));
+  writeNotNull(
+      'material',
+      instance.material
+          ?.map((k, e) => MapEntry(_$OpenFoodFactsLanguageEnumMap[k]!, e)));
+  writeNotNull('children', instance.children);
+  writeNotNull('parents', instance.parents);
+  return val;
+}
+
+const _$OpenFoodFactsLanguageEnumMap = {
+  OpenFoodFactsLanguage.ENGLISH: 'ENGLISH',
+  OpenFoodFactsLanguage.OLD_CHURCH_SLAVONIC: 'OLD_CHURCH_SLAVONIC',
+  OpenFoodFactsLanguage.DZONGKHA_LANGUAGE: 'DZONGKHA_LANGUAGE',
+  OpenFoodFactsLanguage.JAPANESE: 'JAPANESE',
+  OpenFoodFactsLanguage.MALAY: 'MALAY',
+  OpenFoodFactsLanguage.TAGALOG: 'TAGALOG',
+  OpenFoodFactsLanguage.MOLDOVAN: 'MOLDOVAN',
+  OpenFoodFactsLanguage.MONGOLIAN: 'MONGOLIAN',
+  OpenFoodFactsLanguage.KOREAN: 'KOREAN',
+  OpenFoodFactsLanguage.LUBA_KATANGA_LANGUAGE: 'LUBA_KATANGA_LANGUAGE',
+  OpenFoodFactsLanguage.KAZAKH: 'KAZAKH',
+  OpenFoodFactsLanguage.QUECHUA_LANGUAGES: 'QUECHUA_LANGUAGES',
+  OpenFoodFactsLanguage.UKRAINIAN: 'UKRAINIAN',
+  OpenFoodFactsLanguage.OCCITAN: 'OCCITAN',
+  OpenFoodFactsLanguage.BIHARI_LANGUAGES: 'BIHARI_LANGUAGES',
+  OpenFoodFactsLanguage.SOUTHERN_NDEBELE: 'SOUTHERN_NDEBELE',
+  OpenFoodFactsLanguage.BOKMAL: 'BOKMAL',
+  OpenFoodFactsLanguage.KOMI: 'KOMI',
+  OpenFoodFactsLanguage.MODERN_GREEK: 'MODERN_GREEK',
+  OpenFoodFactsLanguage.FIJIAN_LANGUAGE: 'FIJIAN_LANGUAGE',
+  OpenFoodFactsLanguage.ZULU: 'ZULU',
+  OpenFoodFactsLanguage.IDO: 'IDO',
+  OpenFoodFactsLanguage.KHMER: 'KHMER',
+  OpenFoodFactsLanguage.SANSKRIT: 'SANSKRIT',
+  OpenFoodFactsLanguage.MACEDONIAN: 'MACEDONIAN',
+  OpenFoodFactsLanguage.SOTHO: 'SOTHO',
+  OpenFoodFactsLanguage.SCOTTISH_GAELIC: 'SCOTTISH_GAELIC',
+  OpenFoodFactsLanguage.MARATHI: 'MARATHI',
+  OpenFoodFactsLanguage.NAURUAN: 'NAURUAN',
+  OpenFoodFactsLanguage.OROMO: 'OROMO',
+  OpenFoodFactsLanguage.WELSH: 'WELSH',
+  OpenFoodFactsLanguage.VIETNAMESE: 'VIETNAMESE',
+  OpenFoodFactsLanguage.BISLAMA: 'BISLAMA',
+  OpenFoodFactsLanguage.SOMALI: 'SOMALI',
+  OpenFoodFactsLanguage.LITHUANIAN: 'LITHUANIAN',
+  OpenFoodFactsLanguage.HAITIAN_CREOLE: 'HAITIAN_CREOLE',
+  OpenFoodFactsLanguage.MALAGASY: 'MALAGASY',
+  OpenFoodFactsLanguage.SPANISH: 'SPANISH',
+  OpenFoodFactsLanguage.DANISH: 'DANISH',
+  OpenFoodFactsLanguage.SLOVENE: 'SLOVENE',
+  OpenFoodFactsLanguage.ICELANDIC: 'ICELANDIC',
+  OpenFoodFactsLanguage.ESTONIAN: 'ESTONIAN',
+  OpenFoodFactsLanguage.WOLOF: 'WOLOF',
+  OpenFoodFactsLanguage.HIRI_MOTU: 'HIRI_MOTU',
+  OpenFoodFactsLanguage.TAMIL: 'TAMIL',
+  OpenFoodFactsLanguage.SLOVAK: 'SLOVAK',
+  OpenFoodFactsLanguage.HERERO: 'HERERO',
+  OpenFoodFactsLanguage.ITALIAN: 'ITALIAN',
+  OpenFoodFactsLanguage.IRISH: 'IRISH',
+  OpenFoodFactsLanguage.SHONA: 'SHONA',
+  OpenFoodFactsLanguage.MARSHALLESE: 'MARSHALLESE',
+  OpenFoodFactsLanguage.FRENCH: 'FRENCH',
+  OpenFoodFactsLanguage.AYMARA: 'AYMARA',
+  OpenFoodFactsLanguage.HEBREW: 'HEBREW',
+  OpenFoodFactsLanguage.NORTHERN_SAMI: 'NORTHERN_SAMI',
+  OpenFoodFactsLanguage.BENGALI: 'BENGALI',
+  OpenFoodFactsLanguage.ODIA: 'ODIA',
+  OpenFoodFactsLanguage.MALAYALAM: 'MALAYALAM',
+  OpenFoodFactsLanguage.DUTCH: 'DUTCH',
+  OpenFoodFactsLanguage.UYGHUR: 'UYGHUR',
+  OpenFoodFactsLanguage.SERBIAN: 'SERBIAN',
+  OpenFoodFactsLanguage.TIBETAN_LANGUAGE: 'TIBETAN_LANGUAGE',
+  OpenFoodFactsLanguage.BELARUSIAN: 'BELARUSIAN',
+  OpenFoodFactsLanguage.SAMOAN: 'SAMOAN',
+  OpenFoodFactsLanguage.PUNJABI: 'PUNJABI',
+  OpenFoodFactsLanguage.RUSSIAN: 'RUSSIAN',
+  OpenFoodFactsLanguage.TAHITIAN: 'TAHITIAN',
+  OpenFoodFactsLanguage.INTERLINGUA: 'INTERLINGUA',
+  OpenFoodFactsLanguage.AFAR: 'AFAR',
+  OpenFoodFactsLanguage.GREENLANDIC: 'GREENLANDIC',
+  OpenFoodFactsLanguage.LATIN: 'LATIN',
+  OpenFoodFactsLanguage.CHINESE: 'CHINESE',
+  OpenFoodFactsLanguage.TURKMEN: 'TURKMEN',
+  OpenFoodFactsLanguage.WEST_FRISIAN: 'WEST_FRISIAN',
+  OpenFoodFactsLanguage.TSONGA: 'TSONGA',
+  OpenFoodFactsLanguage.ROMANSH: 'ROMANSH',
+  OpenFoodFactsLanguage.INUPIAT_LANGUAGE: 'INUPIAT_LANGUAGE',
+  OpenFoodFactsLanguage.TAJIK: 'TAJIK',
+  OpenFoodFactsLanguage.BURMESE: 'BURMESE',
+  OpenFoodFactsLanguage.JAVANESE: 'JAVANESE',
+  OpenFoodFactsLanguage.CHECHEN: 'CHECHEN',
+  OpenFoodFactsLanguage.ASSAMESE: 'ASSAMESE',
+  OpenFoodFactsLanguage.UNKNOWN_LANGUAGE: 'UNKNOWN_LANGUAGE',
+  OpenFoodFactsLanguage.ARABIC: 'ARABIC',
+  OpenFoodFactsLanguage.KINYARWANDA: 'KINYARWANDA',
+  OpenFoodFactsLanguage.TONGAN_LANGUAGE: 'TONGAN_LANGUAGE',
+  OpenFoodFactsLanguage.CHURCH_SLAVONIC: 'CHURCH_SLAVONIC',
+  OpenFoodFactsLanguage.SINHALA: 'SINHALA',
+  OpenFoodFactsLanguage.ARMENIAN: 'ARMENIAN',
+  OpenFoodFactsLanguage.KURDISH: 'KURDISH',
+  OpenFoodFactsLanguage.THAI: 'THAI',
+  OpenFoodFactsLanguage.CREE: 'CREE',
+  OpenFoodFactsLanguage.SWAHILI: 'SWAHILI',
+  OpenFoodFactsLanguage.GUJARATI: 'GUJARATI',
+  OpenFoodFactsLanguage.PERSIAN: 'PERSIAN',
+  OpenFoodFactsLanguage.BOSNIAN: 'BOSNIAN',
+  OpenFoodFactsLanguage.AMHARIC: 'AMHARIC',
+  OpenFoodFactsLanguage.ARAGONESE: 'ARAGONESE',
+  OpenFoodFactsLanguage.CROATIAN: 'CROATIAN',
+  OpenFoodFactsLanguage.CHEWA: 'CHEWA',
+  OpenFoodFactsLanguage.ZHUANG_LANGUAGES: 'ZHUANG_LANGUAGES',
+  OpenFoodFactsLanguage.LINGALA_LANGUAGE: 'LINGALA_LANGUAGE',
+  OpenFoodFactsLanguage.BAMBARA: 'BAMBARA',
+  OpenFoodFactsLanguage.LIMBURGISH_LANGUAGE: 'LIMBURGISH_LANGUAGE',
+  OpenFoodFactsLanguage.NUOSU_LANGUAGE: 'NUOSU_LANGUAGE',
+  OpenFoodFactsLanguage.KWANYAMA: 'KWANYAMA',
+  OpenFoodFactsLanguage.KIRUNDI: 'KIRUNDI',
+  OpenFoodFactsLanguage.EWE: 'EWE',
+  OpenFoodFactsLanguage.FAROESE: 'FAROESE',
+  OpenFoodFactsLanguage.SINDHI: 'SINDHI',
+  OpenFoodFactsLanguage.CORSICAN: 'CORSICAN',
+  OpenFoodFactsLanguage.KANNADA: 'KANNADA',
+  OpenFoodFactsLanguage.NORWEGIAN: 'NORWEGIAN',
+  OpenFoodFactsLanguage.SUNDANESE_LANGUAGE: 'SUNDANESE_LANGUAGE',
+  OpenFoodFactsLanguage.GEORGIAN: 'GEORGIAN',
+  OpenFoodFactsLanguage.HAUSA: 'HAUSA',
+  OpenFoodFactsLanguage.TSWANA: 'TSWANA',
+  OpenFoodFactsLanguage.CATALAN: 'CATALAN',
+  OpenFoodFactsLanguage.NDONGA_DIALECT: 'NDONGA_DIALECT',
+  OpenFoodFactsLanguage.IGBO_LANGUAGE: 'IGBO_LANGUAGE',
+  OpenFoodFactsLanguage.AFRIKAANS: 'AFRIKAANS',
+  OpenFoodFactsLanguage.POLISH: 'POLISH',
+  OpenFoodFactsLanguage.KASHMIRI: 'KASHMIRI',
+  OpenFoodFactsLanguage.MAORI: 'MAORI',
+  OpenFoodFactsLanguage.HUNGARIAN: 'HUNGARIAN',
+  OpenFoodFactsLanguage.BRETON: 'BRETON',
+  OpenFoodFactsLanguage.PORTUGUESE: 'PORTUGUESE',
+  OpenFoodFactsLanguage.BULGARIAN: 'BULGARIAN',
+  OpenFoodFactsLanguage.AVESTAN: 'AVESTAN',
+  OpenFoodFactsLanguage.NEPALI: 'NEPALI',
+  OpenFoodFactsLanguage.TWI: 'TWI',
+  OpenFoodFactsLanguage.UZBEK: 'UZBEK',
+  OpenFoodFactsLanguage.CHAMORRO: 'CHAMORRO',
+  OpenFoodFactsLanguage.GUARANI: 'GUARANI',
+  OpenFoodFactsLanguage.NYNORSK: 'NYNORSK',
+  OpenFoodFactsLanguage.AZERBAIJANI: 'AZERBAIJANI',
+  OpenFoodFactsLanguage.CZECH: 'CZECH',
+  OpenFoodFactsLanguage.NAVAJO: 'NAVAJO',
+  OpenFoodFactsLanguage.FINNISH: 'FINNISH',
+  OpenFoodFactsLanguage.LUXEMBOURGISH: 'LUXEMBOURGISH',
+  OpenFoodFactsLanguage.SWEDISH: 'SWEDISH',
+  OpenFoodFactsLanguage.YIDDISH: 'YIDDISH',
+  OpenFoodFactsLanguage.INUKTITUT: 'INUKTITUT',
+  OpenFoodFactsLanguage.LAO: 'LAO',
+  OpenFoodFactsLanguage.CHUVASH: 'CHUVASH',
+  OpenFoodFactsLanguage.MALTESE: 'MALTESE',
+  OpenFoodFactsLanguage.MALDIVIAN_LANGUAGE: 'MALDIVIAN_LANGUAGE',
+  OpenFoodFactsLanguage.INTERLINGUE: 'INTERLINGUE',
+  OpenFoodFactsLanguage.OSSETIAN: 'OSSETIAN',
+  OpenFoodFactsLanguage.BASHKIR: 'BASHKIR',
+  OpenFoodFactsLanguage.OJIBWE: 'OJIBWE',
+  OpenFoodFactsLanguage.KANURI: 'KANURI',
+  OpenFoodFactsLanguage.INDONESIAN: 'INDONESIAN',
+  OpenFoodFactsLanguage.SARDINIAN_LANGUAGE: 'SARDINIAN_LANGUAGE',
+  OpenFoodFactsLanguage.AKAN: 'AKAN',
+  OpenFoodFactsLanguage.MANX: 'MANX',
+  OpenFoodFactsLanguage.TURKISH: 'TURKISH',
+  OpenFoodFactsLanguage.ESPERANTO: 'ESPERANTO',
+  OpenFoodFactsLanguage.PASHTO: 'PASHTO',
+  OpenFoodFactsLanguage.KYRGYZ: 'KYRGYZ',
+  OpenFoodFactsLanguage.VOLAPUK: 'VOLAPUK',
+  OpenFoodFactsLanguage.AVAR: 'AVAR',
+  OpenFoodFactsLanguage.SANGO: 'SANGO',
+  OpenFoodFactsLanguage.VENDA: 'VENDA',
+  OpenFoodFactsLanguage.ALBANIAN: 'ALBANIAN',
+  OpenFoodFactsLanguage.BASQUE: 'BASQUE',
+  OpenFoodFactsLanguage.FULA_LANGUAGE: 'FULA_LANGUAGE',
+  OpenFoodFactsLanguage.GERMAN: 'GERMAN',
+  OpenFoodFactsLanguage.LATVIAN: 'LATVIAN',
+  OpenFoodFactsLanguage.CORNISH: 'CORNISH',
+  OpenFoodFactsLanguage.PALI: 'PALI',
+  OpenFoodFactsLanguage.TATAR: 'TATAR',
+  OpenFoodFactsLanguage.ROMANIAN: 'ROMANIAN',
+  OpenFoodFactsLanguage.GIKUYU: 'GIKUYU',
+  OpenFoodFactsLanguage.TIGRINYA: 'TIGRINYA',
+  OpenFoodFactsLanguage.GALICIAN: 'GALICIAN',
+  OpenFoodFactsLanguage.TELUGU: 'TELUGU',
+  OpenFoodFactsLanguage.HINDI: 'HINDI',
+  OpenFoodFactsLanguage.KONGO_LANGUAGE: 'KONGO_LANGUAGE',
+  OpenFoodFactsLanguage.XHOSA: 'XHOSA',
+  OpenFoodFactsLanguage.SWAZI: 'SWAZI',
+  OpenFoodFactsLanguage.LUGANDA: 'LUGANDA',
+  OpenFoodFactsLanguage.URDU: 'URDU',
+  OpenFoodFactsLanguage.NORTHERN_NDEBELE_LANGUAGE: 'NORTHERN_NDEBELE_LANGUAGE',
+  OpenFoodFactsLanguage.YORUBA: 'YORUBA',
+  OpenFoodFactsLanguage.WORLD: 'WORLD',
+  OpenFoodFactsLanguage.UNDEFINED: 'UNDEFINED',
+};

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -24,6 +24,7 @@ import 'package:openfoodfacts/model/TaxonomyLanguage.dart';
 import 'package:openfoodfacts/model/TaxonomyOrigin.dart';
 import 'package:openfoodfacts/model/TaxonomyPackaging.dart';
 import 'package:openfoodfacts/model/TaxonomyPackagingMaterial.dart';
+import 'package:openfoodfacts/model/TaxonomyPackagingRecycling.dart';
 import 'package:openfoodfacts/model/TaxonomyPackagingShape.dart';
 import 'package:openfoodfacts/model/parameter/BarcodeParameter.dart';
 import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
@@ -419,6 +420,18 @@ class OpenFoodAPIClient {
     QueryType? queryType,
   }) =>
       getTaxonomy<TaxonomyPackagingMaterial, TaxonomyPackagingMaterialField>(
+        configuration,
+        user: user,
+        queryType: queryType,
+      );
+
+  static Future<
+      Map<String, TaxonomyPackagingRecycling>?> getTaxonomyPackagingRecycling(
+    TaxonomyPackagingRecyclingQueryConfiguration configuration, {
+    User? user,
+    QueryType? queryType,
+  }) =>
+      getTaxonomy<TaxonomyPackagingRecycling, TaxonomyPackagingRecyclingField>(
         configuration,
         user: user,
         queryType: queryType,

--- a/lib/utils/TagType.dart
+++ b/lib/utils/TagType.dart
@@ -14,6 +14,7 @@ enum TagType implements OffTagged {
   ORIGINS(offTag: 'origins'),
   PACKAGING_SHAPES(offTag: 'packaging_shapes'),
   PACKAGING_MATERIALS(offTag: 'packaging_materials'),
+  PACKAGING_RECYCLING(offTag: 'packaging_recycling'),
   EMB_CODES(offTag: 'emb_codes');
 
   const TagType({

--- a/test/api_getTaxonomyPackagingRecyclingServer_test.dart
+++ b/test/api_getTaxonomyPackagingRecyclingServer_test.dart
@@ -1,0 +1,85 @@
+import 'package:openfoodfacts/model/TaxonomyPackagingRecycling.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
+import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:test/test.dart';
+
+import 'test_constants.dart';
+
+/// Integration test about packaging recycling.
+void main() {
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
+  OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
+  OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
+  OpenFoodAPIConfiguration.globalLanguages = [
+    OpenFoodFactsLanguage.ENGLISH,
+    OpenFoodFactsLanguage.FRENCH,
+  ];
+
+  const String knownTag = 'en:return-to-store';
+  const String expectedNameFrench = 'Consigné';
+  const String expectedNameEnglish = 'Return to store';
+  const Set<String> expectedChildren = <String>{
+    'en:return-pet-bottle-to-store',
+  };
+  const Set<String> expectedParents = <String>{
+    'en:recycle',
+  };
+  const Set<String> knownRootTags = {
+    'en:discard',
+    'en:recycle',
+    'en:reuse',
+  };
+  const String unknownTag = 'en:some_nonexistent_thing';
+
+  group('FABRICE OpenFoodAPIClient getTaxonomyPackagingRecycling SERVER', () {
+    void checkKnown(final TaxonomyPackagingRecycling value) {
+      expect(value.name![OpenFoodFactsLanguage.ENGLISH]!, expectedNameEnglish);
+      expect(value.name![OpenFoodFactsLanguage.FRENCH]!, expectedNameFrench);
+      expect(value.parents, unorderedEquals(expectedParents));
+      expect(value.children, unorderedEquals(expectedChildren));
+    }
+
+    test('get a packaging recycling', () async {
+      final Map<String, TaxonomyPackagingRecycling>? values =
+          await OpenFoodAPIClient.getTaxonomyPackagingRecycling(
+        TaxonomyPackagingRecyclingQueryConfiguration(tags: <String>[knownTag]),
+      );
+      expect(values, isNotNull);
+      expect(values!.length, equals(1));
+      checkKnown(values[knownTag]!);
+    });
+
+    test("get a packaging recycling that doesn't exist", () async {
+      final Map<String, TaxonomyPackagingRecycling>? values =
+          await OpenFoodAPIClient.getTaxonomyPackagingRecycling(
+        TaxonomyPackagingRecyclingQueryConfiguration(
+            tags: <String>[unknownTag]),
+      );
+      expect(values, isNull);
+    });
+
+    test("get a packaging recycling that doesn't exist with one that does",
+        () async {
+      final Map<String, TaxonomyPackagingRecycling>? values =
+          await OpenFoodAPIClient.getTaxonomyPackagingRecycling(
+        TaxonomyPackagingRecyclingQueryConfiguration(
+          tags: <String>[unknownTag, knownTag],
+        ),
+      );
+      expect(values, isNotNull);
+      expect(values!.length, equals(1));
+      checkKnown(values[knownTag]!);
+    });
+
+    test('get all root packaging recycling', () async {
+      final Map<String, TaxonomyPackagingRecycling>? values =
+          await OpenFoodAPIClient.getTaxonomyPackagingRecycling(
+        TaxonomyPackagingRecyclingQueryConfiguration.roots(),
+      );
+      expect(values, isNotNull);
+      expect(values!.keys, unorderedEquals(knownRootTags));
+    });
+  });
+}

--- a/test/api_get_autocompleted_suggestions_test.dart
+++ b/test/api_get_autocompleted_suggestions_test.dart
@@ -269,6 +269,15 @@ void main() {
       );
       listContains(result, 'carton');
     });
+    test('Suggestions for packaging_recycling', () async {
+      final List<dynamic> result =
+          await OpenFoodAPIClient.getAutocompletedSuggestions(
+        TagType.PACKAGING_RECYCLING,
+        language: OpenFoodFactsLanguage.FRENCH,
+        input: 'conten',
+      );
+      listContains(result, 'conteneur');
+    });
     test('Suggestions for emb_code', () async {
       List<dynamic> result =
           await OpenFoodAPIClient.getAutocompletedSuggestions(


### PR DESCRIPTION
New files:
* `api_getTaxonomyPackagingRecyclingServer_test.dart`: server tests around Packaging Recycling Taxonomy
* `TaxonomyPackagingRecycling.dart`: Packaging Recycling Taxonomy classes
* `TaxonomyPackagingRecycling.g.dart`: generated

Impacted files:
* `api_get_autocompleted_suggestions_test.dart`: added suggestion tests for packaging recycling
* `openfoodfacts.dart`: added method `getTaxonomyPackagingRecycling`
* `TagType.dart`: added field type for packaging recycling

### What
- Taxonomy: support of packaging recycling

### Fixes bug(s)
- Closes: #614