### PR TITLE
fix: #571 - last step of migration of enums to dart 2.17

### DIFF
--- a/lib/model/NutrientLevels.dart
+++ b/lib/model/NutrientLevels.dart
@@ -1,19 +1,27 @@
-enum Level { LOW, MODERATE, HIGH, UNDEFINED }
+import 'package:openfoodfacts/model/OffTagged.dart';
+
+enum Level implements OffTagged {
+  LOW(offTag: 'low'),
+  MODERATE(offTag: 'moderate'),
+  HIGH(offTag: 'high'),
+  UNDEFINED(offTag: 'undefined');
+
+  const Level({
+    required this.offTag,
+  });
+
+  @override
+  final String offTag;
+
+  /// Returns the first [Level] that matches the [offTag].
+  static Level? fromOffTag(final String? offTag) =>
+      OffTagged.fromOffTag(offTag, Level.values) as Level?;
+}
 
 extension LevelExtension on Level? {
-  static const Map<Level, String> _VALUES = {
-    Level.LOW: 'low',
-    Level.MODERATE: 'moderate',
-    Level.HIGH: 'high',
-    Level.UNDEFINED: 'undefined',
-  };
+  String get value => (this ?? Level.UNDEFINED).offTag;
 
-  String get value => _VALUES[this] ?? 'undefined';
-
-  static Level getLevel(String? s) => Level.values.firstWhere(
-        (final Level key) => _VALUES[key] == s,
-        orElse: () => Level.UNDEFINED,
-      );
+  static Level getLevel(String? s) => Level.fromOffTag(s) ?? Level.UNDEFINED;
 }
 
 class NutrientLevels {

--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -594,7 +594,7 @@ class Product extends JsonObject {
       Map value, OpenFoodFactsLanguage language) {
     final Map<ImageField, int> result = {};
     for (final ImageField imageField in ImageField.values) {
-      final int? timestamp = value['${imageField.value}_${language.code}'];
+      final int? timestamp = value['${imageField.offTag}_${language.offTag}'];
       if (timestamp != null) {
         result[imageField] = timestamp;
       }
@@ -627,7 +627,7 @@ class Product extends JsonObject {
                 'a proper language. Received: $langKey');
           }
           final keyNoLangs = key.substring(0, key.indexOf('_in_languages'));
-          final realKey = '${keyNoLangs}_${lang.code}';
+          final realKey = '${keyNoLangs}_${lang.offTag}';
           json[realKey] = entry.value;
         }
       }

--- a/lib/model/SendImage.dart
+++ b/lib/model/SendImage.dart
@@ -22,17 +22,17 @@ class SendImage extends JsonObject {
 
   /// the json key depending on the image field of this object.
   String getImageDataKey() {
-    String imageDataKey = 'imgupload_${imageField.value}';
+    String imageDataKey = 'imgupload_${imageField.offTag}';
     if (lang != null) {
-      imageDataKey += '_${lang.code}';
+      imageDataKey += '_${lang!.offTag}';
     }
     return imageDataKey;
   }
 
   String _getImageFieldWithLang() {
-    String imageFieldWithLang = imageField.value;
+    String imageFieldWithLang = imageField.offTag;
     if (lang != null) {
-      imageFieldWithLang += '_${lang.code}';
+      imageFieldWithLang += '_${lang!.offTag}';
     }
     return imageFieldWithLang;
   }

--- a/lib/model/State.dart
+++ b/lib/model/State.dart
@@ -1,72 +1,51 @@
 /// States of a [Product]. To be used in search API, with [StatesTagsParameter].
-enum State {
-  CHECKED,
-  COMPLETED,
-  NUTRITION_FACTS_COMPLETED,
-  INGREDIENTS_COMPLETED,
-  EXPIRATION_DATE_COMPLETED,
-  PACKAGING_CODE_COMPLETED,
-  CHARACTERISTICS_COMPLETED,
-  ORIGINS_COMPLETED,
-  CATEGORIES_COMPLETED,
-  BRANDS_COMPLETED,
-  PACKAGING_COMPLETED,
-  QUANTITY_COMPLETED,
-  PRODUCT_NAME_COMPLETED,
-  PHOTOS_VALIDATED,
-  PACKAGING_PHOTO_SELECTED,
-  NUTRITION_PHOTO_SELECTED,
-  INGREDIENTS_PHOTO_SELECTED,
-  FRONT_PHOTO_SELECTED,
-  PHOTOS_UPLOADED,
-}
-
+///
 /// Provides tags for [State] and its status: completed or to-be-completed.
-extension StateExtension on State {
-  static const Map<State, String> _completed = <State, String>{
-    State.CHECKED: 'en:checked',
-    State.COMPLETED: 'en:complete',
-    State.NUTRITION_FACTS_COMPLETED: 'en:nutrition-facts-completed',
-    State.INGREDIENTS_COMPLETED: 'en:ingredients-completed',
-    State.EXPIRATION_DATE_COMPLETED: 'en:expiration-date-completed',
-    State.PACKAGING_CODE_COMPLETED: 'en:packaging-code-completed',
-    State.CHARACTERISTICS_COMPLETED: 'en:characteristics-completed',
-    State.ORIGINS_COMPLETED: 'en:origins-completed',
-    State.CATEGORIES_COMPLETED: 'en:categories-completed',
-    State.BRANDS_COMPLETED: 'en:brands-completed',
-    State.PACKAGING_COMPLETED: 'en:packaging-completed',
-    State.QUANTITY_COMPLETED: 'en:quantity-completed',
-    State.PRODUCT_NAME_COMPLETED: 'en:product-name-completed',
-    State.PHOTOS_VALIDATED: 'en:photos-validated',
-    State.PACKAGING_PHOTO_SELECTED: 'en:packaging-photo-selected',
-    State.NUTRITION_PHOTO_SELECTED: 'en:nutrition-photo-selected',
-    State.INGREDIENTS_PHOTO_SELECTED: 'en:ingredients-photo-selected',
-    State.FRONT_PHOTO_SELECTED: 'en:front-photo-selected',
-    State.PHOTOS_UPLOADED: 'en:photos-uploaded',
-  };
-  static const Map<State, String> _toBeCompleted = <State, String>{
-    State.CHECKED: 'en:to-be-checked',
-    State.COMPLETED: 'en:to-be-completed',
-    State.NUTRITION_FACTS_COMPLETED: 'en:nutrition-facts-to-be-completed',
-    State.INGREDIENTS_COMPLETED: 'en:ingredients-to-be-completed',
-    State.EXPIRATION_DATE_COMPLETED: 'en:expiration-date-to-be-completed',
-    State.PACKAGING_CODE_COMPLETED: 'en:packaging-code-to-be-completed',
-    State.CHARACTERISTICS_COMPLETED: 'en:characteristics-to-be-completed',
-    State.ORIGINS_COMPLETED: 'en:origins-to-be-completed',
-    State.CATEGORIES_COMPLETED: 'en:categories-to-be-completed',
-    State.BRANDS_COMPLETED: 'en:brands-to-be-completed',
-    State.PACKAGING_COMPLETED: 'en:packaging-to-be-completed',
-    State.QUANTITY_COMPLETED: 'en:quantity-to-be-completed',
-    State.PRODUCT_NAME_COMPLETED: 'en:product-name-to-be-completed',
-    State.PHOTOS_VALIDATED: 'en:photos-to-be-validated',
-    State.PACKAGING_PHOTO_SELECTED: 'en:packaging-photo-to-be-selected',
-    State.NUTRITION_PHOTO_SELECTED: 'en:nutrition-photo-to-be-selected',
-    State.INGREDIENTS_PHOTO_SELECTED: 'en:ingredients-photo-to-be-selected',
-    State.FRONT_PHOTO_SELECTED: 'en:front-photo-to-be-selected',
-    State.PHOTOS_UPLOADED: 'en:photos-to-be-uploaded',
-  };
+enum State {
+  CHECKED(completedTag: 'en:checked', toBeCompletedTag: 'en:to-be-checked'),
+  COMPLETED(
+      completedTag: 'en:complete', toBeCompletedTag: 'en:to-be-completed'),
+  NUTRITION_FACTS_COMPLETED.completed(tag: 'en:nutrition-facts'),
+  INGREDIENTS_COMPLETED.completed(tag: 'en:ingredients'),
+  EXPIRATION_DATE_COMPLETED.completed(tag: 'en:expiration-date'),
+  PACKAGING_CODE_COMPLETED.completed(tag: 'en:packaging-code'),
+  CHARACTERISTICS_COMPLETED.completed(tag: 'en:characteristics'),
+  ORIGINS_COMPLETED.completed(tag: 'en:origins'),
+  CATEGORIES_COMPLETED.completed(tag: 'en:categories'),
+  BRANDS_COMPLETED.completed(tag: 'en:brands'),
+  PACKAGING_COMPLETED.completed(tag: 'en:packaging'),
+  QUANTITY_COMPLETED.completed(tag: 'en:quantity'),
+  PRODUCT_NAME_COMPLETED.completed(tag: 'en:product-name'),
+  PHOTOS_VALIDATED.simple(tag: 'en:photos', action: 'validated'),
+  PACKAGING_PHOTO_SELECTED.selected(tag: 'en:packaging-photo'),
+  NUTRITION_PHOTO_SELECTED.selected(tag: 'en:nutrition-photo'),
+  INGREDIENTS_PHOTO_SELECTED.selected(tag: 'en:ingredients-photo'),
+  FRONT_PHOTO_SELECTED.selected(tag: 'en:front-photo'),
+  PHOTOS_UPLOADED.simple(tag: 'en:photos', action: 'uploaded');
 
-  String get completedTag => _completed[this]!;
+  /// Special case where we need the tag values as we cannot build them.
+  const State({
+    required this.completedTag,
+    required this.toBeCompletedTag,
+  });
 
-  String get toBeCompletedTag => _toBeCompleted[this]!;
+  /// Simple case where we can build the tag values.
+  const State.simple({
+    required final String tag,
+    required final String action,
+  }) : this(
+          completedTag: '$tag-$action',
+          toBeCompletedTag: '$tag-to-be-$action',
+        );
+
+  /// Simple case where we can build the tag values, for 'completed'.
+  const State.completed({required final String tag})
+      : this.simple(tag: tag, action: 'completed');
+
+  /// Simple case where we can build the tag values, for 'selected'.
+  const State.selected({required final String tag})
+      : this.simple(tag: tag, action: 'selected');
+
+  final String completedTag;
+  final String toBeCompletedTag;
 }

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -113,10 +113,10 @@ class OpenFoodAPIClient {
     parameterMap.addAll(user.toData());
     parameterMap.addAll(product.toServerData());
     if (language != null) {
-      parameterMap['lc'] = language.code;
+      parameterMap['lc'] = language.offTag;
     }
     if (country != null) {
-      parameterMap['cc'] = country.iso2Code;
+      parameterMap['cc'] = country.offTag;
     }
 
     var productUri = UriHelper.getPostUri(
@@ -289,13 +289,13 @@ class OpenFoodAPIClient {
     }
     return UriHelper.replaceSubdomainWithCodes(
       uri,
-      languageCode: language.code,
+      languageCode: language.offTag,
     );
   }
 
   /// Returns the URI to the crowdin page for a [language].
   static Uri getCrowdinUri(final OpenFoodFactsLanguage language) =>
-      Uri.parse('https://crowdin.com/project/openfoodfacts/${language.code}');
+      Uri.parse('https://crowdin.com/project/openfoodfacts/${language.offTag}');
 
   /// Search the OpenFoodFacts product database with the given parameters.
   /// Returns the list of products as SearchResult.
@@ -777,7 +777,7 @@ class OpenFoodAPIClient {
     final Map<String, String> queryParameters = <String, String>{
       'code': barcode,
       'process_image': '1',
-      'id': 'ingredients_${language.code}',
+      'id': 'ingredients_${language.offTag}',
       'ocr_engine': ocrField.offTag
     };
     final Response response = await HttpHelper().doPostRequest(
@@ -807,7 +807,7 @@ class OpenFoodAPIClient {
     final Map<String, String> queryParameters = <String, String>{
       'code': barcode,
       'process_image': '1',
-      'id': 'packaging_${language.code}',
+      'id': 'packaging_${language.offTag}',
       'ocr_engine': ocrField.offTag
     };
     final Response response = await HttpHelper().doPostRequest(
@@ -839,7 +839,7 @@ class OpenFoodAPIClient {
     final Map<String, String> queryParameters = <String, String>{
       'tagtype': taxonomyType.offTag,
       'term': input,
-      'lc': language.code,
+      'lc': language.offTag,
       'limit': limit.toString(),
     };
     final Response response = await HttpHelper().doPostRequest(
@@ -1068,8 +1068,8 @@ class OpenFoodAPIClient {
       queryType: queryType,
     );
     Map<String, String> queryParameters = <String, String>{
-      'cc': country.iso2Code,
-      'lc': language.code,
+      'cc': country.offTag,
+      'lc': language.offTag,
     };
     final Response response = await HttpHelper().doPostRequest(
       uri,
@@ -1164,7 +1164,7 @@ class OpenFoodAPIClient {
     required final User user,
     final QueryType? queryType,
   }) async {
-    final String id = '${imageField.value}_${language.code}';
+    final String id = '${imageField.offTag}_${language.offTag}';
     final Map<String, String> queryParameters = <String, String>{
       'code': barcode,
       'id': id,
@@ -1219,7 +1219,7 @@ class OpenFoodAPIClient {
     required final User user,
     final QueryType? queryType,
   }) async {
-    final String id = '${imageField.value}_${language.code}';
+    final String id = '${imageField.offTag}_${language.offTag}';
     final Uri uri = UriHelper.getPostUri(
       path: 'cgi/product_image_unselect.pl',
       queryType: queryType,

--- a/lib/utils/AbstractQueryConfiguration.dart
+++ b/lib/utils/AbstractQueryConfiguration.dart
@@ -74,7 +74,7 @@ abstract class AbstractQueryConfiguration {
 
     if (queryLanguages.isNotEmpty) {
       result.putIfAbsent(
-          'lc', () => queryLanguages.map((e) => e.code).join(','));
+          'lc', () => queryLanguages.map((e) => e.offTag).join(','));
     }
 
     final String? countryCode = computeCountryCode();

--- a/lib/utils/CountryHelper.dart
+++ b/lib/utils/CountryHelper.dart
@@ -1,1008 +1,771 @@
+import 'package:openfoodfacts/model/OffTagged.dart';
+
 /// Countries, cf. https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
-enum OpenFoodFactsCountry {
+enum OpenFoodFactsCountry implements OffTagged {
   /// Andorra
-  ANDORRA,
+  ANDORRA(offTag: 'ad'),
 
   /// United Arab Emirates
-  UNITED_ARAB_EMIRATES,
+  UNITED_ARAB_EMIRATES(offTag: 'ae'),
 
   /// Afghanistan
-  AFGHANISTAN,
+  AFGHANISTAN(offTag: 'af'),
 
   /// Antigua and Barbuda
-  ANTIGUA_AND_BARBUDA,
+  ANTIGUA_AND_BARBUDA(offTag: 'ag'),
 
   /// Anguilla
-  ANGUILLA,
+  ANGUILLA(offTag: 'ai'),
 
   /// Albania
-  ALBANIA,
+  ALBANIA(offTag: 'al'),
 
   /// Armenia
-  ARMENIA,
+  ARMENIA(offTag: 'am'),
 
   /// Angola
-  ANGOLA,
+  ANGOLA(offTag: 'ao'),
 
   /// Antarctica
-  ANTARCTICA,
+  ANTARCTICA(offTag: 'aq'),
 
   /// Argentina
-  ARGENTINA,
+  ARGENTINA(offTag: 'ar'),
 
   /// American Samoa
-  AMERICAN_SAMOA,
+  AMERICAN_SAMOA(offTag: 'as'),
 
   /// Austria
-  AUSTRIA,
+  AUSTRIA(offTag: 'at'),
 
   /// Australia
-  AUSTRALIA,
+  AUSTRALIA(offTag: 'au'),
 
   /// Aruba
-  ARUBA,
+  ARUBA(offTag: 'aw'),
 
   /// Åland Islands
-  ALAND_ISLANDS,
+  ALAND_ISLANDS(offTag: 'ax'),
 
   /// Azerbaijan
-  AZERBAIJAN,
+  AZERBAIJAN(offTag: 'az'),
 
   /// Bosnia and Herzegovina
-  BOSNIA_AND_HERZEGOVINA,
+  BOSNIA_AND_HERZEGOVINA(offTag: 'ba'),
 
   /// Barbados
-  BARBADOS,
+  BARBADOS(offTag: 'bb'),
 
   /// Bangladesh
-  BANGLADESH,
+  BANGLADESH(offTag: 'bd'),
 
   /// Belgium
-  BELGIUM,
+  BELGIUM(offTag: 'be'),
 
   /// Burkina Faso
-  BURKINA_FASO,
+  BURKINA_FASO(offTag: 'bf'),
 
   /// Bulgaria
-  BULGARIA,
+  BULGARIA(offTag: 'bg'),
 
   /// Bahrain
-  BAHRAIN,
+  BAHRAIN(offTag: 'bh'),
 
   /// Burundi
-  BURUNDI,
+  BURUNDI(offTag: 'bi'),
 
   /// Benin
-  BENIN,
+  BENIN(offTag: 'bj'),
 
   /// Saint Barthélemy
-  SAINT_BARTHELEMY,
+  SAINT_BARTHELEMY(offTag: 'bl'),
 
   /// Bermuda
-  BERMUDA,
+  BERMUDA(offTag: 'bm'),
 
   /// Brunei Darussalam
-  BRUNEI_DARUSSALAM,
+  BRUNEI_DARUSSALAM(offTag: 'bn'),
 
   /// Bolivia (Plurinational State of)
-  BOLIVIA,
+  BOLIVIA(offTag: 'bo'),
 
   /// Bonaire, Sint Eustatius and Saba
-  BONAIRE,
+  BONAIRE(offTag: 'bq'),
 
   /// Brazil
-  BRAZIL,
+  BRAZIL(offTag: 'br'),
 
   /// Bahamas
-  BAHAMAS,
+  BAHAMAS(offTag: 'bs'),
 
   /// Bhutan
-  BHUTAN,
+  BHUTAN(offTag: 'bt'),
 
   /// Bouvet Island
-  BOUVET_ISLAND,
+  BOUVET_ISLAND(offTag: 'bv'),
 
   /// Botswana
-  BOTSWANA,
+  BOTSWANA(offTag: 'bw'),
 
   /// Belarus
-  BELARUS,
+  BELARUS(offTag: 'by'),
 
   /// Belize
-  BELIZE,
+  BELIZE(offTag: 'bz'),
 
   /// Canada
-  CANADA,
+  CANADA(offTag: 'ca'),
 
   /// Cocos (Keeling) Islands
-  COCOS_ISLANDS,
+  COCOS_ISLANDS(offTag: 'cc'),
 
   /// Congo, Democratic Republic of the
-  DEMOCRATIC_REPUBLIC_OF_THE_CONGO,
+  DEMOCRATIC_REPUBLIC_OF_THE_CONGO(offTag: 'cd'),
 
   /// Central African Republic
-  CENTRAL_AFRICAN_REPUBLIC,
+  CENTRAL_AFRICAN_REPUBLIC(offTag: 'cf'),
 
   /// Congo
-  CONGO,
+  CONGO(offTag: 'cg'),
 
   /// Switzerland
-  SWITZERLAND,
+  SWITZERLAND(offTag: 'ch'),
 
   /// Côte d'Ivoire
-  COTE_D_IVOIRE,
+  COTE_D_IVOIRE(offTag: 'ci'),
 
   /// Cook Islands
-  COOK_ISLANDS,
+  COOK_ISLANDS(offTag: 'ck'),
 
   /// Chile
-  CHILE,
+  CHILE(offTag: 'cl'),
 
   /// Cameroon
-  CAMEROON,
+  CAMEROON(offTag: 'cm'),
 
   /// China
-  CHINA,
+  CHINA(offTag: 'cn'),
 
   /// Colombia
-  COLOMBIA,
+  COLOMBIA(offTag: 'co'),
 
   /// Costa Rica
-  COSTA_RICA,
+  COSTA_RICA(offTag: 'cr'),
 
   /// Cuba
-  CUBA,
+  CUBA(offTag: 'cu'),
 
   /// Cabo Verde
-  CABO_VERDE,
+  CABO_VERDE(offTag: 'cv'),
 
   /// Curaçao
-  CURACAO,
+  CURACAO(offTag: 'cw'),
 
   /// Christmas Island
-  CHRISTMAS_ISLAND,
+  CHRISTMAS_ISLAND(offTag: 'cx'),
 
   ///Cyprus
-  CYPRUS,
+  CYPRUS(offTag: 'cy'),
 
   /// Czechia
-  CZECHIA,
+  CZECHIA(offTag: 'cz'),
 
   /// Germany
-  GERMANY,
+  GERMANY(offTag: 'de'),
 
   /// Djibouti
-  DJIBOUTI,
+  DJIBOUTI(offTag: 'dj'),
 
   /// Denmark
-  DENMARK,
+  DENMARK(offTag: 'dk'),
 
   /// Dominica
-  DOMINICA,
+  DOMINICA(offTag: 'dm'),
 
   /// Dominican Republic
-  DOMINICAN_REPUBLIC,
+  DOMINICAN_REPUBLIC(offTag: 'do'),
 
   /// Algeria
-  ALGERIA,
+  ALGERIA(offTag: 'dz'),
 
   /// Ecuador
-  ECUADOR,
+  ECUADOR(offTag: 'ec'),
 
   /// Estonia
-  ESTONIA,
+  ESTONIA(offTag: 'ee'),
 
   /// Egypt
-  EGYPT,
+  EGYPT(offTag: 'eg'),
 
   /// Western Sahara
-  WESTERN_SAHARA,
+  WESTERN_SAHARA(offTag: 'eh'),
 
   /// Eritrea
-  ERITREA,
+  ERITREA(offTag: 'er'),
 
   /// Spain
-  SPAIN,
+  SPAIN(offTag: 'es'),
 
   /// Ethiopia
-  ETHIOPIA,
+  ETHIOPIA(offTag: 'et'),
 
   /// Finland
-  FINLAND,
+  FINLAND(offTag: 'fi'),
 
   /// Fiji
-  FIJI,
+  FIJI(offTag: 'fj'),
 
   /// Falkland Islands (Malvinas)
-  FALKLAND_ISLANDS,
+  FALKLAND_ISLANDS(offTag: 'fk'),
 
   /// Micronesia (Federated States of)
-  MICRONESIA,
+  MICRONESIA(offTag: 'fm'),
 
   /// Faroe Islands
-  FAROE_ISLANDS,
+  FAROE_ISLANDS(offTag: 'fo'),
 
   /// France
-  FRANCE,
+  FRANCE(offTag: 'fr'),
 
   /// Gabon
-  GABON,
+  GABON(offTag: 'ga'),
 
   /// United Kingdom of Great Britain and Northern Ireland
-  UNITED_KINGDOM,
+  // in OFF this is not 'gb'
+  UNITED_KINGDOM(offTag: 'uk'),
 
   /// Grenada
-  GRENADA,
+  GRENADA(offTag: 'gd'),
 
   /// Georgia
-  GEORGIA,
+  GEORGIA(offTag: 'ge'),
 
   /// French Guiana
-  FRENCH_GUIANA,
+  FRENCH_GUIANA(offTag: 'gf'),
 
   /// Guernsey
-  GUERNSEY,
+  GUERNSEY(offTag: 'gg'),
 
   /// Ghana
-  GHANA,
+  GHANA(offTag: 'gh'),
 
   /// Gibraltar
-  GIBRALTAR,
+  GIBRALTAR(offTag: 'gi'),
 
   /// Greenland
-  GREENLAND,
+  GREENLAND(offTag: 'gl'),
 
   /// Gambia
-  GAMBIA,
+  GAMBIA(offTag: 'gm'),
 
   /// Guinea
-  GUINEA,
+  GUINEA(offTag: 'gn'),
 
   /// Guadeloupe
-  GUADELOUPE,
+  GUADELOUPE(offTag: 'gp'),
 
   /// Equatorial Guinea
-  EQUATORIAL_GUINEA,
+  EQUATORIAL_GUINEA(offTag: 'gq'),
 
   /// Greece
-  GREECE,
+  GREECE(offTag: 'gr'),
 
   /// South Georgia and the South Sandwich Islands
-  SOUTH_GEORGIA,
+  SOUTH_GEORGIA(offTag: 'gs'),
 
   /// Guatemala
-  GUATEMALA,
+  GUATEMALA(offTag: 'gt'),
 
   /// Guam
-  GUAM,
+  GUAM(offTag: 'gu'),
 
   /// Guinea-Bissau
-  GUINEA_BISSAU,
+  GUINEA_BISSAU(offTag: 'gw'),
 
   /// Guyana
-  GUYANA,
+  GUYANA(offTag: 'gy'),
 
   /// Hong Kong
-  HONG_KONG,
+  HONG_KONG(offTag: 'hk'),
 
   /// Heard Island and McDonald Islands
-  HEARD_ISLAND,
+  HEARD_ISLAND(offTag: 'hm'),
 
   /// Honduras
-  HONDURAS,
+  HONDURAS(offTag: 'hn'),
 
   /// Croatia
-  CROATIA,
+  CROATIA(offTag: 'hr'),
 
   /// Haiti
-  HAITI,
+  HAITI(offTag: 'ht'),
 
   /// Hungary
-  HUNGARY,
+  HUNGARY(offTag: 'hu'),
 
   /// Indonesia
-  INDONESIA,
+  INDONESIA(offTag: 'id'),
 
   /// Ireland
-  IRELAND,
+  IRELAND(offTag: 'ie'),
 
   /// Israel
-  ISRAEL,
+  ISRAEL(offTag: 'il'),
 
   /// Isle of Man
-  ISLE_OF_MAN,
+  ISLE_OF_MAN(offTag: 'im'),
 
   /// India
-  INDIA,
+  INDIA(offTag: 'in'),
 
   /// British Indian Ocean Territory
-  BRITISH_INDIAN_OCEAN_TERRITORY,
+  BRITISH_INDIAN_OCEAN_TERRITORY(offTag: 'io'),
 
   /// Iraq
-  IRAQ,
+  IRAQ(offTag: 'iq'),
 
   /// Iran (Islamic Republic of)
-  IRAN,
+  IRAN(offTag: 'ir'),
 
   /// Iceland
-  ICELAND,
+  ICELAND(offTag: 'is'),
 
   /// Italy
-  ITALY,
+  ITALY(offTag: 'it'),
 
   /// Jersey
-  JERSEY,
+  JERSEY(offTag: 'je'),
 
   /// Jamaica
-  JAMAICA,
+  JAMAICA(offTag: 'jm'),
 
   /// Jordan
-  JORDAN,
+  JORDAN(offTag: 'jo'),
 
   /// Japan
-  JAPAN,
+  JAPAN(offTag: 'jp'),
 
   /// Kenya
-  KENYA,
+  KENYA(offTag: 'ke'),
 
   /// Kyrgyzstan
-  KYRGYZSTAN,
+  KYRGYZSTAN(offTag: 'kg'),
 
   /// Cambodia
-  CAMBODIA,
+  CAMBODIA(offTag: 'kh'),
 
   /// Kiribati
-  KIRIBATI,
+  KIRIBATI(offTag: 'ki'),
 
   /// Comoros
-  COMOROS,
+  COMOROS(offTag: 'km'),
 
   /// Saint Kitts and Nevis
-  SAINT_KITTS_AND_NEVIS,
+  SAINT_KITTS_AND_NEVIS(offTag: 'kn'),
 
   /// Korea (Democratic People's Republic of)
-  NORTH_KOREA,
+  NORTH_KOREA(offTag: 'kp'),
 
   /// Korea, Republic of
-  SOUTH_KOREA,
+  SOUTH_KOREA(offTag: 'kr'),
 
   /// Kuwait
-  KUWAIT,
+  KUWAIT(offTag: 'kw'),
 
   /// Cayman Islands
-  CAYMAN_ISLANDS,
+  CAYMAN_ISLANDS(offTag: 'ky'),
 
   /// Kazakhstan
-  KAZAKHSTAN,
+  KAZAKHSTAN(offTag: 'kz'),
 
   /// Lao People's Democratic Republic
-  LAOS,
+  LAOS(offTag: 'la'),
 
   /// Lebanon
-  LEBANON,
+  LEBANON(offTag: 'lb'),
 
   /// Saint Lucia
-  SAINT_LUCIA,
+  SAINT_LUCIA(offTag: 'lc'),
 
   /// Liechtenstein
-  LIECHTENSTEIN,
+  LIECHTENSTEIN(offTag: 'li'),
 
   /// Sri Lanka
-  SRI_LANKA,
+  SRI_LANKA(offTag: 'lk'),
 
   /// Liberia
-  LIBERIA,
+  LIBERIA(offTag: 'lr'),
 
   /// Lesotho
-  LESOTHO,
+  LESOTHO(offTag: 'ls'),
 
   /// Lithuania
-  LITHUANIA,
+  LITHUANIA(offTag: 'lt'),
 
   /// Luxembourg
-  LUXEMBOURG,
+  LUXEMBOURG(offTag: 'lu'),
 
   /// Latvia
-  LATVIA,
+  LATVIA(offTag: 'lv'),
 
   /// Libya
-  LIBYA,
+  LIBYA(offTag: 'ly'),
 
   /// Morocco
-  MOROCCO,
+  MOROCCO(offTag: 'ma'),
 
   /// Monaco
-  MONACO,
+  MONACO(offTag: 'mc'),
 
   /// Moldova, Republic of
-  MOLDOVA,
+  MOLDOVA(offTag: 'md'),
 
   /// Montenegro
-  MONTENEGRO,
+  MONTENEGRO(offTag: 'me'),
 
   /// Saint Martin (French part)
-  SAINT_MARTIN,
+  SAINT_MARTIN(offTag: 'mf'),
 
   /// Madagascar
-  MADAGASCAR,
+  MADAGASCAR(offTag: 'mg'),
 
   /// Marshall Islands
-  MARSHALL_ISLANDS,
+  MARSHALL_ISLANDS(offTag: 'mh'),
 
   /// North Macedonia
-  NORTH_MACEDONIA,
+  NORTH_MACEDONIA(offTag: 'mk'),
 
   /// Mali
-  MALI,
+  MALI(offTag: 'ml'),
 
   /// Myanmar
-  MYANMAR,
+  MYANMAR(offTag: 'mm'),
 
   /// Mongolia
-  MONGOLIA,
+  MONGOLIA(offTag: 'mn'),
 
   /// Macao
-  MACAO,
+  MACAO(offTag: 'mo'),
 
   /// Northern Mariana Islands
-  NORTHERN_MARIANA_ISLANDS,
+  NORTHERN_MARIANA_ISLANDS(offTag: 'mp'),
 
   /// Martinique
-  MARTINIQUE,
+  MARTINIQUE(offTag: 'mq'),
 
   /// Mauritania
-  MAURITANIA,
+  MAURITANIA(offTag: 'mr'),
 
   /// Montserrat
-  MONTSERRAT,
+  MONTSERRAT(offTag: 'ms'),
 
   /// Malta
-  MALTA,
+  MALTA(offTag: 'mt'),
 
   /// Mauritius
-  MAURITIUS,
+  MAURITIUS(offTag: 'mu'),
 
   /// Maldives
-  MALDIVES,
+  MALDIVES(offTag: 'mv'),
 
   /// Malawi
-  MALAWI,
+  MALAWI(offTag: 'mw'),
 
   /// Mexico
-  MEXICO,
+  MEXICO(offTag: 'mx'),
 
   /// Malaysia
-  MALAYSIA,
+  MALAYSIA(offTag: 'my'),
 
   /// Mozambique
-  MOZAMBIQUE,
+  MOZAMBIQUE(offTag: 'mz'),
 
   /// Namibia
-  NAMIBIA,
+  NAMIBIA(offTag: 'na'),
 
   /// New Caledonia
-  NEW_CALEDONIA,
+  NEW_CALEDONIA(offTag: 'nc'),
 
   /// Niger
-  NIGER,
+  NIGER(offTag: 'ne'),
 
   /// Norfolk Island
-  NORFOLK_ISLAND,
+  NORFOLK_ISLAND(offTag: 'nf'),
 
   /// Nigeria
-  NIGERIA,
+  NIGERIA(offTag: 'ng'),
 
   /// Nicaragua
-  NICARAGUA,
+  NICARAGUA(offTag: 'ni'),
 
   /// Netherlands
-  NETHERLANDS,
+  NETHERLANDS(offTag: 'nl'),
 
   /// Norway
-  NORWAY,
+  NORWAY(offTag: 'no'),
 
   /// Nepal
-  NEPAL,
+  NEPAL(offTag: 'np'),
 
   /// Nauru
-  NAURU,
+  NAURU(offTag: 'nr'),
 
   /// Niue
-  NIUE,
+  NIUE(offTag: 'nu'),
 
   /// New Zealand
-  NEW_ZEALAND,
+  NEW_ZEALAND(offTag: 'nz'),
 
   /// Oman
-  OMAN,
+  OMAN(offTag: 'om'),
 
   /// Panama
-  PANAMA,
+  PANAMA(offTag: 'pa'),
 
   /// Peru
-  PERU,
+  PERU(offTag: 'pe'),
 
   /// French Polynesia
-  FRENCH_POLYNESIA,
+  FRENCH_POLYNESIA(offTag: 'pf'),
 
   /// Papua New Guinea
-  PAPUA_NEW_GUINEA,
+  PAPUA_NEW_GUINEA(offTag: 'pg'),
 
   /// Philippines
-  PHILIPPINES,
+  PHILIPPINES(offTag: 'ph'),
 
   /// Pakistan
-  PAKISTAN,
+  PAKISTAN(offTag: 'pk'),
 
   /// Poland
-  POLAND,
+  POLAND(offTag: 'pl'),
 
   /// Saint Pierre and Miquelon
-  SAINT_PIERRE_AND_MIQUELON,
+  SAINT_PIERRE_AND_MIQUELON(offTag: 'pm'),
 
   /// Pitcairn
-  PITCAIRN,
+  PITCAIRN(offTag: 'pn'),
 
   /// Puerto Rico
-  PUERTO_RICO,
+  PUERTO_RICO(offTag: 'pr'),
 
   /// Palestine, State of
-  PALESTINE,
+  PALESTINE(offTag: 'ps'),
 
   /// Portugal
-  PORTUGAL,
+  PORTUGAL(offTag: 'pt'),
 
   /// Palau
-  PALAU,
+  PALAU(offTag: 'pw'),
 
   /// Paraguay
-  PARAGUAY,
+  PARAGUAY(offTag: 'py'),
 
   /// Qatar
-  QATAR,
+  QATAR(offTag: 'qa'),
 
   /// Réunion
-  REUNION,
+  REUNION(offTag: 're'),
 
   /// Romania
-  ROMANIA,
+  ROMANIA(offTag: 'ro'),
 
   /// Serbia
-  SERBIA,
+  SERBIA(offTag: 'rs'),
 
   /// Russian Federation
-  RUSSIA,
+  RUSSIA(offTag: 'ru'),
 
   /// Rwanda
-  RWANDA,
+  RWANDA(offTag: 'rw'),
 
   /// Saudi Arabia
-  SAUDI_ARABIA,
+  SAUDI_ARABIA(offTag: 'sa'),
 
   /// Solomon Islands
-  SOLOMON_ISLANDS,
+  SOLOMON_ISLANDS(offTag: 'sb'),
 
   /// Seychelles
-  SEYCHELLES,
+  SEYCHELLES(offTag: 'sc'),
 
   /// Sudan
-  SUDAN,
+  SUDAN(offTag: 'sd'),
 
   /// Sweden
-  SWEDEN,
+  SWEDEN(offTag: 'se'),
 
   /// Singapore
-  SINGAPORE,
+  SINGAPORE(offTag: 'sg'),
 
   /// Saint Helena, Ascension and Tristan da Cunha
-  SAINT_HELENA,
+  SAINT_HELENA(offTag: 'sh'),
 
   /// Slovenia
-  SLOVENIA,
+  SLOVENIA(offTag: 'si'),
 
   /// Svalbard and Jan Mayen
-  SVALBARD_AND_JAN_MAYEN,
+  SVALBARD_AND_JAN_MAYEN(offTag: 'sj'),
 
   /// Slovakia
-  SLOVAKIA,
+  SLOVAKIA(offTag: 'sk'),
 
   /// Sierra Leone
-  SIERRA_LEONE,
+  SIERRA_LEONE(offTag: 'sl'),
 
   /// San Marino
-  SAN_MARINO,
+  SAN_MARINO(offTag: 'sm'),
 
   /// Senegal
-  SENEGAL,
+  SENEGAL(offTag: 'sn'),
 
   /// Somalia
-  SOMALIA,
+  SOMALIA(offTag: 'so'),
 
   /// Suriname
-  SURINAME,
+  SURINAME(offTag: 'sr'),
 
   /// South Sudan
-  SOUTH_SUDAN,
+  SOUTH_SUDAN(offTag: 'ss'),
 
   /// Sao Tome and Principe
-  SAO_TOME_AND_PRINCIPE,
+  SAO_TOME_AND_PRINCIPE(offTag: 'st'),
 
   /// El Salvador
-  EL_SALVADOR,
+  EL_SALVADOR(offTag: 'sv'),
 
   /// Sint Maarten (Dutch part)
-  SINT_MAARTEN,
+  SINT_MAARTEN(offTag: 'sx'),
 
   /// Syrian Arab Republic
-  SYRIA,
+  SYRIA(offTag: 'sy'),
 
   /// Eswatini
-  ESWATINI,
+  ESWATINI(offTag: 'sz'),
 
   /// Turks and Caicos Islands
-  TURKS_AND_CAICOS_ISLANDS,
+  TURKS_AND_CAICOS_ISLANDS(offTag: 'tc'),
 
   /// Chad
-  CHAD,
+  CHAD(offTag: 'td'),
 
   /// French Southern Territories
-  FRENCH_SOUTHERN_TERRITORIES,
+  FRENCH_SOUTHERN_TERRITORIES(offTag: 'tf'),
 
   /// Togo
-  TOGO,
+  TOGO(offTag: 'tg'),
 
   /// Thailand
-  THAILAND,
+  THAILAND(offTag: 'th'),
 
   /// Tajikistan
-  TAJIKISTAN,
+  TAJIKISTAN(offTag: 'tj'),
 
   /// Tokelau
-  TOKELAU,
+  TOKELAU(offTag: 'tk'),
 
   /// Timor-Leste
-  TIMOR_LESTE,
+  TIMOR_LESTE(offTag: 'tl'),
 
   /// Turkmenistan
-  TURKMENISTAN,
+  TURKMENISTAN(offTag: 'tm'),
 
   /// Tunisia
-  TUNISIA,
+  TUNISIA(offTag: 'tn'),
 
   /// Tonga
-  TONGA,
+  TONGA(offTag: 'to'),
 
   /// Turkey
-  TURKEY,
+  TURKEY(offTag: 'tr'),
 
   /// Trinidad and Tobago
-  TRINIDAD_AND_TOBAGO,
+  TRINIDAD_AND_TOBAGO(offTag: 'tt'),
 
   /// Tuvalu
-  TUVALU,
+  TUVALU(offTag: 'tv'),
 
   /// Taiwan, Province of China
-  TAIWAN,
+  TAIWAN(offTag: 'tw'),
 
   /// Tanzania, United Republic of
-  TANZANIA,
+  TANZANIA(offTag: 'tz'),
 
   /// Ukraine
-  UKRAINE,
+  UKRAINE(offTag: 'ua'),
 
   /// Uganda
-  UGANDA,
+  UGANDA(offTag: 'ug'),
 
   /// United States Minor Outlying Islands
-  UNITED_STATES_MINOR_OUTLYING_ISLANDS,
+  UNITED_STATES_MINOR_OUTLYING_ISLANDS(offTag: 'um'),
 
   /// United States of America
-  USA,
+  USA(offTag: 'us'),
 
   /// Uruguay
-  URUGUAY,
+  URUGUAY(offTag: 'uy'),
 
   /// Uzbekistan
-  UZBEKISTAN,
+  UZBEKISTAN(offTag: 'uz'),
 
   /// Holy See
-  HOLY_SEE,
+  HOLY_SEE(offTag: 'va'),
 
   /// Saint Vincent and the Grenadines
-  SAINT_VINCENT_AND_THE_GRENADINES,
+  SAINT_VINCENT_AND_THE_GRENADINES(offTag: 'vc'),
 
   /// Venezuela (Bolivarian Republic of)
-  VENEZUELA,
+  VENEZUELA(offTag: 've'),
 
   /// Virgin Islands (British)
-  BRITISH_VIRGIN_ISLANDS,
+  BRITISH_VIRGIN_ISLANDS(offTag: 'vg'),
 
   /// Virgin Islands (U.S.)
-  US_VIRGIN_ISLANDS,
+  US_VIRGIN_ISLANDS(offTag: 'vi'),
 
   /// Viet Nam
-  VIET_NAM,
+  VIET_NAM(offTag: 'vn'),
 
   /// Vanuatu
-  VANUATU,
+  VANUATU(offTag: 'vu'),
 
   /// Wallis and Futuna
-  WALLIS_AND_FUTUNA,
+  WALLIS_AND_FUTUNA(offTag: 'wf'),
 
   /// Samoa
-  SAMOA,
+  SAMOA(offTag: 'ws'),
 
   /// Yemen
-  YEMEN,
+  YEMEN(offTag: 'ye'),
 
   /// Mayotte
-  MAYOTTE,
+  MAYOTTE(offTag: 'yt'),
 
   /// South Africa
-  SOUTH_AFRICA,
+  SOUTH_AFRICA(offTag: 'za'),
 
   /// Zambia
-  ZAMBIA,
+  ZAMBIA(offTag: 'zm'),
 
   /// Zimbabwe
-  ZIMBABWE,
-}
+  ZIMBABWE(offTag: 'zw');
 
-extension OpenFoodFactsCoutryExtension on OpenFoodFactsCountry {
-  static const Map<OpenFoodFactsCountry, String> _ISO_2_CODES = {
-    OpenFoodFactsCountry.ANDORRA: 'ad',
-    OpenFoodFactsCountry.UNITED_ARAB_EMIRATES: 'ae',
-    OpenFoodFactsCountry.AFGHANISTAN: 'af',
-    OpenFoodFactsCountry.ANTIGUA_AND_BARBUDA: 'ag',
-    OpenFoodFactsCountry.ANGUILLA: 'ai',
-    OpenFoodFactsCountry.ALBANIA: 'al',
-    OpenFoodFactsCountry.ARMENIA: 'am',
-    OpenFoodFactsCountry.ANGOLA: 'ao',
-    OpenFoodFactsCountry.ANTARCTICA: 'aq',
-    OpenFoodFactsCountry.ARGENTINA: 'ar',
-    OpenFoodFactsCountry.AMERICAN_SAMOA: 'as',
-    OpenFoodFactsCountry.AUSTRIA: 'at',
-    OpenFoodFactsCountry.AUSTRALIA: 'au',
-    OpenFoodFactsCountry.ARUBA: 'aw',
-    OpenFoodFactsCountry.ALAND_ISLANDS: 'ax',
-    OpenFoodFactsCountry.AZERBAIJAN: 'az',
-    OpenFoodFactsCountry.BOSNIA_AND_HERZEGOVINA: 'ba',
-    OpenFoodFactsCountry.BARBADOS: 'bb',
-    OpenFoodFactsCountry.BANGLADESH: 'bd',
-    OpenFoodFactsCountry.BELGIUM: 'be',
-    OpenFoodFactsCountry.BURKINA_FASO: 'bf',
-    OpenFoodFactsCountry.BULGARIA: 'bg',
-    OpenFoodFactsCountry.BAHRAIN: 'bh',
-    OpenFoodFactsCountry.BURUNDI: 'bi',
-    OpenFoodFactsCountry.BENIN: 'bj',
-    OpenFoodFactsCountry.SAINT_BARTHELEMY: 'bl',
-    OpenFoodFactsCountry.BERMUDA: 'bm',
-    OpenFoodFactsCountry.BRUNEI_DARUSSALAM: 'bn',
-    OpenFoodFactsCountry.BOLIVIA: 'bo',
-    OpenFoodFactsCountry.BONAIRE: 'bq',
-    OpenFoodFactsCountry.BRAZIL: 'br',
-    OpenFoodFactsCountry.BAHAMAS: 'bs',
-    OpenFoodFactsCountry.BHUTAN: 'bt',
-    OpenFoodFactsCountry.BOUVET_ISLAND: 'bv',
-    OpenFoodFactsCountry.BOTSWANA: 'bw',
-    OpenFoodFactsCountry.BELARUS: 'by',
-    OpenFoodFactsCountry.BELIZE: 'bz',
-    OpenFoodFactsCountry.CANADA: 'ca',
-    OpenFoodFactsCountry.COCOS_ISLANDS: 'cc',
-    OpenFoodFactsCountry.DEMOCRATIC_REPUBLIC_OF_THE_CONGO: 'cd',
-    OpenFoodFactsCountry.CENTRAL_AFRICAN_REPUBLIC: 'cf',
-    OpenFoodFactsCountry.CONGO: 'cg',
-    OpenFoodFactsCountry.SWITZERLAND: 'ch',
-    OpenFoodFactsCountry.COTE_D_IVOIRE: 'ci',
-    OpenFoodFactsCountry.COOK_ISLANDS: 'ck',
-    OpenFoodFactsCountry.CHILE: 'cl',
-    OpenFoodFactsCountry.CAMEROON: 'cm',
-    OpenFoodFactsCountry.CHINA: 'cn',
-    OpenFoodFactsCountry.COLOMBIA: 'co',
-    OpenFoodFactsCountry.COSTA_RICA: 'cr',
-    OpenFoodFactsCountry.CUBA: 'cu',
-    OpenFoodFactsCountry.CABO_VERDE: 'cv',
-    OpenFoodFactsCountry.CURACAO: 'cw',
-    OpenFoodFactsCountry.CHRISTMAS_ISLAND: 'cx',
-    OpenFoodFactsCountry.CYPRUS: 'cy',
-    OpenFoodFactsCountry.CZECHIA: 'cz',
-    OpenFoodFactsCountry.GERMANY: 'de',
-    OpenFoodFactsCountry.DJIBOUTI: 'dj',
-    OpenFoodFactsCountry.DENMARK: 'dk',
-    OpenFoodFactsCountry.DOMINICA: 'dm',
-    OpenFoodFactsCountry.DOMINICAN_REPUBLIC: 'do',
-    OpenFoodFactsCountry.ALGERIA: 'dz',
-    OpenFoodFactsCountry.ECUADOR: 'ec',
-    OpenFoodFactsCountry.ESTONIA: 'ee',
-    OpenFoodFactsCountry.EGYPT: 'eg',
-    OpenFoodFactsCountry.WESTERN_SAHARA: 'eh',
-    OpenFoodFactsCountry.ERITREA: 'er',
-    OpenFoodFactsCountry.SPAIN: 'es',
-    OpenFoodFactsCountry.ETHIOPIA: 'et',
-    OpenFoodFactsCountry.FINLAND: 'fi',
-    OpenFoodFactsCountry.FIJI: 'fj',
-    OpenFoodFactsCountry.FALKLAND_ISLANDS: 'fk',
-    OpenFoodFactsCountry.MICRONESIA: 'fm',
-    OpenFoodFactsCountry.FAROE_ISLANDS: 'fo',
-    OpenFoodFactsCountry.FRANCE: 'fr',
-    OpenFoodFactsCountry.GABON: 'ga',
-    // in OFF this is not 'gb'
-    OpenFoodFactsCountry.UNITED_KINGDOM: 'uk',
-    OpenFoodFactsCountry.GRENADA: 'gd',
-    OpenFoodFactsCountry.GEORGIA: 'ge',
-    OpenFoodFactsCountry.FRENCH_GUIANA: 'gf',
-    OpenFoodFactsCountry.GUERNSEY: 'gg',
-    OpenFoodFactsCountry.GHANA: 'gh',
-    OpenFoodFactsCountry.GIBRALTAR: 'gi',
-    OpenFoodFactsCountry.GREENLAND: 'gl',
-    OpenFoodFactsCountry.GAMBIA: 'gm',
-    OpenFoodFactsCountry.GUINEA: 'gn',
-    OpenFoodFactsCountry.GUADELOUPE: 'gp',
-    OpenFoodFactsCountry.EQUATORIAL_GUINEA: 'gq',
-    OpenFoodFactsCountry.GREECE: 'gr',
-    OpenFoodFactsCountry.SOUTH_GEORGIA: 'gs',
-    OpenFoodFactsCountry.GUATEMALA: 'gt',
-    OpenFoodFactsCountry.GUAM: 'gu',
-    OpenFoodFactsCountry.GUINEA_BISSAU: 'gw',
-    OpenFoodFactsCountry.GUYANA: 'gy',
-    OpenFoodFactsCountry.HONG_KONG: 'hk',
-    OpenFoodFactsCountry.HEARD_ISLAND: 'hm',
-    OpenFoodFactsCountry.HONDURAS: 'hn',
-    OpenFoodFactsCountry.CROATIA: 'hr',
-    OpenFoodFactsCountry.HAITI: 'ht',
-    OpenFoodFactsCountry.HUNGARY: 'hu',
-    OpenFoodFactsCountry.INDONESIA: 'id',
-    OpenFoodFactsCountry.IRELAND: 'ie',
-    OpenFoodFactsCountry.ISRAEL: 'il',
-    OpenFoodFactsCountry.ISLE_OF_MAN: 'im',
-    OpenFoodFactsCountry.INDIA: 'in',
-    OpenFoodFactsCountry.BRITISH_INDIAN_OCEAN_TERRITORY: 'io',
-    OpenFoodFactsCountry.IRAQ: 'iq',
-    OpenFoodFactsCountry.IRAN: 'ir',
-    OpenFoodFactsCountry.ICELAND: 'is',
-    OpenFoodFactsCountry.ITALY: 'it',
-    OpenFoodFactsCountry.JERSEY: 'je',
-    OpenFoodFactsCountry.JAMAICA: 'jm',
-    OpenFoodFactsCountry.JORDAN: 'jo',
-    OpenFoodFactsCountry.JAPAN: 'jp',
-    OpenFoodFactsCountry.KENYA: 'ke',
-    OpenFoodFactsCountry.KYRGYZSTAN: 'kg',
-    OpenFoodFactsCountry.CAMBODIA: 'kh',
-    OpenFoodFactsCountry.KIRIBATI: 'ki',
-    OpenFoodFactsCountry.COMOROS: 'km',
-    OpenFoodFactsCountry.SAINT_KITTS_AND_NEVIS: 'kn',
-    OpenFoodFactsCountry.NORTH_KOREA: 'kp',
-    OpenFoodFactsCountry.SOUTH_KOREA: 'kr',
-    OpenFoodFactsCountry.KUWAIT: 'kw',
-    OpenFoodFactsCountry.CAYMAN_ISLANDS: 'ky',
-    OpenFoodFactsCountry.KAZAKHSTAN: 'kz',
-    OpenFoodFactsCountry.LAOS: 'la',
-    OpenFoodFactsCountry.LEBANON: 'lb',
-    OpenFoodFactsCountry.SAINT_LUCIA: 'lc',
-    OpenFoodFactsCountry.LIECHTENSTEIN: 'li',
-    OpenFoodFactsCountry.SRI_LANKA: 'lk',
-    OpenFoodFactsCountry.LIBERIA: 'lr',
-    OpenFoodFactsCountry.LESOTHO: 'ls',
-    OpenFoodFactsCountry.LITHUANIA: 'lt',
-    OpenFoodFactsCountry.LUXEMBOURG: 'lu',
-    OpenFoodFactsCountry.LATVIA: 'lv',
-    OpenFoodFactsCountry.LIBYA: 'ly',
-    OpenFoodFactsCountry.MOROCCO: 'ma',
-    OpenFoodFactsCountry.MONACO: 'mc',
-    OpenFoodFactsCountry.MOLDOVA: 'md',
-    OpenFoodFactsCountry.MONTENEGRO: 'me',
-    OpenFoodFactsCountry.SAINT_MARTIN: 'mf',
-    OpenFoodFactsCountry.MADAGASCAR: 'mg',
-    OpenFoodFactsCountry.MARSHALL_ISLANDS: 'mh',
-    OpenFoodFactsCountry.NORTH_MACEDONIA: 'mk',
-    OpenFoodFactsCountry.MALI: 'ml',
-    OpenFoodFactsCountry.MYANMAR: 'mm',
-    OpenFoodFactsCountry.MONGOLIA: 'mn',
-    OpenFoodFactsCountry.MACAO: 'mo',
-    OpenFoodFactsCountry.NORTHERN_MARIANA_ISLANDS: 'mp',
-    OpenFoodFactsCountry.MARTINIQUE: 'mq',
-    OpenFoodFactsCountry.MAURITANIA: 'mr',
-    OpenFoodFactsCountry.MONTSERRAT: 'ms',
-    OpenFoodFactsCountry.MALTA: 'mt',
-    OpenFoodFactsCountry.MAURITIUS: 'mu',
-    OpenFoodFactsCountry.MALDIVES: 'mv',
-    OpenFoodFactsCountry.MALAWI: 'mw',
-    OpenFoodFactsCountry.MEXICO: 'mx',
-    OpenFoodFactsCountry.MALAYSIA: 'my',
-    OpenFoodFactsCountry.MOZAMBIQUE: 'mz',
-    OpenFoodFactsCountry.NAMIBIA: 'na',
-    OpenFoodFactsCountry.NEW_CALEDONIA: 'nc',
-    OpenFoodFactsCountry.NIGER: 'ne',
-    OpenFoodFactsCountry.NORFOLK_ISLAND: 'nf',
-    OpenFoodFactsCountry.NIGERIA: 'ng',
-    OpenFoodFactsCountry.NICARAGUA: 'ni',
-    OpenFoodFactsCountry.NETHERLANDS: 'nl',
-    OpenFoodFactsCountry.NORWAY: 'no',
-    OpenFoodFactsCountry.NEPAL: 'np',
-    OpenFoodFactsCountry.NAURU: 'nr',
-    OpenFoodFactsCountry.NIUE: 'nu',
-    OpenFoodFactsCountry.NEW_ZEALAND: 'nz',
-    OpenFoodFactsCountry.OMAN: 'om',
-    OpenFoodFactsCountry.PANAMA: 'pa',
-    OpenFoodFactsCountry.PERU: 'pe',
-    OpenFoodFactsCountry.FRENCH_POLYNESIA: 'pf',
-    OpenFoodFactsCountry.PAPUA_NEW_GUINEA: 'pg',
-    OpenFoodFactsCountry.PHILIPPINES: 'ph',
-    OpenFoodFactsCountry.PAKISTAN: 'pk',
-    OpenFoodFactsCountry.POLAND: 'pl',
-    OpenFoodFactsCountry.SAINT_PIERRE_AND_MIQUELON: 'pm',
-    OpenFoodFactsCountry.PITCAIRN: 'pn',
-    OpenFoodFactsCountry.PUERTO_RICO: 'pr',
-    OpenFoodFactsCountry.PALESTINE: 'ps',
-    OpenFoodFactsCountry.PORTUGAL: 'pt',
-    OpenFoodFactsCountry.PALAU: 'pw',
-    OpenFoodFactsCountry.PARAGUAY: 'py',
-    OpenFoodFactsCountry.QATAR: 'qa',
-    OpenFoodFactsCountry.REUNION: 're',
-    OpenFoodFactsCountry.ROMANIA: 'ro',
-    OpenFoodFactsCountry.SERBIA: 'rs',
-    OpenFoodFactsCountry.RUSSIA: 'ru',
-    OpenFoodFactsCountry.RWANDA: 'rw',
-    OpenFoodFactsCountry.SAUDI_ARABIA: 'sa',
-    OpenFoodFactsCountry.SOLOMON_ISLANDS: 'sb',
-    OpenFoodFactsCountry.SEYCHELLES: 'sc',
-    OpenFoodFactsCountry.SUDAN: 'sd',
-    OpenFoodFactsCountry.SWEDEN: 'se',
-    OpenFoodFactsCountry.SINGAPORE: 'sg',
-    OpenFoodFactsCountry.SAINT_HELENA: 'sh',
-    OpenFoodFactsCountry.SLOVENIA: 'si',
-    OpenFoodFactsCountry.SVALBARD_AND_JAN_MAYEN: 'sj',
-    OpenFoodFactsCountry.SLOVAKIA: 'sk',
-    OpenFoodFactsCountry.SIERRA_LEONE: 'sl',
-    OpenFoodFactsCountry.SAN_MARINO: 'sm',
-    OpenFoodFactsCountry.SENEGAL: 'sn',
-    OpenFoodFactsCountry.SOMALIA: 'so',
-    OpenFoodFactsCountry.SURINAME: 'sr',
-    OpenFoodFactsCountry.SOUTH_SUDAN: 'ss',
-    OpenFoodFactsCountry.SAO_TOME_AND_PRINCIPE: 'st',
-    OpenFoodFactsCountry.EL_SALVADOR: 'sv',
-    OpenFoodFactsCountry.SINT_MAARTEN: 'sx',
-    OpenFoodFactsCountry.SYRIA: 'sy',
-    OpenFoodFactsCountry.ESWATINI: 'sz',
-    OpenFoodFactsCountry.TURKS_AND_CAICOS_ISLANDS: 'tc',
-    OpenFoodFactsCountry.CHAD: 'td',
-    OpenFoodFactsCountry.FRENCH_SOUTHERN_TERRITORIES: 'tf',
-    OpenFoodFactsCountry.TOGO: 'tg',
-    OpenFoodFactsCountry.THAILAND: 'th',
-    OpenFoodFactsCountry.TAJIKISTAN: 'tj',
-    OpenFoodFactsCountry.TOKELAU: 'tk',
-    OpenFoodFactsCountry.TIMOR_LESTE: 'tl',
-    OpenFoodFactsCountry.TURKMENISTAN: 'tm',
-    OpenFoodFactsCountry.TUNISIA: 'tn',
-    OpenFoodFactsCountry.TONGA: 'to',
-    OpenFoodFactsCountry.TURKEY: 'tr',
-    OpenFoodFactsCountry.TRINIDAD_AND_TOBAGO: 'tt',
-    OpenFoodFactsCountry.TUVALU: 'tv',
-    OpenFoodFactsCountry.TAIWAN: 'tw',
-    OpenFoodFactsCountry.TANZANIA: 'tz',
-    OpenFoodFactsCountry.UKRAINE: 'ua',
-    OpenFoodFactsCountry.UGANDA: 'ug',
-    OpenFoodFactsCountry.UNITED_STATES_MINOR_OUTLYING_ISLANDS: 'um',
-    OpenFoodFactsCountry.USA: 'us',
-    OpenFoodFactsCountry.URUGUAY: 'uy',
-    OpenFoodFactsCountry.UZBEKISTAN: 'uz',
-    OpenFoodFactsCountry.HOLY_SEE: 'va',
-    OpenFoodFactsCountry.SAINT_VINCENT_AND_THE_GRENADINES: 'vc',
-    OpenFoodFactsCountry.VENEZUELA: 've',
-    OpenFoodFactsCountry.BRITISH_VIRGIN_ISLANDS: 'vg',
-    OpenFoodFactsCountry.US_VIRGIN_ISLANDS: 'vi',
-    OpenFoodFactsCountry.VIET_NAM: 'vn',
-    OpenFoodFactsCountry.VANUATU: 'vu',
-    OpenFoodFactsCountry.WALLIS_AND_FUTUNA: 'wf',
-    OpenFoodFactsCountry.SAMOA: 'ws',
-    OpenFoodFactsCountry.YEMEN: 'ye',
-    OpenFoodFactsCountry.MAYOTTE: 'yt',
-    OpenFoodFactsCountry.SOUTH_AFRICA: 'za',
-    OpenFoodFactsCountry.ZAMBIA: 'zm',
-    OpenFoodFactsCountry.ZIMBABWE: 'zw',
-  };
+  const OpenFoodFactsCountry({
+    required this.offTag,
+  });
 
-  String get iso2Code => _ISO_2_CODES[this]!;
+  /// Lowercase ISO 639-1, except for [UNITED_KINGDOM].
+  @override
+  final String offTag;
+
+  /// Returns the first [OpenFoodFactsCountry] that matches the [offTag].
+  static OpenFoodFactsCountry? fromOffTag(final String? offTag) =>
+      OffTagged.fromOffTag(offTag, OpenFoodFactsCountry.values)
+          as OpenFoodFactsCountry?;
+
+  // TODO: deprecated from 2022-11-13; remove when old enough
+  @Deprecated('Use offTag instead')
+  String get iso2Code => offTag;
 }
 
 /// Helper class around [OpenFoodFactsCountry]
@@ -1014,12 +777,6 @@ class CountryHelper {
     if (code == null) {
       return null;
     }
-    code = code.toLowerCase();
-    for (final OpenFoodFactsCountry key in OpenFoodFactsCountry.values) {
-      if (key.iso2Code == code) {
-        return key;
-      }
-    }
-    return null;
+    return OpenFoodFactsCountry.fromOffTag(code.toLowerCase());
   }
 }

--- a/lib/utils/ImageHelper.dart
+++ b/lib/utils/ImageHelper.dart
@@ -51,7 +51,10 @@ class ImageHelper {
     final ProductImage image, {
     final ImageSize? imageSize,
   }) =>
-      '${image.field.value}_${image.language.code}.${image.rev}.${(imageSize ?? image.size).toNumber()}.jpg';
+      '${image.field.offTag}_${image.language.code}'
+      '.${image.rev}'
+      '.${((imageSize ?? image.size) ?? ImageSize.UNKNOWN).number}'
+      '.jpg';
 
   /// Returns the web folder of the product images (without trailing '/')
   ///

--- a/lib/utils/JsonHelper.dart
+++ b/lib/utils/JsonHelper.dart
@@ -15,21 +15,33 @@ class JsonHelper {
       for (var size in ImageSize.values) {
         for (OpenFoodFactsLanguage lang in OpenFoodFactsLanguage.values) {
           // use the field to get the size
-          if (json[field.value] == null) continue;
-          var sizeJson = json[field.value] as Map<String, dynamic>?;
+          if (json[field.offTag] == null) {
+            continue;
+          }
+          var sizeJson = json[field.offTag] as Map<String, dynamic>?;
 
           // use the size to get the language
-          if (sizeJson == null) continue;
-          var langJson = sizeJson[size.value] as Map<String, dynamic>?;
+          if (sizeJson == null) {
+            continue;
+          }
+          var langJson = sizeJson[size.offTag] as Map<String, dynamic>?;
 
           // use the language to get the url
-          if (langJson == null) continue;
-          var url = langJson[lang.code] as String?;
+          if (langJson == null) {
+            continue;
+          }
+          var url = langJson[lang.offTag] as String?;
 
           // use the url to build the image
-          if (url == null) continue;
-          var image =
-              ProductImage(field: field, size: size, language: lang, url: url);
+          if (url == null) {
+            continue;
+          }
+          var image = ProductImage(
+            field: field,
+            size: size,
+            language: lang,
+            url: url,
+          );
 
           imageList.add(image);
         }
@@ -55,9 +67,9 @@ class JsonHelper {
             sizeMap[image.language.code] = image.url;
           }
         }
-        fieldMap[size.value] = sizeMap;
+        fieldMap[size.offTag] = sizeMap;
       }
-      result[field.value] = fieldMap;
+      result[field.offTag] = fieldMap;
     }
 
     return result;
@@ -72,7 +84,7 @@ class JsonHelper {
     for (var field in ImageField.values) {
       for (OpenFoodFactsLanguage lang in OpenFoodFactsLanguage.values) {
         // get the field object e.g. front_en
-        final String fieldName = '${field.value}_${lang.code}';
+        final String fieldName = '${field.offTag}_${lang.offTag}';
         if (json[fieldName] == null) continue;
 
         final fieldObject = json[fieldName] as Map<String, dynamic>?;
@@ -96,7 +108,7 @@ class JsonHelper {
 
         // get each number object (e.g. 200)
         for (var size in ImageSize.values) {
-          var number = size.toNumber();
+          var number = size.number;
           var numberObject = sizesObject[number] as Map<String, dynamic>?;
           if (numberObject == null) continue;
 

--- a/lib/utils/LanguageHelper.dart
+++ b/lib/utils/LanguageHelper.dart
@@ -1,765 +1,590 @@
+import 'package:openfoodfacts/model/OffTagged.dart';
+
 /// Available languages
-enum OpenFoodFactsLanguage {
+enum OpenFoodFactsLanguage implements OffTagged {
   /// English
-  ENGLISH,
+  ENGLISH(offTag: 'en'),
 
   /// Old Church Slavonic
-  OLD_CHURCH_SLAVONIC,
+  OLD_CHURCH_SLAVONIC(offTag: 'cu'),
 
   /// Dzongkha
-  DZONGKHA_LANGUAGE,
+  DZONGKHA_LANGUAGE(offTag: 'dz'),
 
   /// Japanese
-  JAPANESE,
+  JAPANESE(offTag: 'ja'),
 
   /// Malay
-  MALAY,
+  MALAY(offTag: 'ms'),
 
   /// Tagalog
-  TAGALOG,
+  TAGALOG(offTag: 'tl'),
 
   /// Moldovan
-  MOLDOVAN,
+  MOLDOVAN(offTag: 'mo'),
 
   /// Mongolian
-  MONGOLIAN,
+  MONGOLIAN(offTag: 'mn'),
 
   /// Korean
-  KOREAN,
+  KOREAN(offTag: 'ko'),
 
   /// Luba-Katanga
-  LUBA_KATANGA_LANGUAGE,
+  LUBA_KATANGA_LANGUAGE(offTag: 'lu'),
 
   /// Kazakh
-  KAZAKH,
+  KAZAKH(offTag: 'kk'),
 
   /// Quechua
-  QUECHUA_LANGUAGES,
+  QUECHUA_LANGUAGES(offTag: 'qu'),
 
   /// Ukrainian
-  UKRAINIAN,
+  UKRAINIAN(offTag: 'uk'),
 
   /// Occitan
-  OCCITAN,
+  OCCITAN(offTag: 'oc'),
 
   /// Bihari
-  BIHARI_LANGUAGES,
+  BIHARI_LANGUAGES(offTag: 'bh'),
 
   /// South Ndebele
-  SOUTHERN_NDEBELE,
+  SOUTHERN_NDEBELE(offTag: 'nr'),
 
   /// Bokmal
-  BOKMAL,
+  BOKMAL(offTag: 'nb'),
 
   /// Komi
-  KOMI,
+  KOMI(offTag: 'kv'),
 
   /// Modern Greek
-  MODERN_GREEK,
+  MODERN_GREEK(offTag: 'el'),
 
   /// Fijian
-  FIJIAN_LANGUAGE,
+  FIJIAN_LANGUAGE(offTag: 'fj'),
 
   /// Zulu
-  ZULU,
+  ZULU(offTag: 'zu'),
 
   /// Ido
-  IDO,
+  IDO(offTag: 'io'),
 
   /// Khmer
-  KHMER,
+  KHMER(offTag: 'km'),
 
   /// Sanskrit
-  SANSKRIT,
+  SANSKRIT(offTag: 'sa'),
 
   /// Macedonian
-  MACEDONIAN,
+  MACEDONIAN(offTag: 'mk'),
 
   /// Sotho
-  SOTHO,
+  SOTHO(offTag: 'st'),
 
   /// Scottish Gaelic
-  SCOTTISH_GAELIC,
+  SCOTTISH_GAELIC(offTag: 'gd'),
 
   /// Marathi
-  MARATHI,
+  MARATHI(offTag: 'mr'),
 
   /// Nauruan
-  NAURUAN,
+  NAURUAN(offTag: 'na'),
 
   /// Oromo
-  OROMO,
+  OROMO(offTag: 'om'),
 
   /// Welsh
-  WELSH,
+  WELSH(offTag: 'cy'),
 
   /// Vietnamese
-  VIETNAMESE,
+  VIETNAMESE(offTag: 'vi'),
 
   /// Bislama
-  BISLAMA,
+  BISLAMA(offTag: 'bi'),
 
   /// Somali
-  SOMALI,
+  SOMALI(offTag: 'so'),
 
   /// Lithuanian
-  LITHUANIAN,
+  LITHUANIAN(offTag: 'lt'),
 
   /// Haitian Creole
-  HAITIAN_CREOLE,
+  HAITIAN_CREOLE(offTag: 'ht'),
 
   /// Malagasy
-  MALAGASY,
+  MALAGASY(offTag: 'mg'),
 
   /// Spanish
-  SPANISH,
+  SPANISH(offTag: 'es'),
 
   /// Danish
-  DANISH,
+  DANISH(offTag: 'da'),
 
   /// Slovenian
-  SLOVENE,
+  SLOVENE(offTag: 'sl'),
 
   /// Icelandic
-  ICELANDIC,
+  ICELANDIC(offTag: 'is'),
 
   /// Estonian
-  ESTONIAN,
+  ESTONIAN(offTag: 'et'),
 
   /// Wolof
-  WOLOF,
+  WOLOF(offTag: 'wo'),
 
   /// Hiri Motu
-  HIRI_MOTU,
+  HIRI_MOTU(offTag: 'ho'),
 
   /// Tamil
-  TAMIL,
+  TAMIL(offTag: 'ta'),
 
   /// Slovak
-  SLOVAK,
+  SLOVAK(offTag: 'sk'),
 
   /// Herero
-  HERERO,
+  HERERO(offTag: 'hz'),
 
   /// Italian
-  ITALIAN,
+  ITALIAN(offTag: 'it'),
 
   /// Irish
-  IRISH,
+  IRISH(offTag: 'ga'),
 
   /// Shona
-  SHONA,
+  SHONA(offTag: 'sn'),
 
   /// Marshallese
-  MARSHALLESE,
+  MARSHALLESE(offTag: 'mh'),
 
   /// French
-  FRENCH,
+  FRENCH(offTag: 'fr'),
 
   /// Aymara
-  AYMARA,
+  AYMARA(offTag: 'ay'),
 
   /// Hebrew
-  HEBREW,
+  HEBREW(offTag: 'he'),
 
   /// Northern Sami
-  NORTHERN_SAMI,
+  NORTHERN_SAMI(offTag: 'se'),
 
   /// Bengali
-  BENGALI,
+  BENGALI(offTag: 'bn'),
 
   /// Odia
-  ODIA,
+  ODIA(offTag: 'or'),
 
   /// Malayalam
-  MALAYALAM,
+  MALAYALAM(offTag: 'ml'),
 
   /// Dutch
-  DUTCH,
+  DUTCH(offTag: 'nl'),
 
   /// Uyghur
-  UYGHUR,
+  UYGHUR(offTag: 'ug'),
 
   /// Serbian
-  SERBIAN,
+  SERBIAN(offTag: 'sr'),
 
   /// Tibetan
-  TIBETAN_LANGUAGE,
+  TIBETAN_LANGUAGE(offTag: 'bo'),
 
   /// Belarusian
-  BELARUSIAN,
+  BELARUSIAN(offTag: 'be'),
 
   /// Samoan
-  SAMOAN,
+  SAMOAN(offTag: 'sm'),
 
   /// Punjabi
-  PUNJABI,
+  PUNJABI(offTag: 'pa'),
 
   /// Russian
-  RUSSIAN,
+  RUSSIAN(offTag: 'ru'),
 
   /// Tahitian
-  TAHITIAN,
+  TAHITIAN(offTag: 'ty'),
 
   /// Interlingua
-  INTERLINGUA,
+  INTERLINGUA(offTag: 'ia'),
 
   /// Afar
-  AFAR,
+  AFAR(offTag: 'aa'),
 
   /// Greenlandic
-  GREENLANDIC,
+  GREENLANDIC(offTag: 'kl'),
 
   /// Latin
-  LATIN,
+  LATIN(offTag: 'la'),
 
   /// Chinese
-  CHINESE,
+  CHINESE(offTag: 'zh'),
 
   /// Turkmen
-  TURKMEN,
+  TURKMEN(offTag: 'tk'),
 
   /// West Frisian
-  WEST_FRISIAN,
+  WEST_FRISIAN(offTag: 'fy'),
 
   /// Tsonga
-  TSONGA,
+  TSONGA(offTag: 'ts'),
 
   /// Romansh
-  ROMANSH,
+  ROMANSH(offTag: 'rm'),
 
   /// Inupiaq
-  INUPIAT_LANGUAGE,
+  INUPIAT_LANGUAGE(offTag: 'ik'),
 
   /// Tajik
-  TAJIK,
+  TAJIK(offTag: 'tg'),
 
   /// Burmese
-  BURMESE,
+  BURMESE(offTag: 'my'),
 
   /// Javanese
-  JAVANESE,
+  JAVANESE(offTag: 'jv'),
 
   /// Chechen
-  CHECHEN,
+  CHECHEN(offTag: 'ce'),
 
   /// Assamese
-  ASSAMESE,
+  ASSAMESE(offTag: 'as'),
 
   /// Unknown language
-  UNKNOWN_LANGUAGE,
+  UNKNOWN_LANGUAGE(offTag: 'xx'),
 
   /// Arabic
-  ARABIC,
+  ARABIC(offTag: 'ar'),
 
   /// Kinyarmanda
-  KINYARWANDA,
+  KINYARWANDA(offTag: 'rw'),
 
   /// Tonga
-  TONGAN_LANGUAGE,
+  TONGAN_LANGUAGE(offTag: 'to'),
 
   /// Church Slavonic
-  CHURCH_SLAVONIC,
+  // same as OLD_CHURCH_SLAVONIC
+  CHURCH_SLAVONIC(offTag: 'cu'),
 
   /// Sinhala
-  SINHALA,
+  SINHALA(offTag: 'si'),
 
   /// Armenian
-  ARMENIAN,
+  ARMENIAN(offTag: 'hy'),
 
   /// Kurdish
-  KURDISH,
+  KURDISH(offTag: 'ku'),
 
   /// Thai
-  THAI,
+  THAI(offTag: 'th'),
 
   /// Cree
-  CREE,
+  CREE(offTag: 'cr'),
 
   /// Swahili
-  SWAHILI,
+  SWAHILI(offTag: 'sw'),
 
   /// Gujarati
-  GUJARATI,
+  GUJARATI(offTag: 'gu'),
 
   /// Persian
-  PERSIAN,
+  PERSIAN(offTag: 'fa'),
 
   /// Bosnian
-  BOSNIAN,
+  BOSNIAN(offTag: 'bs'),
 
   /// Amharic
-  AMHARIC,
+  AMHARIC(offTag: 'am'),
 
   /// Aragonese
-  ARAGONESE,
+  ARAGONESE(offTag: 'an'),
 
   /// Croatian
-  CROATIAN,
+  CROATIAN(offTag: 'hr'),
 
   /// Chewa
-  CHEWA,
+  CHEWA(offTag: 'ny'),
 
   /// Zhuang
-  ZHUANG_LANGUAGES,
+  ZHUANG_LANGUAGES(offTag: 'za'),
 
   /// Lingala
-  LINGALA_LANGUAGE,
+  LINGALA_LANGUAGE(offTag: 'ln'),
 
   /// Bambara
-  BAMBARA,
+  BAMBARA(offTag: 'bm'),
 
   /// Limburgan
-  LIMBURGISH_LANGUAGE,
+  LIMBURGISH_LANGUAGE(offTag: 'li'),
 
   /// Nuosu
-  NUOSU_LANGUAGE,
+  NUOSU_LANGUAGE(offTag: 'ii'),
 
   /// Kwanyama
-  KWANYAMA,
+  KWANYAMA(offTag: 'kj'),
 
   /// Kirundi
-  KIRUNDI,
+  KIRUNDI(offTag: 'rn'),
 
   /// Ewe
-  EWE,
+  EWE(offTag: 'ee'),
 
   /// Faorese
-  FAROESE,
+  FAROESE(offTag: 'fo'),
 
   /// Sindhi
-  SINDHI,
+  SINDHI(offTag: 'sd'),
 
   /// Corsican
-  CORSICAN,
+  CORSICAN(offTag: 'co'),
 
   /// Kannada
-  KANNADA,
+  KANNADA(offTag: 'kn'),
 
   /// Norwegian
-  NORWEGIAN,
+  NORWEGIAN(offTag: 'no'),
 
   /// Sundanese
-  SUNDANESE_LANGUAGE,
+  SUNDANESE_LANGUAGE(offTag: 'su'),
 
   /// Georgian
-  GEORGIAN,
+  GEORGIAN(offTag: 'ka'),
 
   /// Hausa
-  HAUSA,
+  HAUSA(offTag: 'ha'),
 
   /// Tswana
-  TSWANA,
+  TSWANA(offTag: 'tn'),
 
   /// Catalan
-  CATALAN,
+  CATALAN(offTag: 'ca'),
 
   /// Ndonga
-  NDONGA_DIALECT,
+  NDONGA_DIALECT(offTag: 'ng'),
 
   /// Igbo
-  IGBO_LANGUAGE,
+  IGBO_LANGUAGE(offTag: 'ig'),
 
   /// Afrikaans
-  AFRIKAANS,
+  AFRIKAANS(offTag: 'af'),
 
   /// Polish
-  POLISH,
+  POLISH(offTag: 'pl'),
 
   /// Kashmiri
-  KASHMIRI,
+  KASHMIRI(offTag: 'ks'),
 
   /// Maori
-  MAORI,
+  MAORI(offTag: 'mi'),
 
   /// Hungarian
-  HUNGARIAN,
+  HUNGARIAN(offTag: 'hu'),
 
   /// Breton
-  BRETON,
+  BRETON(offTag: 'br'),
 
   /// Portuguese
-  PORTUGUESE,
+  PORTUGUESE(offTag: 'pt'),
 
   /// Bulgarian
-  BULGARIAN,
+  BULGARIAN(offTag: 'bg'),
 
   /// Avestan
-  AVESTAN,
+  AVESTAN(offTag: 'ae'),
 
   /// Nepali
-  NEPALI,
+  NEPALI(offTag: 'ne'),
 
   /// Twi
-  TWI,
+  TWI(offTag: 'tw'),
 
   /// Uzbek
-  UZBEK,
+  UZBEK(offTag: 'uz'),
 
   /// Chamorro
-  CHAMORRO,
+  CHAMORRO(offTag: 'ch'),
 
   /// Guarani
-  GUARANI,
+  GUARANI(offTag: 'gn'),
 
   /// Nynorsk
-  NYNORSK,
+  NYNORSK(offTag: 'nn'),
 
   /// Azerbaijani
-  AZERBAIJANI,
+  AZERBAIJANI(offTag: 'az'),
 
   /// Czech
-  CZECH,
+  CZECH(offTag: 'cs'),
 
   /// Navajo
-  NAVAJO,
+  NAVAJO(offTag: 'nv'),
 
   /// Finnish
-  FINNISH,
+  FINNISH(offTag: 'fi'),
 
   /// Luxembourgish
-  LUXEMBOURGISH,
+  LUXEMBOURGISH(offTag: 'lb'),
 
   /// Swedish
-  SWEDISH,
+  SWEDISH(offTag: 'sv'),
 
   /// Yiddish
-  YIDDISH,
+  YIDDISH(offTag: 'yi'),
 
   /// Inuktitut
-  INUKTITUT,
+  INUKTITUT(offTag: 'iu'),
 
   /// Lao
-  LAO,
+  LAO(offTag: 'lo'),
 
   /// Chuvash
-  CHUVASH,
+  CHUVASH(offTag: 'cv'),
 
   /// Maltese
-  MALTESE,
+  MALTESE(offTag: 'mt'),
 
   /// Maldivian
-  MALDIVIAN_LANGUAGE,
+  MALDIVIAN_LANGUAGE(offTag: 'dv'),
 
   /// Interlingue
-  INTERLINGUE,
+  INTERLINGUE(offTag: 'ie'),
 
   /// Ossetian
-  OSSETIAN,
+  OSSETIAN(offTag: 'os'),
 
   /// Bashkir
-  BASHKIR,
+  BASHKIR(offTag: 'ba'),
 
   /// Ojibwe
-  OJIBWE,
+  OJIBWE(offTag: 'oj'),
 
   /// Kanuri
-  KANURI,
+  KANURI(offTag: 'kr'),
 
   /// Indonesian
-  INDONESIAN,
+  INDONESIAN(offTag: 'id'),
 
   /// Sardinian
-  SARDINIAN_LANGUAGE,
+  SARDINIAN_LANGUAGE(offTag: 'sc'),
 
   /// Akan
-  AKAN,
+  AKAN(offTag: 'ak'),
 
   /// Manx
-  MANX,
+  MANX(offTag: 'gv'),
 
   /// Turkish
-  TURKISH,
+  TURKISH(offTag: 'tr'),
 
   /// Esperanto
-  ESPERANTO,
+  ESPERANTO(offTag: 'eo'),
 
   /// Pashto
-  PASHTO,
+  PASHTO(offTag: 'ps'),
 
   /// Kyrgyz
-  KYRGYZ,
+  KYRGYZ(offTag: 'ky'),
 
   /// Volapuk
-  VOLAPUK,
+  VOLAPUK(offTag: 'vo'),
 
   /// Avar
-  AVAR,
+  AVAR(offTag: 'av'),
 
   /// Sango
-  SANGO,
+  SANGO(offTag: 'sg'),
 
   /// Venda
-  VENDA,
+  VENDA(offTag: 've'),
 
   /// Albanian
-  ALBANIAN,
+  ALBANIAN(offTag: 'sq'),
 
   /// Basque
-  BASQUE,
+  BASQUE(offTag: 'eu'),
 
   /// Fulah
-  FULA_LANGUAGE,
+  FULA_LANGUAGE(offTag: 'ff'),
 
   /// German
-  GERMAN,
+  GERMAN(offTag: 'de'),
 
   /// Latvian
-  LATVIAN,
+  LATVIAN(offTag: 'lv'),
 
   /// Cornish
-  CORNISH,
+  CORNISH(offTag: 'kw'),
 
   /// Pali
-  PALI,
+  PALI(offTag: 'pi'),
 
   /// Tatar
-  TATAR,
+  TATAR(offTag: 'tt'),
 
   /// Romanian
-  ROMANIAN,
+  ROMANIAN(offTag: 'ro'),
 
   /// Gikuyu
-  GIKUYU,
+  GIKUYU(offTag: 'ki'),
 
   /// Tigrinya
-  TIGRINYA,
+  TIGRINYA(offTag: 'ti'),
 
   /// Galician
-  GALICIAN,
+  GALICIAN(offTag: 'gl'),
 
   /// Telugu
-  TELUGU,
+  TELUGU(offTag: 'te'),
 
   /// Hindi
-  HINDI,
+  HINDI(offTag: 'hi'),
 
   /// Kongo
-  KONGO_LANGUAGE,
+  KONGO_LANGUAGE(offTag: 'kg'),
 
   /// Xhosa
-  XHOSA,
+  XHOSA(offTag: 'xh'),
 
   /// Swazi
-  SWAZI,
+  SWAZI(offTag: 'ss'),
 
   /// Luganda
-  LUGANDA,
+  LUGANDA(offTag: 'lg'),
 
   /// Urdu
-  URDU,
+  URDU(offTag: 'ur'),
 
   /// North Ndbele
-  NORTHERN_NDEBELE_LANGUAGE,
+  NORTHERN_NDEBELE_LANGUAGE(offTag: 'nd'),
 
   /// Yoruba
-  YORUBA,
+  YORUBA(offTag: 'yo'),
 
   /// World, as pseudo language
-  WORLD,
+  WORLD(offTag: 'world'),
 
   /// Undefined language
-  UNDEFINED
+  UNDEFINED(offTag: '-');
+
+  const OpenFoodFactsLanguage({
+    required this.offTag,
+  });
+
+  /// ISO 639-1
+  @override
+  final String offTag;
+
+  /// Returns the first [OpenFoodFactsLanguage] that matches the [offTag].
+  static OpenFoodFactsLanguage? fromOffTag(final String? offTag) =>
+      OffTagged.fromOffTag(offTag, OpenFoodFactsLanguage.values)
+          as OpenFoodFactsLanguage?;
 }
 
 extension OpenFoodFactsLanguageExtension on OpenFoodFactsLanguage? {
-  /// ISO 639-1 for [OpenFoodFactsLanguage]s
-  static const Map<OpenFoodFactsLanguage, String> _CODES = {
-    OpenFoodFactsLanguage.ENGLISH: 'en',
-    OpenFoodFactsLanguage.OLD_CHURCH_SLAVONIC: 'cu',
-    OpenFoodFactsLanguage.DZONGKHA_LANGUAGE: 'dz',
-    OpenFoodFactsLanguage.JAPANESE: 'ja',
-    OpenFoodFactsLanguage.MALAY: 'ms',
-    OpenFoodFactsLanguage.TAGALOG: 'tl',
-    OpenFoodFactsLanguage.MOLDOVAN: 'mo',
-    OpenFoodFactsLanguage.MONGOLIAN: 'mn',
-    OpenFoodFactsLanguage.KOREAN: 'ko',
-    OpenFoodFactsLanguage.LUBA_KATANGA_LANGUAGE: 'lu',
-    OpenFoodFactsLanguage.KAZAKH: 'kk',
-    OpenFoodFactsLanguage.QUECHUA_LANGUAGES: 'qu',
-    OpenFoodFactsLanguage.UKRAINIAN: 'uk',
-    OpenFoodFactsLanguage.OCCITAN: 'oc',
-    OpenFoodFactsLanguage.BIHARI_LANGUAGES: 'bh',
-    OpenFoodFactsLanguage.SOUTHERN_NDEBELE: 'nr',
-    OpenFoodFactsLanguage.BOKMAL: 'nb',
-    OpenFoodFactsLanguage.KOMI: 'kv',
-    OpenFoodFactsLanguage.MODERN_GREEK: 'el',
-    OpenFoodFactsLanguage.FIJIAN_LANGUAGE: 'fj',
-    OpenFoodFactsLanguage.ZULU: 'zu',
-    OpenFoodFactsLanguage.IDO: 'io',
-    OpenFoodFactsLanguage.KHMER: 'km',
-    OpenFoodFactsLanguage.SANSKRIT: 'sa',
-    OpenFoodFactsLanguage.MACEDONIAN: 'mk',
-    OpenFoodFactsLanguage.SOTHO: 'st',
-    OpenFoodFactsLanguage.SCOTTISH_GAELIC: 'gd',
-    OpenFoodFactsLanguage.MARATHI: 'mr',
-    OpenFoodFactsLanguage.NAURUAN: 'na',
-    OpenFoodFactsLanguage.OROMO: 'om',
-    OpenFoodFactsLanguage.WELSH: 'cy',
-    OpenFoodFactsLanguage.VIETNAMESE: 'vi',
-    OpenFoodFactsLanguage.BISLAMA: 'bi',
-    OpenFoodFactsLanguage.SOMALI: 'so',
-    OpenFoodFactsLanguage.LITHUANIAN: 'lt',
-    OpenFoodFactsLanguage.HAITIAN_CREOLE: 'ht',
-    OpenFoodFactsLanguage.MALAGASY: 'mg',
-    OpenFoodFactsLanguage.SPANISH: 'es',
-    OpenFoodFactsLanguage.DANISH: 'da',
-    OpenFoodFactsLanguage.SLOVENE: 'sl',
-    OpenFoodFactsLanguage.ICELANDIC: 'is',
-    OpenFoodFactsLanguage.ESTONIAN: 'et',
-    OpenFoodFactsLanguage.WOLOF: 'wo',
-    OpenFoodFactsLanguage.HIRI_MOTU: 'ho',
-    OpenFoodFactsLanguage.TAMIL: 'ta',
-    OpenFoodFactsLanguage.SLOVAK: 'sk',
-    OpenFoodFactsLanguage.HERERO: 'hz',
-    OpenFoodFactsLanguage.ITALIAN: 'it',
-    OpenFoodFactsLanguage.IRISH: 'ga',
-    OpenFoodFactsLanguage.SHONA: 'sn',
-    OpenFoodFactsLanguage.MARSHALLESE: 'mh',
-    OpenFoodFactsLanguage.FRENCH: 'fr',
-    OpenFoodFactsLanguage.AYMARA: 'ay',
-    OpenFoodFactsLanguage.HEBREW: 'he',
-    OpenFoodFactsLanguage.NORTHERN_SAMI: 'se',
-    OpenFoodFactsLanguage.BENGALI: 'bn',
-    OpenFoodFactsLanguage.ODIA: 'or',
-    OpenFoodFactsLanguage.MALAYALAM: 'ml',
-    OpenFoodFactsLanguage.DUTCH: 'nl',
-    OpenFoodFactsLanguage.UYGHUR: 'ug',
-    OpenFoodFactsLanguage.SERBIAN: 'sr',
-    OpenFoodFactsLanguage.TIBETAN_LANGUAGE: 'bo',
-    OpenFoodFactsLanguage.BELARUSIAN: 'be',
-    OpenFoodFactsLanguage.SAMOAN: 'sm',
-    OpenFoodFactsLanguage.PUNJABI: 'pa',
-    OpenFoodFactsLanguage.RUSSIAN: 'ru',
-    OpenFoodFactsLanguage.TAHITIAN: 'ty',
-    OpenFoodFactsLanguage.INTERLINGUA: 'ia',
-    OpenFoodFactsLanguage.AFAR: 'aa',
-    OpenFoodFactsLanguage.GREENLANDIC: 'kl',
-    OpenFoodFactsLanguage.LATIN: 'la',
-    OpenFoodFactsLanguage.CHINESE: 'zh',
-    OpenFoodFactsLanguage.TURKMEN: 'tk',
-    OpenFoodFactsLanguage.WEST_FRISIAN: 'fy',
-    OpenFoodFactsLanguage.TSONGA: 'ts',
-    OpenFoodFactsLanguage.ROMANSH: 'rm',
-    OpenFoodFactsLanguage.INUPIAT_LANGUAGE: 'ik',
-    OpenFoodFactsLanguage.TAJIK: 'tg',
-    OpenFoodFactsLanguage.BURMESE: 'my',
-    OpenFoodFactsLanguage.JAVANESE: 'jv',
-    OpenFoodFactsLanguage.CHECHEN: 'ce',
-    OpenFoodFactsLanguage.ASSAMESE: 'as',
-    OpenFoodFactsLanguage.UNKNOWN_LANGUAGE: 'xx',
-    OpenFoodFactsLanguage.ARABIC: 'ar',
-    OpenFoodFactsLanguage.KINYARWANDA: 'rw',
-    OpenFoodFactsLanguage.TONGAN_LANGUAGE: 'to',
-    OpenFoodFactsLanguage.CHURCH_SLAVONIC: 'cu',
-    OpenFoodFactsLanguage.SINHALA: 'si',
-    OpenFoodFactsLanguage.ARMENIAN: 'hy',
-    OpenFoodFactsLanguage.KURDISH: 'ku',
-    OpenFoodFactsLanguage.THAI: 'th',
-    OpenFoodFactsLanguage.CREE: 'cr',
-    OpenFoodFactsLanguage.SWAHILI: 'sw',
-    OpenFoodFactsLanguage.GUJARATI: 'gu',
-    OpenFoodFactsLanguage.PERSIAN: 'fa',
-    OpenFoodFactsLanguage.BOSNIAN: 'bs',
-    OpenFoodFactsLanguage.AMHARIC: 'am',
-    OpenFoodFactsLanguage.ARAGONESE: 'an',
-    OpenFoodFactsLanguage.CROATIAN: 'hr',
-    OpenFoodFactsLanguage.CHEWA: 'ny',
-    OpenFoodFactsLanguage.ZHUANG_LANGUAGES: 'za',
-    OpenFoodFactsLanguage.LINGALA_LANGUAGE: 'ln',
-    OpenFoodFactsLanguage.BAMBARA: 'bm',
-    OpenFoodFactsLanguage.LIMBURGISH_LANGUAGE: 'li',
-    OpenFoodFactsLanguage.NUOSU_LANGUAGE: 'ii',
-    OpenFoodFactsLanguage.KWANYAMA: 'kj',
-    OpenFoodFactsLanguage.KIRUNDI: 'rn',
-    OpenFoodFactsLanguage.EWE: 'ee',
-    OpenFoodFactsLanguage.FAROESE: 'fo',
-    OpenFoodFactsLanguage.SINDHI: 'sd',
-    OpenFoodFactsLanguage.CORSICAN: 'co',
-    OpenFoodFactsLanguage.KANNADA: 'kn',
-    OpenFoodFactsLanguage.NORWEGIAN: 'no',
-    OpenFoodFactsLanguage.SUNDANESE_LANGUAGE: 'su',
-    OpenFoodFactsLanguage.GEORGIAN: 'ka',
-    OpenFoodFactsLanguage.HAUSA: 'ha',
-    OpenFoodFactsLanguage.TSWANA: 'tn',
-    OpenFoodFactsLanguage.CATALAN: 'ca',
-    OpenFoodFactsLanguage.NDONGA_DIALECT: 'ng',
-    OpenFoodFactsLanguage.IGBO_LANGUAGE: 'ig',
-    OpenFoodFactsLanguage.AFRIKAANS: 'af',
-    OpenFoodFactsLanguage.POLISH: 'pl',
-    OpenFoodFactsLanguage.KASHMIRI: 'ks',
-    OpenFoodFactsLanguage.MAORI: 'mi',
-    OpenFoodFactsLanguage.HUNGARIAN: 'hu',
-    OpenFoodFactsLanguage.BRETON: 'br',
-    OpenFoodFactsLanguage.PORTUGUESE: 'pt',
-    OpenFoodFactsLanguage.BULGARIAN: 'bg',
-    OpenFoodFactsLanguage.AVESTAN: 'ae',
-    OpenFoodFactsLanguage.NEPALI: 'ne',
-    OpenFoodFactsLanguage.TWI: 'tw',
-    OpenFoodFactsLanguage.UZBEK: 'uz',
-    OpenFoodFactsLanguage.CHAMORRO: 'ch',
-    OpenFoodFactsLanguage.GUARANI: 'gn',
-    OpenFoodFactsLanguage.NYNORSK: 'nn',
-    OpenFoodFactsLanguage.AZERBAIJANI: 'az',
-    OpenFoodFactsLanguage.CZECH: 'cs',
-    OpenFoodFactsLanguage.NAVAJO: 'nv',
-    OpenFoodFactsLanguage.FINNISH: 'fi',
-    OpenFoodFactsLanguage.LUXEMBOURGISH: 'lb',
-    OpenFoodFactsLanguage.SWEDISH: 'sv',
-    OpenFoodFactsLanguage.YIDDISH: 'yi',
-    OpenFoodFactsLanguage.INUKTITUT: 'iu',
-    OpenFoodFactsLanguage.LAO: 'lo',
-    OpenFoodFactsLanguage.CHUVASH: 'cv',
-    OpenFoodFactsLanguage.MALTESE: 'mt',
-    OpenFoodFactsLanguage.MALDIVIAN_LANGUAGE: 'dv',
-    OpenFoodFactsLanguage.INTERLINGUE: 'ie',
-    OpenFoodFactsLanguage.OSSETIAN: 'os',
-    OpenFoodFactsLanguage.BASHKIR: 'ba',
-    OpenFoodFactsLanguage.OJIBWE: 'oj',
-    OpenFoodFactsLanguage.KANURI: 'kr',
-    OpenFoodFactsLanguage.INDONESIAN: 'id',
-    OpenFoodFactsLanguage.SARDINIAN_LANGUAGE: 'sc',
-    OpenFoodFactsLanguage.AKAN: 'ak',
-    OpenFoodFactsLanguage.MANX: 'gv',
-    OpenFoodFactsLanguage.TURKISH: 'tr',
-    OpenFoodFactsLanguage.ESPERANTO: 'eo',
-    OpenFoodFactsLanguage.PASHTO: 'ps',
-    OpenFoodFactsLanguage.KYRGYZ: 'ky',
-    OpenFoodFactsLanguage.VOLAPUK: 'vo',
-    OpenFoodFactsLanguage.AVAR: 'av',
-    OpenFoodFactsLanguage.SANGO: 'sg',
-    OpenFoodFactsLanguage.VENDA: 've',
-    OpenFoodFactsLanguage.ALBANIAN: 'sq',
-    OpenFoodFactsLanguage.BASQUE: 'eu',
-    OpenFoodFactsLanguage.FULA_LANGUAGE: 'ff',
-    OpenFoodFactsLanguage.GERMAN: 'de',
-    OpenFoodFactsLanguage.LATVIAN: 'lv',
-    OpenFoodFactsLanguage.CORNISH: 'kw',
-    OpenFoodFactsLanguage.PALI: 'pi',
-    OpenFoodFactsLanguage.TATAR: 'tt',
-    OpenFoodFactsLanguage.ROMANIAN: 'ro',
-    OpenFoodFactsLanguage.GIKUYU: 'ki',
-    OpenFoodFactsLanguage.TIGRINYA: 'ti',
-    OpenFoodFactsLanguage.GALICIAN: 'gl',
-    OpenFoodFactsLanguage.TELUGU: 'te',
-    OpenFoodFactsLanguage.HINDI: 'hi',
-    OpenFoodFactsLanguage.KONGO_LANGUAGE: 'kg',
-    OpenFoodFactsLanguage.XHOSA: 'xh',
-    OpenFoodFactsLanguage.SWAZI: 'ss',
-    OpenFoodFactsLanguage.LUGANDA: 'lg',
-    OpenFoodFactsLanguage.URDU: 'ur',
-    OpenFoodFactsLanguage.NORTHERN_NDEBELE_LANGUAGE: 'nd',
-    OpenFoodFactsLanguage.YORUBA: 'yo',
-    OpenFoodFactsLanguage.WORLD: 'world',
-    OpenFoodFactsLanguage.UNDEFINED: '-',
-  };
-
   /// Returns the corresponding ISO-639-1 code
   ///
   /// Won't return 2 characters for special cases like
   /// * [OpenFoodFactsLanguage.WORLD]
   /// * [OpenFoodFactsLanguage.UNDEFINED]
-  String get code => _CODES[this] ?? '-';
+  String get code => this?.offTag ?? '-';
 }
 
 /// Helper class around [OpenFoodFactsLanguage]
@@ -769,10 +594,7 @@ class LanguageHelper {
 
   /// Converts an ISO-639-1 code into an [OpenFoodFactsLanguage]
   static OpenFoodFactsLanguage fromJson(String? code) =>
-      OpenFoodFactsLanguage.values.firstWhere(
-        (final OpenFoodFactsLanguage language) => language.code == code,
-        orElse: () => OpenFoodFactsLanguage.UNDEFINED,
-      );
+      OpenFoodFactsLanguage.fromOffTag(code) ?? OpenFoodFactsLanguage.UNDEFINED;
 
   /// Converts a Map with [OpenFoodFactsLanguage] into
   /// a map with ISO-639-1 codes.
@@ -780,7 +602,7 @@ class LanguageHelper {
     if (map == null) {
       return null;
     }
-    return map.map((key, value) => MapEntry(key.code, value));
+    return map.map((key, value) => MapEntry(key.offTag, value));
   }
 
   /// Helper function without generic types. Needed for the

--- a/lib/utils/OpenFoodAPIConfiguration.dart
+++ b/lib/utils/OpenFoodAPIConfiguration.dart
@@ -82,10 +82,10 @@ class OpenFoodAPIConfiguration {
     final String? cc,
   ) {
     if (country != null) {
-      return country.iso2Code;
+      return country.offTag;
     }
     if (globalCountry != null) {
-      return globalCountry!.iso2Code;
+      return globalCountry!.offTag;
     }
     if (cc != null) {
       return cc;

--- a/lib/utils/ProductFields.dart
+++ b/lib/utils/ProductFields.dart
@@ -117,7 +117,7 @@ List<String> convertFieldsToStrings(
             'Cannot request in-lang field $field without language');
       }
       for (final language in languages) {
-        fieldsStrings.add('${field.offTag}${language.code}');
+        fieldsStrings.add('${field.offTag}${language.offTag}');
       }
     } else {
       fieldsStrings.add(field.offTag);

--- a/lib/utils/TaxonomyQueryConfiguration.dart
+++ b/lib/utils/TaxonomyQueryConfiguration.dart
@@ -99,7 +99,7 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
 
     if (languages.isNotEmpty) {
       result.putIfAbsent('lc',
-          () => languages.map<String>((language) => language.code).join(','));
+          () => languages.map<String>((language) => language.offTag).join(','));
     }
 
     result.putIfAbsent('cc',

--- a/lib/utils/UriHelper.dart
+++ b/lib/utils/UriHelper.dart
@@ -101,8 +101,8 @@ class UriHelper {
                     OpenFoodAPIConfiguration.globalLanguages!.isNotEmpty
                 ? OpenFoodAPIConfiguration.globalLanguages![0].code
                 : null),
-        countryCode: country?.iso2Code ??
-            OpenFoodAPIConfiguration.globalCountry?.iso2Code,
+        countryCode:
+            country?.offTag ?? OpenFoodAPIConfiguration.globalCountry?.offTag,
       );
 
   /// Replaces the subdomain of an URI with specific country and language.

--- a/test/api_getProduct_test.dart
+++ b/test/api_getProduct_test.dart
@@ -1768,7 +1768,7 @@ void main() {
           ).toString();
           expect(
             url,
-            'https://world-${language.code}.openfoodfacts.net/'
+            'https://world-${language.offTag}.openfoodfacts.net/'
             '${tagType.offTag}'
             '?translate=1',
           );

--- a/test/ordered_nutrient_test.dart
+++ b/test/ordered_nutrient_test.dart
@@ -168,7 +168,7 @@ void main() {
       for (final OpenFoodFactsCountry country in countries) {
         checkNutrients(
           await OpenFoodAPIClient.getOrderedNutrients(
-            cc: country.iso2Code,
+            cc: country.offTag,
             language: language,
           ),
           country,


### PR DESCRIPTION
Impacted files:
* `AbstractQueryConfiguration.dart`: minor refactoring
* `api_getProduct_test.dart`: minor refactoring
* `CountryHelper.dart`: upgraded `OpenFoodFactsCountry` to dart 2.17
* `ImageHelper.dart`: minor refactoring
* `JsonHelper.dart`: minor refactoring
* `LanguageHelper.dart`: upgraded `OpenFoodFactsLanguage` to dart 2.17
* `NutrientsLevels.dart`: upgraded `Level` to dart 2.17
* `OpenFoodAPIConfiguration.dart`: minor refactoring
* `openfoodfacts.dart`: minor refactoring
* `ordered_nutrient_test.dart`: minor refactoring
* `Product.dart`: minor refactoring
* `ProductFields.dart`: minor refactoring
* `ProductImage.dart`: upgraded `ImageField`, `ImageSize`, `ImageAngle` to dart 2.17; minor refactoring
* `SendImage.dart`: minor refactoring
* `State.dart`: upgraded `State` to dart 2.17
* `TaxonomyQueryConfiguration.dart`: minor refactoring
* `UriHelper.dart`: minor refactoring

### What
- Again, migrating `enum`s to dart 2.17
- That finally closes #571 (which is already closed for some reason).
- Some `enum`s are still written in the old-fashioned way, they can be processed later if needed, but now the bulk of `enum`s have migrated. Or is it "are migrated"? Maybe both, whatever.

### Fixes bug(s)
- Closes: #571