### PR TITLE
feat: Add copyWith method to all models

### DIFF
--- a/lib/model/Agribalyse.dart
+++ b/lib/model/Agribalyse.dart
@@ -1,8 +1,11 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'Agribalyse.g.dart';
 
+@CopyWith()
 @JsonSerializable()
 class Agribalyse extends JsonObject {
   @JsonKey(includeIfNull: false, fromJson: JsonObject.parseDouble)

--- a/lib/model/Agribalyse.g.dart
+++ b/lib/model/Agribalyse.g.dart
@@ -3,6 +3,59 @@
 part of 'Agribalyse.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$AgribalyseCWProxy {
+  Agribalyse score(double? score);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Agribalyse(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Agribalyse(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Agribalyse call({
+    double? score,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfAgribalyse.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfAgribalyse.copyWith.fieldName(...)`
+class _$AgribalyseCWProxyImpl implements _$AgribalyseCWProxy {
+  final Agribalyse _value;
+
+  const _$AgribalyseCWProxyImpl(this._value);
+
+  @override
+  Agribalyse score(double? score) => this(score: score);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Agribalyse(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Agribalyse(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Agribalyse call({
+    Object? score = const $CopyWithPlaceholder(),
+  }) {
+    return Agribalyse(
+      score: score == const $CopyWithPlaceholder()
+          ? _value.score
+          // ignore: cast_nullable_to_non_nullable
+          : score as double?,
+    );
+  }
+}
+
+extension $AgribalyseCopyWith on Agribalyse {
+  /// Returns a callable class that can be used as follows: `instanceOfAgribalyse.copyWith(...)` or like so:`instanceOfAgribalyse.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$AgribalyseCWProxy get copyWith => _$AgribalyseCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/BadgeBase.dart
+++ b/lib/model/BadgeBase.dart
@@ -1,9 +1,12 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'BadgeBase.g.dart';
 
 /// Events API: badge.
+@CopyWith()
 @JsonSerializable()
 class BadgeBase extends JsonObject {
   @JsonKey(name: 'user_id')

--- a/lib/model/BadgeBase.g.dart
+++ b/lib/model/BadgeBase.g.dart
@@ -3,6 +3,81 @@
 part of 'BadgeBase.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$BadgeBaseCWProxy {
+  BadgeBase badgeName(String badgeName);
+
+  BadgeBase level(int level);
+
+  BadgeBase userId(String? userId);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `BadgeBase(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// BadgeBase(...).copyWith(id: 12, name: "My name")
+  /// ````
+  BadgeBase call({
+    String? badgeName,
+    int? level,
+    String? userId,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfBadgeBase.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfBadgeBase.copyWith.fieldName(...)`
+class _$BadgeBaseCWProxyImpl implements _$BadgeBaseCWProxy {
+  final BadgeBase _value;
+
+  const _$BadgeBaseCWProxyImpl(this._value);
+
+  @override
+  BadgeBase badgeName(String badgeName) => this(badgeName: badgeName);
+
+  @override
+  BadgeBase level(int level) => this(level: level);
+
+  @override
+  BadgeBase userId(String? userId) => this(userId: userId);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `BadgeBase(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// BadgeBase(...).copyWith(id: 12, name: "My name")
+  /// ````
+  BadgeBase call({
+    Object? badgeName = const $CopyWithPlaceholder(),
+    Object? level = const $CopyWithPlaceholder(),
+    Object? userId = const $CopyWithPlaceholder(),
+  }) {
+    return BadgeBase(
+      badgeName: badgeName == const $CopyWithPlaceholder() || badgeName == null
+          ? _value.badgeName
+          // ignore: cast_nullable_to_non_nullable
+          : badgeName as String,
+      level: level == const $CopyWithPlaceholder() || level == null
+          ? _value.level
+          // ignore: cast_nullable_to_non_nullable
+          : level as int,
+      userId: userId == const $CopyWithPlaceholder()
+          ? _value.userId
+          // ignore: cast_nullable_to_non_nullable
+          : userId as String?,
+    );
+  }
+}
+
+extension $BadgeBaseCopyWith on BadgeBase {
+  /// Returns a callable class that can be used as follows: `instanceOfBadgeBase.copyWith(...)` or like so:`instanceOfBadgeBase.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$BadgeBaseCWProxy get copyWith => _$BadgeBaseCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/EcoscoreAdjustments.dart
+++ b/lib/model/EcoscoreAdjustments.dart
@@ -1,10 +1,13 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
+
 import '../interface/JsonObject.dart';
 import 'OriginsOfIngredients.dart';
 import 'Packaging.dart';
 
 part 'EcoscoreAdjustments.g.dart';
 
+@CopyWith()
 @JsonSerializable(explicitToJson: true)
 class EcoscoreAdjustments extends JsonObject {
   @JsonKey(includeIfNull: false)

--- a/lib/model/EcoscoreAdjustments.g.dart
+++ b/lib/model/EcoscoreAdjustments.g.dart
@@ -3,6 +3,75 @@
 part of 'EcoscoreAdjustments.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$EcoscoreAdjustmentsCWProxy {
+  EcoscoreAdjustments originsOfIngredients(
+      OriginsOfIngredients? originsOfIngredients);
+
+  EcoscoreAdjustments packaging(Packaging? packaging);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `EcoscoreAdjustments(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// EcoscoreAdjustments(...).copyWith(id: 12, name: "My name")
+  /// ````
+  EcoscoreAdjustments call({
+    OriginsOfIngredients? originsOfIngredients,
+    Packaging? packaging,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfEcoscoreAdjustments.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfEcoscoreAdjustments.copyWith.fieldName(...)`
+class _$EcoscoreAdjustmentsCWProxyImpl implements _$EcoscoreAdjustmentsCWProxy {
+  final EcoscoreAdjustments _value;
+
+  const _$EcoscoreAdjustmentsCWProxyImpl(this._value);
+
+  @override
+  EcoscoreAdjustments originsOfIngredients(
+          OriginsOfIngredients? originsOfIngredients) =>
+      this(originsOfIngredients: originsOfIngredients);
+
+  @override
+  EcoscoreAdjustments packaging(Packaging? packaging) =>
+      this(packaging: packaging);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `EcoscoreAdjustments(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// EcoscoreAdjustments(...).copyWith(id: 12, name: "My name")
+  /// ````
+  EcoscoreAdjustments call({
+    Object? originsOfIngredients = const $CopyWithPlaceholder(),
+    Object? packaging = const $CopyWithPlaceholder(),
+  }) {
+    return EcoscoreAdjustments(
+      originsOfIngredients: originsOfIngredients == const $CopyWithPlaceholder()
+          ? _value.originsOfIngredients
+          // ignore: cast_nullable_to_non_nullable
+          : originsOfIngredients as OriginsOfIngredients?,
+      packaging: packaging == const $CopyWithPlaceholder()
+          ? _value.packaging
+          // ignore: cast_nullable_to_non_nullable
+          : packaging as Packaging?,
+    );
+  }
+}
+
+extension $EcoscoreAdjustmentsCopyWith on EcoscoreAdjustments {
+  /// Returns a callable class that can be used as follows: `instanceOfEcoscoreAdjustments.copyWith(...)` or like so:`instanceOfEcoscoreAdjustments.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$EcoscoreAdjustmentsCWProxy get copyWith =>
+      _$EcoscoreAdjustmentsCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/EcoscoreData.dart
+++ b/lib/model/EcoscoreData.dart
@@ -1,4 +1,6 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
+
 import '../interface/JsonObject.dart';
 import 'Agribalyse.dart';
 import 'EcoscoreAdjustments.dart';
@@ -12,6 +14,7 @@ enum EcoscoreStatus {
   UNKNOWN
 }
 
+@CopyWith()
 @JsonSerializable(explicitToJson: true)
 class EcoscoreData extends JsonObject {
   @JsonKey(includeIfNull: false)

--- a/lib/model/EcoscoreData.g.dart
+++ b/lib/model/EcoscoreData.g.dart
@@ -3,6 +3,118 @@
 part of 'EcoscoreData.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$EcoscoreDataCWProxy {
+  EcoscoreData adjustments(EcoscoreAdjustments? adjustments);
+
+  EcoscoreData agribalyse(Agribalyse? agribalyse);
+
+  EcoscoreData grade(String? grade);
+
+  EcoscoreData missingDataWarning(bool missingDataWarning);
+
+  EcoscoreData score(double? score);
+
+  EcoscoreData status(EcoscoreStatus? status);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `EcoscoreData(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// EcoscoreData(...).copyWith(id: 12, name: "My name")
+  /// ````
+  EcoscoreData call({
+    EcoscoreAdjustments? adjustments,
+    Agribalyse? agribalyse,
+    String? grade,
+    bool? missingDataWarning,
+    double? score,
+    EcoscoreStatus? status,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfEcoscoreData.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfEcoscoreData.copyWith.fieldName(...)`
+class _$EcoscoreDataCWProxyImpl implements _$EcoscoreDataCWProxy {
+  final EcoscoreData _value;
+
+  const _$EcoscoreDataCWProxyImpl(this._value);
+
+  @override
+  EcoscoreData adjustments(EcoscoreAdjustments? adjustments) =>
+      this(adjustments: adjustments);
+
+  @override
+  EcoscoreData agribalyse(Agribalyse? agribalyse) =>
+      this(agribalyse: agribalyse);
+
+  @override
+  EcoscoreData grade(String? grade) => this(grade: grade);
+
+  @override
+  EcoscoreData missingDataWarning(bool missingDataWarning) =>
+      this(missingDataWarning: missingDataWarning);
+
+  @override
+  EcoscoreData score(double? score) => this(score: score);
+
+  @override
+  EcoscoreData status(EcoscoreStatus? status) => this(status: status);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `EcoscoreData(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// EcoscoreData(...).copyWith(id: 12, name: "My name")
+  /// ````
+  EcoscoreData call({
+    Object? adjustments = const $CopyWithPlaceholder(),
+    Object? agribalyse = const $CopyWithPlaceholder(),
+    Object? grade = const $CopyWithPlaceholder(),
+    Object? missingDataWarning = const $CopyWithPlaceholder(),
+    Object? score = const $CopyWithPlaceholder(),
+    Object? status = const $CopyWithPlaceholder(),
+  }) {
+    return EcoscoreData(
+      adjustments: adjustments == const $CopyWithPlaceholder()
+          ? _value.adjustments
+          // ignore: cast_nullable_to_non_nullable
+          : adjustments as EcoscoreAdjustments?,
+      agribalyse: agribalyse == const $CopyWithPlaceholder()
+          ? _value.agribalyse
+          // ignore: cast_nullable_to_non_nullable
+          : agribalyse as Agribalyse?,
+      grade: grade == const $CopyWithPlaceholder()
+          ? _value.grade
+          // ignore: cast_nullable_to_non_nullable
+          : grade as String?,
+      missingDataWarning: missingDataWarning == const $CopyWithPlaceholder() ||
+              missingDataWarning == null
+          ? _value.missingDataWarning
+          // ignore: cast_nullable_to_non_nullable
+          : missingDataWarning as bool,
+      score: score == const $CopyWithPlaceholder()
+          ? _value.score
+          // ignore: cast_nullable_to_non_nullable
+          : score as double?,
+      status: status == const $CopyWithPlaceholder()
+          ? _value.status
+          // ignore: cast_nullable_to_non_nullable
+          : status as EcoscoreStatus?,
+    );
+  }
+}
+
+extension $EcoscoreDataCopyWith on EcoscoreData {
+  /// Returns a callable class that can be used as follows: `instanceOfEcoscoreData.copyWith(...)` or like so:`instanceOfEcoscoreData.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$EcoscoreDataCWProxy get copyWith => _$EcoscoreDataCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/EventsBase.dart
+++ b/lib/model/EventsBase.dart
@@ -1,10 +1,13 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:openfoodfacts/utils/JsonHelper.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'EventsBase.g.dart';
 
 /// Events API: event.
+@CopyWith()
 @JsonSerializable()
 class EventsBase extends JsonObject {
   @JsonKey(name: 'event_type')

--- a/lib/model/EventsBase.g.dart
+++ b/lib/model/EventsBase.g.dart
@@ -3,6 +3,103 @@
 part of 'EventsBase.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$EventsBaseCWProxy {
+  EventsBase barcode(String? barcode);
+
+  EventsBase eventType(String eventType);
+
+  EventsBase points(int? points);
+
+  EventsBase timestamp(DateTime? timestamp);
+
+  EventsBase userId(String? userId);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `EventsBase(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// EventsBase(...).copyWith(id: 12, name: "My name")
+  /// ````
+  EventsBase call({
+    String? barcode,
+    String? eventType,
+    int? points,
+    DateTime? timestamp,
+    String? userId,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfEventsBase.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfEventsBase.copyWith.fieldName(...)`
+class _$EventsBaseCWProxyImpl implements _$EventsBaseCWProxy {
+  final EventsBase _value;
+
+  const _$EventsBaseCWProxyImpl(this._value);
+
+  @override
+  EventsBase barcode(String? barcode) => this(barcode: barcode);
+
+  @override
+  EventsBase eventType(String eventType) => this(eventType: eventType);
+
+  @override
+  EventsBase points(int? points) => this(points: points);
+
+  @override
+  EventsBase timestamp(DateTime? timestamp) => this(timestamp: timestamp);
+
+  @override
+  EventsBase userId(String? userId) => this(userId: userId);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `EventsBase(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// EventsBase(...).copyWith(id: 12, name: "My name")
+  /// ````
+  EventsBase call({
+    Object? barcode = const $CopyWithPlaceholder(),
+    Object? eventType = const $CopyWithPlaceholder(),
+    Object? points = const $CopyWithPlaceholder(),
+    Object? timestamp = const $CopyWithPlaceholder(),
+    Object? userId = const $CopyWithPlaceholder(),
+  }) {
+    return EventsBase(
+      barcode: barcode == const $CopyWithPlaceholder()
+          ? _value.barcode
+          // ignore: cast_nullable_to_non_nullable
+          : barcode as String?,
+      eventType: eventType == const $CopyWithPlaceholder() || eventType == null
+          ? _value.eventType
+          // ignore: cast_nullable_to_non_nullable
+          : eventType as String,
+      points: points == const $CopyWithPlaceholder()
+          ? _value.points
+          // ignore: cast_nullable_to_non_nullable
+          : points as int?,
+      timestamp: timestamp == const $CopyWithPlaceholder()
+          ? _value.timestamp
+          // ignore: cast_nullable_to_non_nullable
+          : timestamp as DateTime?,
+      userId: userId == const $CopyWithPlaceholder()
+          ? _value.userId
+          // ignore: cast_nullable_to_non_nullable
+          : userId as String?,
+    );
+  }
+}
+
+extension $EventsBaseCopyWith on EventsBase {
+  /// Returns a callable class that can be used as follows: `instanceOfEventsBase.copyWith(...)` or like so:`instanceOfEventsBase.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$EventsBaseCWProxy get copyWith => _$EventsBaseCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/Ingredient.dart
+++ b/lib/model/Ingredient.dart
@@ -1,11 +1,14 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:openfoodfacts/utils/JsonHelper.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'Ingredient.g.dart';
 
 enum IngredientSpecialPropertyStatus { POSITIVE, NEGATIVE, MAYBE, IGNORE }
 
+@CopyWith()
 @JsonSerializable()
 class Ingredient extends JsonObject {
   @JsonKey(includeIfNull: false, fromJson: JsonObject.parseInt)

--- a/lib/model/Ingredient.g.dart
+++ b/lib/model/Ingredient.g.dart
@@ -3,6 +3,163 @@
 part of 'Ingredient.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$IngredientCWProxy {
+  Ingredient bold(bool? bold);
+
+  Ingredient fromPalmOil(IngredientSpecialPropertyStatus? fromPalmOil);
+
+  Ingredient id(String? id);
+
+  Ingredient ingredients(List<Ingredient>? ingredients);
+
+  Ingredient percent(double? percent);
+
+  Ingredient percentEstimate(double? percentEstimate);
+
+  Ingredient rank(int? rank);
+
+  Ingredient text(String? text);
+
+  Ingredient vegan(IngredientSpecialPropertyStatus? vegan);
+
+  Ingredient vegetarian(IngredientSpecialPropertyStatus? vegetarian);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Ingredient(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Ingredient(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Ingredient call({
+    bool? bold,
+    IngredientSpecialPropertyStatus? fromPalmOil,
+    String? id,
+    List<Ingredient>? ingredients,
+    double? percent,
+    double? percentEstimate,
+    int? rank,
+    String? text,
+    IngredientSpecialPropertyStatus? vegan,
+    IngredientSpecialPropertyStatus? vegetarian,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfIngredient.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfIngredient.copyWith.fieldName(...)`
+class _$IngredientCWProxyImpl implements _$IngredientCWProxy {
+  final Ingredient _value;
+
+  const _$IngredientCWProxyImpl(this._value);
+
+  @override
+  Ingredient bold(bool? bold) => this(bold: bold);
+
+  @override
+  Ingredient fromPalmOil(IngredientSpecialPropertyStatus? fromPalmOil) =>
+      this(fromPalmOil: fromPalmOil);
+
+  @override
+  Ingredient id(String? id) => this(id: id);
+
+  @override
+  Ingredient ingredients(List<Ingredient>? ingredients) =>
+      this(ingredients: ingredients);
+
+  @override
+  Ingredient percent(double? percent) => this(percent: percent);
+
+  @override
+  Ingredient percentEstimate(double? percentEstimate) =>
+      this(percentEstimate: percentEstimate);
+
+  @override
+  Ingredient rank(int? rank) => this(rank: rank);
+
+  @override
+  Ingredient text(String? text) => this(text: text);
+
+  @override
+  Ingredient vegan(IngredientSpecialPropertyStatus? vegan) =>
+      this(vegan: vegan);
+
+  @override
+  Ingredient vegetarian(IngredientSpecialPropertyStatus? vegetarian) =>
+      this(vegetarian: vegetarian);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Ingredient(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Ingredient(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Ingredient call({
+    Object? bold = const $CopyWithPlaceholder(),
+    Object? fromPalmOil = const $CopyWithPlaceholder(),
+    Object? id = const $CopyWithPlaceholder(),
+    Object? ingredients = const $CopyWithPlaceholder(),
+    Object? percent = const $CopyWithPlaceholder(),
+    Object? percentEstimate = const $CopyWithPlaceholder(),
+    Object? rank = const $CopyWithPlaceholder(),
+    Object? text = const $CopyWithPlaceholder(),
+    Object? vegan = const $CopyWithPlaceholder(),
+    Object? vegetarian = const $CopyWithPlaceholder(),
+  }) {
+    return Ingredient(
+      bold: bold == const $CopyWithPlaceholder()
+          ? _value.bold
+          // ignore: cast_nullable_to_non_nullable
+          : bold as bool?,
+      fromPalmOil: fromPalmOil == const $CopyWithPlaceholder()
+          ? _value.fromPalmOil
+          // ignore: cast_nullable_to_non_nullable
+          : fromPalmOil as IngredientSpecialPropertyStatus?,
+      id: id == const $CopyWithPlaceholder()
+          ? _value.id
+          // ignore: cast_nullable_to_non_nullable
+          : id as String?,
+      ingredients: ingredients == const $CopyWithPlaceholder()
+          ? _value.ingredients
+          // ignore: cast_nullable_to_non_nullable
+          : ingredients as List<Ingredient>?,
+      percent: percent == const $CopyWithPlaceholder()
+          ? _value.percent
+          // ignore: cast_nullable_to_non_nullable
+          : percent as double?,
+      percentEstimate: percentEstimate == const $CopyWithPlaceholder()
+          ? _value.percentEstimate
+          // ignore: cast_nullable_to_non_nullable
+          : percentEstimate as double?,
+      rank: rank == const $CopyWithPlaceholder()
+          ? _value.rank
+          // ignore: cast_nullable_to_non_nullable
+          : rank as int?,
+      text: text == const $CopyWithPlaceholder()
+          ? _value.text
+          // ignore: cast_nullable_to_non_nullable
+          : text as String?,
+      vegan: vegan == const $CopyWithPlaceholder()
+          ? _value.vegan
+          // ignore: cast_nullable_to_non_nullable
+          : vegan as IngredientSpecialPropertyStatus?,
+      vegetarian: vegetarian == const $CopyWithPlaceholder()
+          ? _value.vegetarian
+          // ignore: cast_nullable_to_non_nullable
+          : vegetarian as IngredientSpecialPropertyStatus?,
+    );
+  }
+}
+
+extension $IngredientCopyWith on Ingredient {
+  /// Returns a callable class that can be used as follows: `instanceOfIngredient.copyWith(...)` or like so:`instanceOfIngredient.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$IngredientCWProxy get copyWith => _$IngredientCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/Insight.dart
+++ b/lib/model/Insight.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 
 part 'Insight.g.dart';
@@ -60,6 +61,7 @@ extension InsightTypesExtension on InsightType? {
       );
 }
 
+@CopyWith()
 @JsonSerializable()
 class InsightsResult extends JsonObject {
   final String? status;

--- a/lib/model/Insight.g.dart
+++ b/lib/model/Insight.g.dart
@@ -3,6 +3,70 @@
 part of 'Insight.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$InsightsResultCWProxy {
+  InsightsResult insights(List<Insight>? insights);
+
+  InsightsResult status(String? status);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `InsightsResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// InsightsResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  InsightsResult call({
+    List<Insight>? insights,
+    String? status,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfInsightsResult.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfInsightsResult.copyWith.fieldName(...)`
+class _$InsightsResultCWProxyImpl implements _$InsightsResultCWProxy {
+  final InsightsResult _value;
+
+  const _$InsightsResultCWProxyImpl(this._value);
+
+  @override
+  InsightsResult insights(List<Insight>? insights) => this(insights: insights);
+
+  @override
+  InsightsResult status(String? status) => this(status: status);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `InsightsResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// InsightsResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  InsightsResult call({
+    Object? insights = const $CopyWithPlaceholder(),
+    Object? status = const $CopyWithPlaceholder(),
+  }) {
+    return InsightsResult(
+      insights: insights == const $CopyWithPlaceholder()
+          ? _value.insights
+          // ignore: cast_nullable_to_non_nullable
+          : insights as List<Insight>?,
+      status: status == const $CopyWithPlaceholder()
+          ? _value.status
+          // ignore: cast_nullable_to_non_nullable
+          : status as String?,
+    );
+  }
+}
+
+extension $InsightsResultCopyWith on InsightsResult {
+  /// Returns a callable class that can be used as follows: `instanceOfInsightsResult.copyWith(...)` or like so:`instanceOfInsightsResult.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$InsightsResultCWProxy get copyWith => _$InsightsResultCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
@@ -12,17 +76,8 @@ InsightsResult _$InsightsResultFromJson(Map<String, dynamic> json) =>
       insights: Insight.fromJson(json['insights']),
     );
 
-Map<String, dynamic> _$InsightsResultToJson(InsightsResult instance) {
-  final val = <String, dynamic>{
-    'status': instance.status,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('insights', Insight.toJson(instance.insights));
-  return val;
-}
+Map<String, dynamic> _$InsightsResultToJson(InsightsResult instance) =>
+    <String, dynamic>{
+      'status': instance.status,
+      'insights': Insight.toJson(instance.insights),
+    };

--- a/lib/model/KeyStats.dart
+++ b/lib/model/KeyStats.dart
@@ -1,9 +1,12 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'KeyStats.g.dart';
 
 /// Folksonomy: statistics around a tag key.
+@CopyWith()
 @JsonSerializable()
 class KeyStats extends JsonObject {
   @JsonKey(name: 'k')

--- a/lib/model/KeyStats.g.dart
+++ b/lib/model/KeyStats.g.dart
@@ -3,6 +3,81 @@
 part of 'KeyStats.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$KeyStatsCWProxy {
+  KeyStats count(int count);
+
+  KeyStats key(String key);
+
+  KeyStats values(int values);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KeyStats(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KeyStats(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KeyStats call({
+    int? count,
+    String? key,
+    int? values,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKeyStats.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKeyStats.copyWith.fieldName(...)`
+class _$KeyStatsCWProxyImpl implements _$KeyStatsCWProxy {
+  final KeyStats _value;
+
+  const _$KeyStatsCWProxyImpl(this._value);
+
+  @override
+  KeyStats count(int count) => this(count: count);
+
+  @override
+  KeyStats key(String key) => this(key: key);
+
+  @override
+  KeyStats values(int values) => this(values: values);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KeyStats(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KeyStats(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KeyStats call({
+    Object? count = const $CopyWithPlaceholder(),
+    Object? key = const $CopyWithPlaceholder(),
+    Object? values = const $CopyWithPlaceholder(),
+  }) {
+    return KeyStats(
+      count: count == const $CopyWithPlaceholder() || count == null
+          ? _value.count
+          // ignore: cast_nullable_to_non_nullable
+          : count as int,
+      key: key == const $CopyWithPlaceholder() || key == null
+          ? _value.key
+          // ignore: cast_nullable_to_non_nullable
+          : key as String,
+      values: values == const $CopyWithPlaceholder() || values == null
+          ? _value.values
+          // ignore: cast_nullable_to_non_nullable
+          : values as int,
+    );
+  }
+}
+
+extension $KeyStatsCopyWith on KeyStats {
+  /// Returns a callable class that can be used as follows: `instanceOfKeyStats.copyWith(...)` or like so:`instanceOfKeyStats.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KeyStatsCWProxy get copyWith => _$KeyStatsCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/KnowledgePanel.dart
+++ b/lib/model/KnowledgePanel.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
-import '../interface/JsonObject.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
 
+import '../interface/JsonObject.dart';
 import 'KnowledgePanelElement.dart';
 
 part 'KnowledgePanel.g.dart';
@@ -75,6 +76,7 @@ enum KnowledgePanelSize {
 ///
 /// See http://shorturl.at/oxRS9 for details.
 // NOTE: This is WIP, do not use and expect changes.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanel extends JsonObject {
   /// Title of the KnowledgePanel.
@@ -124,6 +126,7 @@ class KnowledgePanel extends JsonObject {
 
 /// An element representing the title of the KnowledgePanel which could consist
 /// of a text title, subtitle and an icon.
+@CopyWith()
 @JsonSerializable()
 class TitleElement extends JsonObject {
   /// Title string of the panel. Example - 'Eco-Score D'.

--- a/lib/model/KnowledgePanel.g.dart
+++ b/lib/model/KnowledgePanel.g.dart
@@ -3,6 +3,234 @@
 part of 'KnowledgePanel.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$KnowledgePanelCWProxy {
+  KnowledgePanel elements(List<KnowledgePanelElement>? elements);
+
+  KnowledgePanel evaluation(Evaluation? evaluation);
+
+  KnowledgePanel expanded(bool? expanded);
+
+  KnowledgePanel level(Level? level);
+
+  KnowledgePanel size(KnowledgePanelSize? size);
+
+  KnowledgePanel titleElement(TitleElement? titleElement);
+
+  KnowledgePanel topics(List<String>? topics);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanel(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanel(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanel call({
+    List<KnowledgePanelElement>? elements,
+    Evaluation? evaluation,
+    bool? expanded,
+    Level? level,
+    KnowledgePanelSize? size,
+    TitleElement? titleElement,
+    List<String>? topics,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanel.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanel.copyWith.fieldName(...)`
+class _$KnowledgePanelCWProxyImpl implements _$KnowledgePanelCWProxy {
+  final KnowledgePanel _value;
+
+  const _$KnowledgePanelCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanel elements(List<KnowledgePanelElement>? elements) =>
+      this(elements: elements);
+
+  @override
+  KnowledgePanel evaluation(Evaluation? evaluation) =>
+      this(evaluation: evaluation);
+
+  @override
+  KnowledgePanel expanded(bool? expanded) => this(expanded: expanded);
+
+  @override
+  KnowledgePanel level(Level? level) => this(level: level);
+
+  @override
+  KnowledgePanel size(KnowledgePanelSize? size) => this(size: size);
+
+  @override
+  KnowledgePanel titleElement(TitleElement? titleElement) =>
+      this(titleElement: titleElement);
+
+  @override
+  KnowledgePanel topics(List<String>? topics) => this(topics: topics);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanel(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanel(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanel call({
+    Object? elements = const $CopyWithPlaceholder(),
+    Object? evaluation = const $CopyWithPlaceholder(),
+    Object? expanded = const $CopyWithPlaceholder(),
+    Object? level = const $CopyWithPlaceholder(),
+    Object? size = const $CopyWithPlaceholder(),
+    Object? titleElement = const $CopyWithPlaceholder(),
+    Object? topics = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanel(
+      elements: elements == const $CopyWithPlaceholder()
+          ? _value.elements
+          // ignore: cast_nullable_to_non_nullable
+          : elements as List<KnowledgePanelElement>?,
+      evaluation: evaluation == const $CopyWithPlaceholder()
+          ? _value.evaluation
+          // ignore: cast_nullable_to_non_nullable
+          : evaluation as Evaluation?,
+      expanded: expanded == const $CopyWithPlaceholder()
+          ? _value.expanded
+          // ignore: cast_nullable_to_non_nullable
+          : expanded as bool?,
+      level: level == const $CopyWithPlaceholder()
+          ? _value.level
+          // ignore: cast_nullable_to_non_nullable
+          : level as Level?,
+      size: size == const $CopyWithPlaceholder()
+          ? _value.size
+          // ignore: cast_nullable_to_non_nullable
+          : size as KnowledgePanelSize?,
+      titleElement: titleElement == const $CopyWithPlaceholder()
+          ? _value.titleElement
+          // ignore: cast_nullable_to_non_nullable
+          : titleElement as TitleElement?,
+      topics: topics == const $CopyWithPlaceholder()
+          ? _value.topics
+          // ignore: cast_nullable_to_non_nullable
+          : topics as List<String>?,
+    );
+  }
+}
+
+extension $KnowledgePanelCopyWith on KnowledgePanel {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanel.copyWith(...)` or like so:`instanceOfKnowledgePanel.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelCWProxy get copyWith => _$KnowledgePanelCWProxyImpl(this);
+}
+
+abstract class _$TitleElementCWProxy {
+  TitleElement grade(Grade? grade);
+
+  TitleElement iconColorFromEvaluation(bool? iconColorFromEvaluation);
+
+  TitleElement iconUrl(String? iconUrl);
+
+  TitleElement subtitle(String? subtitle);
+
+  TitleElement title(String title);
+
+  TitleElement type(TitleElementType? type);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TitleElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TitleElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TitleElement call({
+    Grade? grade,
+    bool? iconColorFromEvaluation,
+    String? iconUrl,
+    String? subtitle,
+    String? title,
+    TitleElementType? type,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTitleElement.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTitleElement.copyWith.fieldName(...)`
+class _$TitleElementCWProxyImpl implements _$TitleElementCWProxy {
+  final TitleElement _value;
+
+  const _$TitleElementCWProxyImpl(this._value);
+
+  @override
+  TitleElement grade(Grade? grade) => this(grade: grade);
+
+  @override
+  TitleElement iconColorFromEvaluation(bool? iconColorFromEvaluation) =>
+      this(iconColorFromEvaluation: iconColorFromEvaluation);
+
+  @override
+  TitleElement iconUrl(String? iconUrl) => this(iconUrl: iconUrl);
+
+  @override
+  TitleElement subtitle(String? subtitle) => this(subtitle: subtitle);
+
+  @override
+  TitleElement title(String title) => this(title: title);
+
+  @override
+  TitleElement type(TitleElementType? type) => this(type: type);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TitleElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TitleElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TitleElement call({
+    Object? grade = const $CopyWithPlaceholder(),
+    Object? iconColorFromEvaluation = const $CopyWithPlaceholder(),
+    Object? iconUrl = const $CopyWithPlaceholder(),
+    Object? subtitle = const $CopyWithPlaceholder(),
+    Object? title = const $CopyWithPlaceholder(),
+    Object? type = const $CopyWithPlaceholder(),
+  }) {
+    return TitleElement(
+      grade: grade == const $CopyWithPlaceholder()
+          ? _value.grade
+          // ignore: cast_nullable_to_non_nullable
+          : grade as Grade?,
+      iconColorFromEvaluation:
+          iconColorFromEvaluation == const $CopyWithPlaceholder()
+              ? _value.iconColorFromEvaluation
+              // ignore: cast_nullable_to_non_nullable
+              : iconColorFromEvaluation as bool?,
+      iconUrl: iconUrl == const $CopyWithPlaceholder()
+          ? _value.iconUrl
+          // ignore: cast_nullable_to_non_nullable
+          : iconUrl as String?,
+      subtitle: subtitle == const $CopyWithPlaceholder()
+          ? _value.subtitle
+          // ignore: cast_nullable_to_non_nullable
+          : subtitle as String?,
+      title: title == const $CopyWithPlaceholder() || title == null
+          ? _value.title
+          // ignore: cast_nullable_to_non_nullable
+          : title as String,
+      type: type == const $CopyWithPlaceholder()
+          ? _value.type
+          // ignore: cast_nullable_to_non_nullable
+          : type as TitleElementType?,
+    );
+  }
+}
+
+extension $TitleElementCopyWith on TitleElement {
+  /// Returns a callable class that can be used as follows: `instanceOfTitleElement.copyWith(...)` or like so:`instanceOfTitleElement.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TitleElementCWProxy get copyWith => _$TitleElementCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/KnowledgePanelElement.dart
+++ b/lib/model/KnowledgePanelElement.dart
@@ -1,5 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:openfoodfacts/model/KnowledgePanel.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'KnowledgePanelElement.g.dart';
@@ -34,6 +36,7 @@ enum KnowledgePanelColumnType {
 }
 
 /// Description element of the Knowledge panel.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelTextElement extends JsonObject {
   /// HTML description of one Knowledge Panel Unit.
@@ -77,6 +80,7 @@ class KnowledgePanelTextElement extends JsonObject {
 }
 
 /// Image that represents the KnowledgePanel.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelImageElement extends JsonObject {
   /// Url of the image.
@@ -109,6 +113,7 @@ class KnowledgePanelImageElement extends JsonObject {
 }
 
 /// Element representing a Panel group that contains 1+ KnowledgePanels.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelPanelGroupElement extends JsonObject {
   /// Title of the panel group. Example: "Carbon Footprint" or "Labels" etc.
@@ -132,6 +137,7 @@ class KnowledgePanelPanelGroupElement extends JsonObject {
 /// Element representing a Panel Id of a KnowledgePanel. This element is a
 /// Knowledge panel itself, the KnowledgePanel can be found in the list of
 /// Knowledge panels using the id.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelPanelIdElement extends JsonObject {
   @JsonKey(name: 'panel_id')
@@ -147,6 +153,7 @@ class KnowledgePanelPanelIdElement extends JsonObject {
 }
 
 /// Provides the values for each table cell inside a KnowledgePanel table.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelTableCell extends JsonObject {
   final String text;
@@ -171,6 +178,7 @@ class KnowledgePanelTableCell extends JsonObject {
 }
 
 /// A table row inside Table element of KonwledgePanel
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelTableRowElement extends JsonObject {
   final List<KnowledgePanelTableCell> values;
@@ -185,6 +193,7 @@ class KnowledgePanelTableRowElement extends JsonObject {
 }
 
 /// A descriptor that describes the type and label of each column.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelTableColumn extends JsonObject {
   final String text;
@@ -220,6 +229,7 @@ class KnowledgePanelTableColumn extends JsonObject {
 }
 
 /// Element representing a world map.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelWorldMapElement extends JsonObject {
   final List<KnowledgePanelGeoPointer> pointers;
@@ -236,6 +246,7 @@ class KnowledgePanelWorldMapElement extends JsonObject {
 }
 
 /// Element representing a geo location of a map pointer.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelGeoPointer extends JsonObject {
   final KnowledgePanelLatLng? geo;
@@ -252,6 +263,7 @@ class KnowledgePanelGeoPointer extends JsonObject {
 }
 
 /// Element representing a lat/long positioning of a map pointer.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelLatLng extends JsonObject {
   final double lat;
@@ -270,6 +282,7 @@ class KnowledgePanelLatLng extends JsonObject {
 }
 
 /// Element representing a tabular data for the KnowledgePanel.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelTableElement extends JsonObject {
   final String id;
@@ -296,6 +309,7 @@ class KnowledgePanelTableElement extends JsonObject {
 }
 
 /// "Contribute action" element of the Knowledge panel.
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelActionElement extends JsonObject {
   /// Possible needed contribute action: add categories.
@@ -354,6 +368,7 @@ enum KnowledgePanelElementType {
 /// KnowledgePanelElement is a single unit of KnowledgePanel that can be rendered on the client.
 ///
 /// An Element could be one of [{@code ]KnowledgePanelElementType].
+@CopyWith()
 @JsonSerializable()
 class KnowledgePanelElement extends JsonObject {
   /// Type of the text description.

--- a/lib/model/KnowledgePanelElement.g.dart
+++ b/lib/model/KnowledgePanelElement.g.dart
@@ -3,6 +3,1032 @@
 part of 'KnowledgePanelElement.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$KnowledgePanelTextElementCWProxy {
+  KnowledgePanelTextElement html(String html);
+
+  KnowledgePanelTextElement sourceLanguage(String? sourceLanguage);
+
+  KnowledgePanelTextElement sourceLocale(String? sourceLocale);
+
+  KnowledgePanelTextElement sourceText(String? sourceText);
+
+  KnowledgePanelTextElement sourceUrl(String? sourceUrl);
+
+  KnowledgePanelTextElement type(KnowledgePanelTextElementType? type);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelTextElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelTextElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelTextElement call({
+    String? html,
+    String? sourceLanguage,
+    String? sourceLocale,
+    String? sourceText,
+    String? sourceUrl,
+    KnowledgePanelTextElementType? type,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelTextElement.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelTextElement.copyWith.fieldName(...)`
+class _$KnowledgePanelTextElementCWProxyImpl
+    implements _$KnowledgePanelTextElementCWProxy {
+  final KnowledgePanelTextElement _value;
+
+  const _$KnowledgePanelTextElementCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelTextElement html(String html) => this(html: html);
+
+  @override
+  KnowledgePanelTextElement sourceLanguage(String? sourceLanguage) =>
+      this(sourceLanguage: sourceLanguage);
+
+  @override
+  KnowledgePanelTextElement sourceLocale(String? sourceLocale) =>
+      this(sourceLocale: sourceLocale);
+
+  @override
+  KnowledgePanelTextElement sourceText(String? sourceText) =>
+      this(sourceText: sourceText);
+
+  @override
+  KnowledgePanelTextElement sourceUrl(String? sourceUrl) =>
+      this(sourceUrl: sourceUrl);
+
+  @override
+  KnowledgePanelTextElement type(KnowledgePanelTextElementType? type) =>
+      this(type: type);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelTextElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelTextElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelTextElement call({
+    Object? html = const $CopyWithPlaceholder(),
+    Object? sourceLanguage = const $CopyWithPlaceholder(),
+    Object? sourceLocale = const $CopyWithPlaceholder(),
+    Object? sourceText = const $CopyWithPlaceholder(),
+    Object? sourceUrl = const $CopyWithPlaceholder(),
+    Object? type = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelTextElement(
+      html: html == const $CopyWithPlaceholder() || html == null
+          ? _value.html
+          // ignore: cast_nullable_to_non_nullable
+          : html as String,
+      sourceLanguage: sourceLanguage == const $CopyWithPlaceholder()
+          ? _value.sourceLanguage
+          // ignore: cast_nullable_to_non_nullable
+          : sourceLanguage as String?,
+      sourceLocale: sourceLocale == const $CopyWithPlaceholder()
+          ? _value.sourceLocale
+          // ignore: cast_nullable_to_non_nullable
+          : sourceLocale as String?,
+      sourceText: sourceText == const $CopyWithPlaceholder()
+          ? _value.sourceText
+          // ignore: cast_nullable_to_non_nullable
+          : sourceText as String?,
+      sourceUrl: sourceUrl == const $CopyWithPlaceholder()
+          ? _value.sourceUrl
+          // ignore: cast_nullable_to_non_nullable
+          : sourceUrl as String?,
+      type: type == const $CopyWithPlaceholder()
+          ? _value.type
+          // ignore: cast_nullable_to_non_nullable
+          : type as KnowledgePanelTextElementType?,
+    );
+  }
+}
+
+extension $KnowledgePanelTextElementCopyWith on KnowledgePanelTextElement {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelTextElement.copyWith(...)` or like so:`instanceOfKnowledgePanelTextElement.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelTextElementCWProxy get copyWith =>
+      _$KnowledgePanelTextElementCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelImageElementCWProxy {
+  KnowledgePanelImageElement altText(String? altText);
+
+  KnowledgePanelImageElement height(int? height);
+
+  KnowledgePanelImageElement url(String url);
+
+  KnowledgePanelImageElement width(int? width);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelImageElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelImageElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelImageElement call({
+    String? altText,
+    int? height,
+    String? url,
+    int? width,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelImageElement.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelImageElement.copyWith.fieldName(...)`
+class _$KnowledgePanelImageElementCWProxyImpl
+    implements _$KnowledgePanelImageElementCWProxy {
+  final KnowledgePanelImageElement _value;
+
+  const _$KnowledgePanelImageElementCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelImageElement altText(String? altText) => this(altText: altText);
+
+  @override
+  KnowledgePanelImageElement height(int? height) => this(height: height);
+
+  @override
+  KnowledgePanelImageElement url(String url) => this(url: url);
+
+  @override
+  KnowledgePanelImageElement width(int? width) => this(width: width);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelImageElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelImageElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelImageElement call({
+    Object? altText = const $CopyWithPlaceholder(),
+    Object? height = const $CopyWithPlaceholder(),
+    Object? url = const $CopyWithPlaceholder(),
+    Object? width = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelImageElement(
+      altText: altText == const $CopyWithPlaceholder()
+          ? _value.altText
+          // ignore: cast_nullable_to_non_nullable
+          : altText as String?,
+      height: height == const $CopyWithPlaceholder()
+          ? _value.height
+          // ignore: cast_nullable_to_non_nullable
+          : height as int?,
+      url: url == const $CopyWithPlaceholder() || url == null
+          ? _value.url
+          // ignore: cast_nullable_to_non_nullable
+          : url as String,
+      width: width == const $CopyWithPlaceholder()
+          ? _value.width
+          // ignore: cast_nullable_to_non_nullable
+          : width as int?,
+    );
+  }
+}
+
+extension $KnowledgePanelImageElementCopyWith on KnowledgePanelImageElement {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelImageElement.copyWith(...)` or like so:`instanceOfKnowledgePanelImageElement.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelImageElementCWProxy get copyWith =>
+      _$KnowledgePanelImageElementCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelPanelGroupElementCWProxy {
+  KnowledgePanelPanelGroupElement panelIds(List<String> panelIds);
+
+  KnowledgePanelPanelGroupElement title(String? title);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelPanelGroupElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelPanelGroupElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelPanelGroupElement call({
+    List<String>? panelIds,
+    String? title,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelPanelGroupElement.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelPanelGroupElement.copyWith.fieldName(...)`
+class _$KnowledgePanelPanelGroupElementCWProxyImpl
+    implements _$KnowledgePanelPanelGroupElementCWProxy {
+  final KnowledgePanelPanelGroupElement _value;
+
+  const _$KnowledgePanelPanelGroupElementCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelPanelGroupElement panelIds(List<String> panelIds) =>
+      this(panelIds: panelIds);
+
+  @override
+  KnowledgePanelPanelGroupElement title(String? title) => this(title: title);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelPanelGroupElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelPanelGroupElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelPanelGroupElement call({
+    Object? panelIds = const $CopyWithPlaceholder(),
+    Object? title = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelPanelGroupElement(
+      panelIds: panelIds == const $CopyWithPlaceholder() || panelIds == null
+          ? _value.panelIds
+          // ignore: cast_nullable_to_non_nullable
+          : panelIds as List<String>,
+      title: title == const $CopyWithPlaceholder()
+          ? _value.title
+          // ignore: cast_nullable_to_non_nullable
+          : title as String?,
+    );
+  }
+}
+
+extension $KnowledgePanelPanelGroupElementCopyWith
+    on KnowledgePanelPanelGroupElement {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelPanelGroupElement.copyWith(...)` or like so:`instanceOfKnowledgePanelPanelGroupElement.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelPanelGroupElementCWProxy get copyWith =>
+      _$KnowledgePanelPanelGroupElementCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelPanelIdElementCWProxy {
+  KnowledgePanelPanelIdElement panelId(String panelId);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelPanelIdElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelPanelIdElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelPanelIdElement call({
+    String? panelId,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelPanelIdElement.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelPanelIdElement.copyWith.fieldName(...)`
+class _$KnowledgePanelPanelIdElementCWProxyImpl
+    implements _$KnowledgePanelPanelIdElementCWProxy {
+  final KnowledgePanelPanelIdElement _value;
+
+  const _$KnowledgePanelPanelIdElementCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelPanelIdElement panelId(String panelId) =>
+      this(panelId: panelId);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelPanelIdElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelPanelIdElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelPanelIdElement call({
+    Object? panelId = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelPanelIdElement(
+      panelId: panelId == const $CopyWithPlaceholder() || panelId == null
+          ? _value.panelId
+          // ignore: cast_nullable_to_non_nullable
+          : panelId as String,
+    );
+  }
+}
+
+extension $KnowledgePanelPanelIdElementCopyWith
+    on KnowledgePanelPanelIdElement {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelPanelIdElement.copyWith(...)` or like so:`instanceOfKnowledgePanelPanelIdElement.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelPanelIdElementCWProxy get copyWith =>
+      _$KnowledgePanelPanelIdElementCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelTableCellCWProxy {
+  KnowledgePanelTableCell evaluation(Evaluation? evaluation);
+
+  KnowledgePanelTableCell iconUrl(String? iconUrl);
+
+  KnowledgePanelTableCell percent(double? percent);
+
+  KnowledgePanelTableCell text(String text);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelTableCell(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelTableCell(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelTableCell call({
+    Evaluation? evaluation,
+    String? iconUrl,
+    double? percent,
+    String? text,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelTableCell.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelTableCell.copyWith.fieldName(...)`
+class _$KnowledgePanelTableCellCWProxyImpl
+    implements _$KnowledgePanelTableCellCWProxy {
+  final KnowledgePanelTableCell _value;
+
+  const _$KnowledgePanelTableCellCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelTableCell evaluation(Evaluation? evaluation) =>
+      this(evaluation: evaluation);
+
+  @override
+  KnowledgePanelTableCell iconUrl(String? iconUrl) => this(iconUrl: iconUrl);
+
+  @override
+  KnowledgePanelTableCell percent(double? percent) => this(percent: percent);
+
+  @override
+  KnowledgePanelTableCell text(String text) => this(text: text);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelTableCell(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelTableCell(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelTableCell call({
+    Object? evaluation = const $CopyWithPlaceholder(),
+    Object? iconUrl = const $CopyWithPlaceholder(),
+    Object? percent = const $CopyWithPlaceholder(),
+    Object? text = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelTableCell(
+      evaluation: evaluation == const $CopyWithPlaceholder()
+          ? _value.evaluation
+          // ignore: cast_nullable_to_non_nullable
+          : evaluation as Evaluation?,
+      iconUrl: iconUrl == const $CopyWithPlaceholder()
+          ? _value.iconUrl
+          // ignore: cast_nullable_to_non_nullable
+          : iconUrl as String?,
+      percent: percent == const $CopyWithPlaceholder()
+          ? _value.percent
+          // ignore: cast_nullable_to_non_nullable
+          : percent as double?,
+      text: text == const $CopyWithPlaceholder() || text == null
+          ? _value.text
+          // ignore: cast_nullable_to_non_nullable
+          : text as String,
+    );
+  }
+}
+
+extension $KnowledgePanelTableCellCopyWith on KnowledgePanelTableCell {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelTableCell.copyWith(...)` or like so:`instanceOfKnowledgePanelTableCell.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelTableCellCWProxy get copyWith =>
+      _$KnowledgePanelTableCellCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelTableRowElementCWProxy {
+  KnowledgePanelTableRowElement values(List<KnowledgePanelTableCell> values);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelTableRowElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelTableRowElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelTableRowElement call({
+    List<KnowledgePanelTableCell>? values,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelTableRowElement.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelTableRowElement.copyWith.fieldName(...)`
+class _$KnowledgePanelTableRowElementCWProxyImpl
+    implements _$KnowledgePanelTableRowElementCWProxy {
+  final KnowledgePanelTableRowElement _value;
+
+  const _$KnowledgePanelTableRowElementCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelTableRowElement values(List<KnowledgePanelTableCell> values) =>
+      this(values: values);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelTableRowElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelTableRowElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelTableRowElement call({
+    Object? values = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelTableRowElement(
+      values: values == const $CopyWithPlaceholder() || values == null
+          ? _value.values
+          // ignore: cast_nullable_to_non_nullable
+          : values as List<KnowledgePanelTableCell>,
+    );
+  }
+}
+
+extension $KnowledgePanelTableRowElementCopyWith
+    on KnowledgePanelTableRowElement {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelTableRowElement.copyWith(...)` or like so:`instanceOfKnowledgePanelTableRowElement.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelTableRowElementCWProxy get copyWith =>
+      _$KnowledgePanelTableRowElementCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelTableColumnCWProxy {
+  KnowledgePanelTableColumn columnGroupId(String? columnGroupId);
+
+  KnowledgePanelTableColumn showByDefault(bool? showByDefault);
+
+  KnowledgePanelTableColumn style(String? style);
+
+  KnowledgePanelTableColumn text(String text);
+
+  KnowledgePanelTableColumn textForSmallScreens(String? textForSmallScreens);
+
+  KnowledgePanelTableColumn type(KnowledgePanelColumnType? type);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelTableColumn(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelTableColumn(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelTableColumn call({
+    String? columnGroupId,
+    bool? showByDefault,
+    String? style,
+    String? text,
+    String? textForSmallScreens,
+    KnowledgePanelColumnType? type,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelTableColumn.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelTableColumn.copyWith.fieldName(...)`
+class _$KnowledgePanelTableColumnCWProxyImpl
+    implements _$KnowledgePanelTableColumnCWProxy {
+  final KnowledgePanelTableColumn _value;
+
+  const _$KnowledgePanelTableColumnCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelTableColumn columnGroupId(String? columnGroupId) =>
+      this(columnGroupId: columnGroupId);
+
+  @override
+  KnowledgePanelTableColumn showByDefault(bool? showByDefault) =>
+      this(showByDefault: showByDefault);
+
+  @override
+  KnowledgePanelTableColumn style(String? style) => this(style: style);
+
+  @override
+  KnowledgePanelTableColumn text(String text) => this(text: text);
+
+  @override
+  KnowledgePanelTableColumn textForSmallScreens(String? textForSmallScreens) =>
+      this(textForSmallScreens: textForSmallScreens);
+
+  @override
+  KnowledgePanelTableColumn type(KnowledgePanelColumnType? type) =>
+      this(type: type);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelTableColumn(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelTableColumn(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelTableColumn call({
+    Object? columnGroupId = const $CopyWithPlaceholder(),
+    Object? showByDefault = const $CopyWithPlaceholder(),
+    Object? style = const $CopyWithPlaceholder(),
+    Object? text = const $CopyWithPlaceholder(),
+    Object? textForSmallScreens = const $CopyWithPlaceholder(),
+    Object? type = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelTableColumn(
+      columnGroupId: columnGroupId == const $CopyWithPlaceholder()
+          ? _value.columnGroupId
+          // ignore: cast_nullable_to_non_nullable
+          : columnGroupId as String?,
+      showByDefault: showByDefault == const $CopyWithPlaceholder()
+          ? _value.showByDefault
+          // ignore: cast_nullable_to_non_nullable
+          : showByDefault as bool?,
+      style: style == const $CopyWithPlaceholder()
+          ? _value.style
+          // ignore: cast_nullable_to_non_nullable
+          : style as String?,
+      text: text == const $CopyWithPlaceholder() || text == null
+          ? _value.text
+          // ignore: cast_nullable_to_non_nullable
+          : text as String,
+      textForSmallScreens: textForSmallScreens == const $CopyWithPlaceholder()
+          ? _value.textForSmallScreens
+          // ignore: cast_nullable_to_non_nullable
+          : textForSmallScreens as String?,
+      type: type == const $CopyWithPlaceholder()
+          ? _value.type
+          // ignore: cast_nullable_to_non_nullable
+          : type as KnowledgePanelColumnType?,
+    );
+  }
+}
+
+extension $KnowledgePanelTableColumnCopyWith on KnowledgePanelTableColumn {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelTableColumn.copyWith(...)` or like so:`instanceOfKnowledgePanelTableColumn.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelTableColumnCWProxy get copyWith =>
+      _$KnowledgePanelTableColumnCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelWorldMapElementCWProxy {
+  KnowledgePanelWorldMapElement pointers(
+      List<KnowledgePanelGeoPointer> pointers);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelWorldMapElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelWorldMapElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelWorldMapElement call({
+    List<KnowledgePanelGeoPointer>? pointers,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelWorldMapElement.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelWorldMapElement.copyWith.fieldName(...)`
+class _$KnowledgePanelWorldMapElementCWProxyImpl
+    implements _$KnowledgePanelWorldMapElementCWProxy {
+  final KnowledgePanelWorldMapElement _value;
+
+  const _$KnowledgePanelWorldMapElementCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelWorldMapElement pointers(
+          List<KnowledgePanelGeoPointer> pointers) =>
+      this(pointers: pointers);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelWorldMapElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelWorldMapElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelWorldMapElement call({
+    Object? pointers = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelWorldMapElement(
+      pointers: pointers == const $CopyWithPlaceholder() || pointers == null
+          ? _value.pointers
+          // ignore: cast_nullable_to_non_nullable
+          : pointers as List<KnowledgePanelGeoPointer>,
+    );
+  }
+}
+
+extension $KnowledgePanelWorldMapElementCopyWith
+    on KnowledgePanelWorldMapElement {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelWorldMapElement.copyWith(...)` or like so:`instanceOfKnowledgePanelWorldMapElement.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelWorldMapElementCWProxy get copyWith =>
+      _$KnowledgePanelWorldMapElementCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelGeoPointerCWProxy {
+  KnowledgePanelGeoPointer geo(KnowledgePanelLatLng? geo);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelGeoPointer(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelGeoPointer(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelGeoPointer call({
+    KnowledgePanelLatLng? geo,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelGeoPointer.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelGeoPointer.copyWith.fieldName(...)`
+class _$KnowledgePanelGeoPointerCWProxyImpl
+    implements _$KnowledgePanelGeoPointerCWProxy {
+  final KnowledgePanelGeoPointer _value;
+
+  const _$KnowledgePanelGeoPointerCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelGeoPointer geo(KnowledgePanelLatLng? geo) => this(geo: geo);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelGeoPointer(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelGeoPointer(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelGeoPointer call({
+    Object? geo = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelGeoPointer(
+      geo: geo == const $CopyWithPlaceholder()
+          ? _value.geo
+          // ignore: cast_nullable_to_non_nullable
+          : geo as KnowledgePanelLatLng?,
+    );
+  }
+}
+
+extension $KnowledgePanelGeoPointerCopyWith on KnowledgePanelGeoPointer {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelGeoPointer.copyWith(...)` or like so:`instanceOfKnowledgePanelGeoPointer.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelGeoPointerCWProxy get copyWith =>
+      _$KnowledgePanelGeoPointerCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelLatLngCWProxy {
+  KnowledgePanelLatLng lat(double lat);
+
+  KnowledgePanelLatLng lng(double lng);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelLatLng(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelLatLng(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelLatLng call({
+    double? lat,
+    double? lng,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelLatLng.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelLatLng.copyWith.fieldName(...)`
+class _$KnowledgePanelLatLngCWProxyImpl
+    implements _$KnowledgePanelLatLngCWProxy {
+  final KnowledgePanelLatLng _value;
+
+  const _$KnowledgePanelLatLngCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelLatLng lat(double lat) => this(lat: lat);
+
+  @override
+  KnowledgePanelLatLng lng(double lng) => this(lng: lng);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelLatLng(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelLatLng(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelLatLng call({
+    Object? lat = const $CopyWithPlaceholder(),
+    Object? lng = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelLatLng(
+      lat: lat == const $CopyWithPlaceholder() || lat == null
+          ? _value.lat
+          // ignore: cast_nullable_to_non_nullable
+          : lat as double,
+      lng: lng == const $CopyWithPlaceholder() || lng == null
+          ? _value.lng
+          // ignore: cast_nullable_to_non_nullable
+          : lng as double,
+    );
+  }
+}
+
+extension $KnowledgePanelLatLngCopyWith on KnowledgePanelLatLng {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelLatLng.copyWith(...)` or like so:`instanceOfKnowledgePanelLatLng.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelLatLngCWProxy get copyWith =>
+      _$KnowledgePanelLatLngCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelTableElementCWProxy {
+  KnowledgePanelTableElement columns(List<KnowledgePanelTableColumn> columns);
+
+  KnowledgePanelTableElement id(String id);
+
+  KnowledgePanelTableElement rows(List<KnowledgePanelTableRowElement> rows);
+
+  KnowledgePanelTableElement title(String? title);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelTableElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelTableElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelTableElement call({
+    List<KnowledgePanelTableColumn>? columns,
+    String? id,
+    List<KnowledgePanelTableRowElement>? rows,
+    String? title,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelTableElement.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelTableElement.copyWith.fieldName(...)`
+class _$KnowledgePanelTableElementCWProxyImpl
+    implements _$KnowledgePanelTableElementCWProxy {
+  final KnowledgePanelTableElement _value;
+
+  const _$KnowledgePanelTableElementCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelTableElement columns(List<KnowledgePanelTableColumn> columns) =>
+      this(columns: columns);
+
+  @override
+  KnowledgePanelTableElement id(String id) => this(id: id);
+
+  @override
+  KnowledgePanelTableElement rows(List<KnowledgePanelTableRowElement> rows) =>
+      this(rows: rows);
+
+  @override
+  KnowledgePanelTableElement title(String? title) => this(title: title);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelTableElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelTableElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelTableElement call({
+    Object? columns = const $CopyWithPlaceholder(),
+    Object? id = const $CopyWithPlaceholder(),
+    Object? rows = const $CopyWithPlaceholder(),
+    Object? title = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelTableElement(
+      columns: columns == const $CopyWithPlaceholder() || columns == null
+          ? _value.columns
+          // ignore: cast_nullable_to_non_nullable
+          : columns as List<KnowledgePanelTableColumn>,
+      id: id == const $CopyWithPlaceholder() || id == null
+          ? _value.id
+          // ignore: cast_nullable_to_non_nullable
+          : id as String,
+      rows: rows == const $CopyWithPlaceholder() || rows == null
+          ? _value.rows
+          // ignore: cast_nullable_to_non_nullable
+          : rows as List<KnowledgePanelTableRowElement>,
+      title: title == const $CopyWithPlaceholder()
+          ? _value.title
+          // ignore: cast_nullable_to_non_nullable
+          : title as String?,
+    );
+  }
+}
+
+extension $KnowledgePanelTableElementCopyWith on KnowledgePanelTableElement {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelTableElement.copyWith(...)` or like so:`instanceOfKnowledgePanelTableElement.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelTableElementCWProxy get copyWith =>
+      _$KnowledgePanelTableElementCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelActionElementCWProxy {
+  KnowledgePanelActionElement actions(List<String> actions);
+
+  KnowledgePanelActionElement html(String html);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelActionElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelActionElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelActionElement call({
+    List<String>? actions,
+    String? html,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelActionElement.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelActionElement.copyWith.fieldName(...)`
+class _$KnowledgePanelActionElementCWProxyImpl
+    implements _$KnowledgePanelActionElementCWProxy {
+  final KnowledgePanelActionElement _value;
+
+  const _$KnowledgePanelActionElementCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelActionElement actions(List<String> actions) =>
+      this(actions: actions);
+
+  @override
+  KnowledgePanelActionElement html(String html) => this(html: html);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelActionElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelActionElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelActionElement call({
+    Object? actions = const $CopyWithPlaceholder(),
+    Object? html = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelActionElement(
+      actions: actions == const $CopyWithPlaceholder() || actions == null
+          ? _value.actions
+          // ignore: cast_nullable_to_non_nullable
+          : actions as List<String>,
+      html: html == const $CopyWithPlaceholder() || html == null
+          ? _value.html
+          // ignore: cast_nullable_to_non_nullable
+          : html as String,
+    );
+  }
+}
+
+extension $KnowledgePanelActionElementCopyWith on KnowledgePanelActionElement {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelActionElement.copyWith(...)` or like so:`instanceOfKnowledgePanelActionElement.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelActionElementCWProxy get copyWith =>
+      _$KnowledgePanelActionElementCWProxyImpl(this);
+}
+
+abstract class _$KnowledgePanelElementCWProxy {
+  KnowledgePanelElement actionElement(
+      KnowledgePanelActionElement? actionElement);
+
+  KnowledgePanelElement elementType(KnowledgePanelElementType elementType);
+
+  KnowledgePanelElement imageElement(KnowledgePanelImageElement? imageElement);
+
+  KnowledgePanelElement mapElement(KnowledgePanelWorldMapElement? mapElement);
+
+  KnowledgePanelElement panelElement(
+      KnowledgePanelPanelIdElement? panelElement);
+
+  KnowledgePanelElement panelGroupElement(
+      KnowledgePanelPanelGroupElement? panelGroupElement);
+
+  KnowledgePanelElement tableElement(KnowledgePanelTableElement? tableElement);
+
+  KnowledgePanelElement textElement(KnowledgePanelTextElement? textElement);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelElement call({
+    KnowledgePanelActionElement? actionElement,
+    KnowledgePanelElementType? elementType,
+    KnowledgePanelImageElement? imageElement,
+    KnowledgePanelWorldMapElement? mapElement,
+    KnowledgePanelPanelIdElement? panelElement,
+    KnowledgePanelPanelGroupElement? panelGroupElement,
+    KnowledgePanelTableElement? tableElement,
+    KnowledgePanelTextElement? textElement,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfKnowledgePanelElement.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfKnowledgePanelElement.copyWith.fieldName(...)`
+class _$KnowledgePanelElementCWProxyImpl
+    implements _$KnowledgePanelElementCWProxy {
+  final KnowledgePanelElement _value;
+
+  const _$KnowledgePanelElementCWProxyImpl(this._value);
+
+  @override
+  KnowledgePanelElement actionElement(
+          KnowledgePanelActionElement? actionElement) =>
+      this(actionElement: actionElement);
+
+  @override
+  KnowledgePanelElement elementType(KnowledgePanelElementType elementType) =>
+      this(elementType: elementType);
+
+  @override
+  KnowledgePanelElement imageElement(
+          KnowledgePanelImageElement? imageElement) =>
+      this(imageElement: imageElement);
+
+  @override
+  KnowledgePanelElement mapElement(KnowledgePanelWorldMapElement? mapElement) =>
+      this(mapElement: mapElement);
+
+  @override
+  KnowledgePanelElement panelElement(
+          KnowledgePanelPanelIdElement? panelElement) =>
+      this(panelElement: panelElement);
+
+  @override
+  KnowledgePanelElement panelGroupElement(
+          KnowledgePanelPanelGroupElement? panelGroupElement) =>
+      this(panelGroupElement: panelGroupElement);
+
+  @override
+  KnowledgePanelElement tableElement(
+          KnowledgePanelTableElement? tableElement) =>
+      this(tableElement: tableElement);
+
+  @override
+  KnowledgePanelElement textElement(KnowledgePanelTextElement? textElement) =>
+      this(textElement: textElement);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `KnowledgePanelElement(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// KnowledgePanelElement(...).copyWith(id: 12, name: "My name")
+  /// ````
+  KnowledgePanelElement call({
+    Object? actionElement = const $CopyWithPlaceholder(),
+    Object? elementType = const $CopyWithPlaceholder(),
+    Object? imageElement = const $CopyWithPlaceholder(),
+    Object? mapElement = const $CopyWithPlaceholder(),
+    Object? panelElement = const $CopyWithPlaceholder(),
+    Object? panelGroupElement = const $CopyWithPlaceholder(),
+    Object? tableElement = const $CopyWithPlaceholder(),
+    Object? textElement = const $CopyWithPlaceholder(),
+  }) {
+    return KnowledgePanelElement(
+      actionElement: actionElement == const $CopyWithPlaceholder()
+          ? _value.actionElement
+          // ignore: cast_nullable_to_non_nullable
+          : actionElement as KnowledgePanelActionElement?,
+      elementType:
+          elementType == const $CopyWithPlaceholder() || elementType == null
+              ? _value.elementType
+              // ignore: cast_nullable_to_non_nullable
+              : elementType as KnowledgePanelElementType,
+      imageElement: imageElement == const $CopyWithPlaceholder()
+          ? _value.imageElement
+          // ignore: cast_nullable_to_non_nullable
+          : imageElement as KnowledgePanelImageElement?,
+      mapElement: mapElement == const $CopyWithPlaceholder()
+          ? _value.mapElement
+          // ignore: cast_nullable_to_non_nullable
+          : mapElement as KnowledgePanelWorldMapElement?,
+      panelElement: panelElement == const $CopyWithPlaceholder()
+          ? _value.panelElement
+          // ignore: cast_nullable_to_non_nullable
+          : panelElement as KnowledgePanelPanelIdElement?,
+      panelGroupElement: panelGroupElement == const $CopyWithPlaceholder()
+          ? _value.panelGroupElement
+          // ignore: cast_nullable_to_non_nullable
+          : panelGroupElement as KnowledgePanelPanelGroupElement?,
+      tableElement: tableElement == const $CopyWithPlaceholder()
+          ? _value.tableElement
+          // ignore: cast_nullable_to_non_nullable
+          : tableElement as KnowledgePanelTableElement?,
+      textElement: textElement == const $CopyWithPlaceholder()
+          ? _value.textElement
+          // ignore: cast_nullable_to_non_nullable
+          : textElement as KnowledgePanelTextElement?,
+    );
+  }
+}
+
+extension $KnowledgePanelElementCopyWith on KnowledgePanelElement {
+  /// Returns a callable class that can be used as follows: `instanceOfKnowledgePanelElement.copyWith(...)` or like so:`instanceOfKnowledgePanelElement.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$KnowledgePanelElementCWProxy get copyWith =>
+      _$KnowledgePanelElementCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/LeaderboardEntry.dart
+++ b/lib/model/LeaderboardEntry.dart
@@ -1,9 +1,12 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'LeaderboardEntry.g.dart';
 
 /// Events API: leaderboard entry.
+@CopyWith()
 @JsonSerializable()
 class LeaderboardEntry extends JsonObject {
   @JsonKey(name: 'user_id')

--- a/lib/model/LeaderboardEntry.g.dart
+++ b/lib/model/LeaderboardEntry.g.dart
@@ -3,6 +3,70 @@
 part of 'LeaderboardEntry.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$LeaderboardEntryCWProxy {
+  LeaderboardEntry score(int score);
+
+  LeaderboardEntry userId(String? userId);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `LeaderboardEntry(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// LeaderboardEntry(...).copyWith(id: 12, name: "My name")
+  /// ````
+  LeaderboardEntry call({
+    int? score,
+    String? userId,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfLeaderboardEntry.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfLeaderboardEntry.copyWith.fieldName(...)`
+class _$LeaderboardEntryCWProxyImpl implements _$LeaderboardEntryCWProxy {
+  final LeaderboardEntry _value;
+
+  const _$LeaderboardEntryCWProxyImpl(this._value);
+
+  @override
+  LeaderboardEntry score(int score) => this(score: score);
+
+  @override
+  LeaderboardEntry userId(String? userId) => this(userId: userId);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `LeaderboardEntry(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// LeaderboardEntry(...).copyWith(id: 12, name: "My name")
+  /// ````
+  LeaderboardEntry call({
+    Object? score = const $CopyWithPlaceholder(),
+    Object? userId = const $CopyWithPlaceholder(),
+  }) {
+    return LeaderboardEntry(
+      score: score == const $CopyWithPlaceholder() || score == null
+          ? _value.score
+          // ignore: cast_nullable_to_non_nullable
+          : score as int,
+      userId: userId == const $CopyWithPlaceholder()
+          ? _value.userId
+          // ignore: cast_nullable_to_non_nullable
+          : userId as String?,
+    );
+  }
+}
+
+extension $LeaderboardEntryCopyWith on LeaderboardEntry {
+  /// Returns a callable class that can be used as follows: `instanceOfLeaderboardEntry.copyWith(...)` or like so:`instanceOfLeaderboardEntry.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$LeaderboardEntryCWProxy get copyWith => _$LeaderboardEntryCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/OcrIngredientsResult.dart
+++ b/lib/model/OcrIngredientsResult.dart
@@ -1,9 +1,12 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'OcrIngredientsResult.g.dart';
 
 /// Result from OCR applied to ingredients.
+@CopyWith()
 @JsonSerializable()
 class OcrIngredientsResult extends JsonObject {
   const OcrIngredientsResult({

--- a/lib/model/OcrIngredientsResult.g.dart
+++ b/lib/model/OcrIngredientsResult.g.dart
@@ -3,6 +3,91 @@
 part of 'OcrIngredientsResult.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$OcrIngredientsResultCWProxy {
+  OcrIngredientsResult ingredientsTextFromImage(
+      String? ingredientsTextFromImage);
+
+  OcrIngredientsResult ingredientsTextFromImageOrig(
+      String? ingredientsTextFromImageOrig);
+
+  OcrIngredientsResult status(int? status);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `OcrIngredientsResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// OcrIngredientsResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  OcrIngredientsResult call({
+    String? ingredientsTextFromImage,
+    String? ingredientsTextFromImageOrig,
+    int? status,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfOcrIngredientsResult.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfOcrIngredientsResult.copyWith.fieldName(...)`
+class _$OcrIngredientsResultCWProxyImpl
+    implements _$OcrIngredientsResultCWProxy {
+  final OcrIngredientsResult _value;
+
+  const _$OcrIngredientsResultCWProxyImpl(this._value);
+
+  @override
+  OcrIngredientsResult ingredientsTextFromImage(
+          String? ingredientsTextFromImage) =>
+      this(ingredientsTextFromImage: ingredientsTextFromImage);
+
+  @override
+  OcrIngredientsResult ingredientsTextFromImageOrig(
+          String? ingredientsTextFromImageOrig) =>
+      this(ingredientsTextFromImageOrig: ingredientsTextFromImageOrig);
+
+  @override
+  OcrIngredientsResult status(int? status) => this(status: status);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `OcrIngredientsResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// OcrIngredientsResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  OcrIngredientsResult call({
+    Object? ingredientsTextFromImage = const $CopyWithPlaceholder(),
+    Object? ingredientsTextFromImageOrig = const $CopyWithPlaceholder(),
+    Object? status = const $CopyWithPlaceholder(),
+  }) {
+    return OcrIngredientsResult(
+      ingredientsTextFromImage:
+          ingredientsTextFromImage == const $CopyWithPlaceholder()
+              ? _value.ingredientsTextFromImage
+              // ignore: cast_nullable_to_non_nullable
+              : ingredientsTextFromImage as String?,
+      ingredientsTextFromImageOrig:
+          ingredientsTextFromImageOrig == const $CopyWithPlaceholder()
+              ? _value.ingredientsTextFromImageOrig
+              // ignore: cast_nullable_to_non_nullable
+              : ingredientsTextFromImageOrig as String?,
+      status: status == const $CopyWithPlaceholder()
+          ? _value.status
+          // ignore: cast_nullable_to_non_nullable
+          : status as int?,
+    );
+  }
+}
+
+extension $OcrIngredientsResultCopyWith on OcrIngredientsResult {
+  /// Returns a callable class that can be used as follows: `instanceOfOcrIngredientsResult.copyWith(...)` or like so:`instanceOfOcrIngredientsResult.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$OcrIngredientsResultCWProxy get copyWith =>
+      _$OcrIngredientsResultCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/OcrPackagingResult.dart
+++ b/lib/model/OcrPackagingResult.dart
@@ -1,9 +1,12 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'OcrPackagingResult.g.dart';
 
 /// Result from OCR applied to packaging.
+@CopyWith()
 @JsonSerializable()
 class OcrPackagingResult extends JsonObject {
   const OcrPackagingResult({

--- a/lib/model/OcrPackagingResult.g.dart
+++ b/lib/model/OcrPackagingResult.g.dart
@@ -3,6 +3,84 @@
 part of 'OcrPackagingResult.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$OcrPackagingResultCWProxy {
+  OcrPackagingResult status(int? status);
+
+  OcrPackagingResult textFromImage(String? textFromImage);
+
+  OcrPackagingResult textFromImageOrig(String? textFromImageOrig);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `OcrPackagingResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// OcrPackagingResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  OcrPackagingResult call({
+    int? status,
+    String? textFromImage,
+    String? textFromImageOrig,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfOcrPackagingResult.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfOcrPackagingResult.copyWith.fieldName(...)`
+class _$OcrPackagingResultCWProxyImpl implements _$OcrPackagingResultCWProxy {
+  final OcrPackagingResult _value;
+
+  const _$OcrPackagingResultCWProxyImpl(this._value);
+
+  @override
+  OcrPackagingResult status(int? status) => this(status: status);
+
+  @override
+  OcrPackagingResult textFromImage(String? textFromImage) =>
+      this(textFromImage: textFromImage);
+
+  @override
+  OcrPackagingResult textFromImageOrig(String? textFromImageOrig) =>
+      this(textFromImageOrig: textFromImageOrig);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `OcrPackagingResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// OcrPackagingResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  OcrPackagingResult call({
+    Object? status = const $CopyWithPlaceholder(),
+    Object? textFromImage = const $CopyWithPlaceholder(),
+    Object? textFromImageOrig = const $CopyWithPlaceholder(),
+  }) {
+    return OcrPackagingResult(
+      status: status == const $CopyWithPlaceholder()
+          ? _value.status
+          // ignore: cast_nullable_to_non_nullable
+          : status as int?,
+      textFromImage: textFromImage == const $CopyWithPlaceholder()
+          ? _value.textFromImage
+          // ignore: cast_nullable_to_non_nullable
+          : textFromImage as String?,
+      textFromImageOrig: textFromImageOrig == const $CopyWithPlaceholder()
+          ? _value.textFromImageOrig
+          // ignore: cast_nullable_to_non_nullable
+          : textFromImageOrig as String?,
+    );
+  }
+}
+
+extension $OcrPackagingResultCopyWith on OcrPackagingResult {
+  /// Returns a callable class that can be used as follows: `instanceOfOcrPackagingResult.copyWith(...)` or like so:`instanceOfOcrPackagingResult.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$OcrPackagingResultCWProxy get copyWith =>
+      _$OcrPackagingResultCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/OrderedNutrient.dart
+++ b/lib/model/OrderedNutrient.dart
@@ -1,5 +1,7 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/model/Nutrient.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'OrderedNutrient.g.dart';
@@ -9,6 +11,7 @@ part 'OrderedNutrient.g.dart';
 /// cf. https://github.com/openfoodfacts/openfoodfacts-dart/issues/210
 /// Example in https://fr.openfoodfacts.org/cgi/nutrients.pl
 /// To be compared to [OrderedNutrients], which is the root of the structure.
+@CopyWith()
 @JsonSerializable(includeIfNull: false)
 class OrderedNutrient extends JsonObject {
   /// Nutrient ID (e.g. 'energy-kcal')

--- a/lib/model/OrderedNutrient.g.dart
+++ b/lib/model/OrderedNutrient.g.dart
@@ -3,6 +3,106 @@
 part of 'OrderedNutrient.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$OrderedNutrientCWProxy {
+  OrderedNutrient displayInEditForm(bool displayInEditForm);
+
+  OrderedNutrient id(String id);
+
+  OrderedNutrient important(bool important);
+
+  OrderedNutrient name(String? name);
+
+  OrderedNutrient subNutrients(List<OrderedNutrient>? subNutrients);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `OrderedNutrient(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// OrderedNutrient(...).copyWith(id: 12, name: "My name")
+  /// ````
+  OrderedNutrient call({
+    bool? displayInEditForm,
+    String? id,
+    bool? important,
+    String? name,
+    List<OrderedNutrient>? subNutrients,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfOrderedNutrient.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfOrderedNutrient.copyWith.fieldName(...)`
+class _$OrderedNutrientCWProxyImpl implements _$OrderedNutrientCWProxy {
+  final OrderedNutrient _value;
+
+  const _$OrderedNutrientCWProxyImpl(this._value);
+
+  @override
+  OrderedNutrient displayInEditForm(bool displayInEditForm) =>
+      this(displayInEditForm: displayInEditForm);
+
+  @override
+  OrderedNutrient id(String id) => this(id: id);
+
+  @override
+  OrderedNutrient important(bool important) => this(important: important);
+
+  @override
+  OrderedNutrient name(String? name) => this(name: name);
+
+  @override
+  OrderedNutrient subNutrients(List<OrderedNutrient>? subNutrients) =>
+      this(subNutrients: subNutrients);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `OrderedNutrient(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// OrderedNutrient(...).copyWith(id: 12, name: "My name")
+  /// ````
+  OrderedNutrient call({
+    Object? displayInEditForm = const $CopyWithPlaceholder(),
+    Object? id = const $CopyWithPlaceholder(),
+    Object? important = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? subNutrients = const $CopyWithPlaceholder(),
+  }) {
+    return OrderedNutrient(
+      displayInEditForm: displayInEditForm == const $CopyWithPlaceholder() ||
+              displayInEditForm == null
+          ? _value.displayInEditForm
+          // ignore: cast_nullable_to_non_nullable
+          : displayInEditForm as bool,
+      id: id == const $CopyWithPlaceholder() || id == null
+          ? _value.id
+          // ignore: cast_nullable_to_non_nullable
+          : id as String,
+      important: important == const $CopyWithPlaceholder() || important == null
+          ? _value.important
+          // ignore: cast_nullable_to_non_nullable
+          : important as bool,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as String?,
+      subNutrients: subNutrients == const $CopyWithPlaceholder()
+          ? _value.subNutrients
+          // ignore: cast_nullable_to_non_nullable
+          : subNutrients as List<OrderedNutrient>?,
+    );
+  }
+}
+
+extension $OrderedNutrientCopyWith on OrderedNutrient {
+  /// Returns a callable class that can be used as follows: `instanceOfOrderedNutrient.copyWith(...)` or like so:`instanceOfOrderedNutrient.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$OrderedNutrientCWProxy get copyWith => _$OrderedNutrientCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/OrderedNutrients.dart
+++ b/lib/model/OrderedNutrients.dart
@@ -1,4 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 import 'OrderedNutrient.dart';
 
@@ -9,6 +11,7 @@ part 'OrderedNutrients.g.dart';
 /// cf. https://github.com/openfoodfacts/openfoodfacts-dart/issues/210
 /// Example in https://fr.openfoodfacts.org/cgi/nutrients.pl
 /// Compared to [OrderedNutrient], this is the root of the structure.
+@CopyWith()
 @JsonSerializable()
 class OrderedNutrients extends JsonObject {
   /// Most important nutrients (level 0 in the hierarchy)

--- a/lib/model/OrderedNutrients.g.dart
+++ b/lib/model/OrderedNutrients.g.dart
@@ -3,6 +3,60 @@
 part of 'OrderedNutrients.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$OrderedNutrientsCWProxy {
+  OrderedNutrients nutrients(List<OrderedNutrient> nutrients);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `OrderedNutrients(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// OrderedNutrients(...).copyWith(id: 12, name: "My name")
+  /// ````
+  OrderedNutrients call({
+    List<OrderedNutrient>? nutrients,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfOrderedNutrients.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfOrderedNutrients.copyWith.fieldName(...)`
+class _$OrderedNutrientsCWProxyImpl implements _$OrderedNutrientsCWProxy {
+  final OrderedNutrients _value;
+
+  const _$OrderedNutrientsCWProxyImpl(this._value);
+
+  @override
+  OrderedNutrients nutrients(List<OrderedNutrient> nutrients) =>
+      this(nutrients: nutrients);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `OrderedNutrients(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// OrderedNutrients(...).copyWith(id: 12, name: "My name")
+  /// ````
+  OrderedNutrients call({
+    Object? nutrients = const $CopyWithPlaceholder(),
+  }) {
+    return OrderedNutrients(
+      nutrients: nutrients == const $CopyWithPlaceholder() || nutrients == null
+          ? _value.nutrients
+          // ignore: cast_nullable_to_non_nullable
+          : nutrients as List<OrderedNutrient>,
+    );
+  }
+}
+
+extension $OrderedNutrientsCopyWith on OrderedNutrients {
+  /// Returns a callable class that can be used as follows: `instanceOfOrderedNutrients.copyWith(...)` or like so:`instanceOfOrderedNutrients.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$OrderedNutrientsCWProxy get copyWith => _$OrderedNutrientsCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/OriginsOfIngredients.dart
+++ b/lib/model/OriginsOfIngredients.dart
@@ -1,8 +1,11 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'OriginsOfIngredients.g.dart';
 
+@CopyWith()
 @JsonSerializable()
 class OriginsOfIngredients extends JsonObject {
   @JsonKey(

--- a/lib/model/OriginsOfIngredients.g.dart
+++ b/lib/model/OriginsOfIngredients.g.dart
@@ -3,6 +3,96 @@
 part of 'OriginsOfIngredients.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$OriginsOfIngredientsCWProxy {
+  OriginsOfIngredients epiScore(double? epiScore);
+
+  OriginsOfIngredients epiValue(double? epiValue);
+
+  OriginsOfIngredients transportationScore(double? transportationScore);
+
+  OriginsOfIngredients transportationValue(double? transportationValue);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `OriginsOfIngredients(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// OriginsOfIngredients(...).copyWith(id: 12, name: "My name")
+  /// ````
+  OriginsOfIngredients call({
+    double? epiScore,
+    double? epiValue,
+    double? transportationScore,
+    double? transportationValue,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfOriginsOfIngredients.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfOriginsOfIngredients.copyWith.fieldName(...)`
+class _$OriginsOfIngredientsCWProxyImpl
+    implements _$OriginsOfIngredientsCWProxy {
+  final OriginsOfIngredients _value;
+
+  const _$OriginsOfIngredientsCWProxyImpl(this._value);
+
+  @override
+  OriginsOfIngredients epiScore(double? epiScore) => this(epiScore: epiScore);
+
+  @override
+  OriginsOfIngredients epiValue(double? epiValue) => this(epiValue: epiValue);
+
+  @override
+  OriginsOfIngredients transportationScore(double? transportationScore) =>
+      this(transportationScore: transportationScore);
+
+  @override
+  OriginsOfIngredients transportationValue(double? transportationValue) =>
+      this(transportationValue: transportationValue);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `OriginsOfIngredients(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// OriginsOfIngredients(...).copyWith(id: 12, name: "My name")
+  /// ````
+  OriginsOfIngredients call({
+    Object? epiScore = const $CopyWithPlaceholder(),
+    Object? epiValue = const $CopyWithPlaceholder(),
+    Object? transportationScore = const $CopyWithPlaceholder(),
+    Object? transportationValue = const $CopyWithPlaceholder(),
+  }) {
+    return OriginsOfIngredients(
+      epiScore: epiScore == const $CopyWithPlaceholder()
+          ? _value.epiScore
+          // ignore: cast_nullable_to_non_nullable
+          : epiScore as double?,
+      epiValue: epiValue == const $CopyWithPlaceholder()
+          ? _value.epiValue
+          // ignore: cast_nullable_to_non_nullable
+          : epiValue as double?,
+      transportationScore: transportationScore == const $CopyWithPlaceholder()
+          ? _value.transportationScore
+          // ignore: cast_nullable_to_non_nullable
+          : transportationScore as double?,
+      transportationValue: transportationValue == const $CopyWithPlaceholder()
+          ? _value.transportationValue
+          // ignore: cast_nullable_to_non_nullable
+          : transportationValue as double?,
+    );
+  }
+}
+
+extension $OriginsOfIngredientsCopyWith on OriginsOfIngredients {
+  /// Returns a callable class that can be used as follows: `instanceOfOriginsOfIngredients.copyWith(...)` or like so:`instanceOfOriginsOfIngredients.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$OriginsOfIngredientsCWProxy get copyWith =>
+      _$OriginsOfIngredientsCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/Packaging.dart
+++ b/lib/model/Packaging.dart
@@ -1,8 +1,11 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'Packaging.g.dart';
 
+@CopyWith()
 @JsonSerializable()
 class Packaging extends JsonObject {
   @JsonKey(includeIfNull: false, fromJson: JsonObject.parseDouble)

--- a/lib/model/Packaging.g.dart
+++ b/lib/model/Packaging.g.dart
@@ -3,6 +3,70 @@
 part of 'Packaging.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$PackagingCWProxy {
+  Packaging score(double? score);
+
+  Packaging value(double? value);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Packaging(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Packaging(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Packaging call({
+    double? score,
+    double? value,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfPackaging.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfPackaging.copyWith.fieldName(...)`
+class _$PackagingCWProxyImpl implements _$PackagingCWProxy {
+  final Packaging _value;
+
+  const _$PackagingCWProxyImpl(this._value);
+
+  @override
+  Packaging score(double? score) => this(score: score);
+
+  @override
+  Packaging value(double? value) => this(value: value);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Packaging(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Packaging(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Packaging call({
+    Object? score = const $CopyWithPlaceholder(),
+    Object? value = const $CopyWithPlaceholder(),
+  }) {
+    return Packaging(
+      score: score == const $CopyWithPlaceholder()
+          ? _value.score
+          // ignore: cast_nullable_to_non_nullable
+          : score as double?,
+      value: value == const $CopyWithPlaceholder()
+          ? _value.value
+          // ignore: cast_nullable_to_non_nullable
+          : value as double?,
+    );
+  }
+}
+
+extension $PackagingCopyWith on Packaging {
+  /// Returns a callable class that can be used as follows: `instanceOfPackaging.copyWith(...)` or like so:`instanceOfPackaging.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$PackagingCWProxy get copyWith => _$PackagingCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/Product.dart
+++ b/lib/model/Product.dart
@@ -1,3 +1,4 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/AttributeGroup.dart';
@@ -87,6 +88,7 @@ enum ProductImprovementCategory {
 ///
 /// Please read the language mechanics explanation if you intend to display
 /// or update data in specific language: https://github.com/openfoodfacts/openfoodfacts-dart/blob/master/DOCUMENTATION.md#about-languages-mechanics
+@CopyWith()
 @JsonSerializable()
 class Product extends JsonObject {
   @JsonKey(name: 'code')

--- a/lib/model/Product.g.dart
+++ b/lib/model/Product.g.dart
@@ -3,6 +3,741 @@
 part of 'Product.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$ProductCWProxy {
+  Product additives(Additives? additives);
+
+  Product allergens(Allergens? allergens);
+
+  Product attributeGroups(List<AttributeGroup>? attributeGroups);
+
+  Product barcode(String? barcode);
+
+  Product brands(String? brands);
+
+  Product brandsTags(List<String>? brandsTags);
+
+  Product categories(String? categories);
+
+  Product categoriesTags(List<String>? categoriesTags);
+
+  Product categoriesTagsInLanguages(
+      Map<OpenFoodFactsLanguage, List<String>>? categoriesTagsInLanguages);
+
+  Product countries(String? countries);
+
+  Product countriesTags(List<String>? countriesTags);
+
+  Product countriesTagsInLanguages(
+      Map<OpenFoodFactsLanguage, List<String>>? countriesTagsInLanguages);
+
+  Product ecoscoreData(EcoscoreData? ecoscoreData);
+
+  Product ecoscoreGrade(String? ecoscoreGrade);
+
+  Product ecoscoreScore(double? ecoscoreScore);
+
+  Product environmentImpactLevels(
+      EnvironmentImpactLevels? environmentImpactLevels);
+
+  Product genericName(String? genericName);
+
+  Product imageFrontSmallUrl(String? imageFrontSmallUrl);
+
+  Product imageFrontUrl(String? imageFrontUrl);
+
+  Product imageIngredientsSmallUrl(String? imageIngredientsSmallUrl);
+
+  Product imageIngredientsUrl(String? imageIngredientsUrl);
+
+  Product imageNutritionSmallUrl(String? imageNutritionSmallUrl);
+
+  Product imageNutritionUrl(String? imageNutritionUrl);
+
+  Product imagePackagingSmallUrl(String? imagePackagingSmallUrl);
+
+  Product imagePackagingUrl(String? imagePackagingUrl);
+
+  Product images(List<ProductImage>? images);
+
+  Product ingredients(List<Ingredient>? ingredients);
+
+  Product ingredientsAnalysisTags(
+      IngredientsAnalysisTags? ingredientsAnalysisTags);
+
+  Product ingredientsTags(List<String>? ingredientsTags);
+
+  Product ingredientsTagsInLanguages(
+      Map<OpenFoodFactsLanguage, List<String>>? ingredientsTagsInLanguages);
+
+  Product ingredientsText(String? ingredientsText);
+
+  Product ingredientsTextInLanguages(
+      Map<OpenFoodFactsLanguage, String>? ingredientsTextInLanguages);
+
+  Product labels(String? labels);
+
+  Product labelsTags(List<String>? labelsTags);
+
+  Product labelsTagsInLanguages(
+      Map<OpenFoodFactsLanguage, List<String>>? labelsTagsInLanguages);
+
+  Product lang(OpenFoodFactsLanguage? lang);
+
+  Product lastModified(DateTime? lastModified);
+
+  Product miscTags(List<String>? miscTags);
+
+  Product noNutritionData(bool? noNutritionData);
+
+  Product nutrientLevels(NutrientLevels? nutrientLevels);
+
+  Product nutrimentDataPer(String? nutrimentDataPer);
+
+  Product nutrimentEnergyUnit(String? nutrimentEnergyUnit);
+
+  Product nutriments(Nutriments? nutriments);
+
+  Product nutriscore(String? nutriscore);
+
+  Product packaging(String? packaging);
+
+  Product packagingQuantity(double? packagingQuantity);
+
+  Product packagingTags(List<String>? packagingTags);
+
+  Product productName(String? productName);
+
+  Product productNameInLanguages(
+      Map<OpenFoodFactsLanguage, String>? productNameInLanguages);
+
+  Product quantity(String? quantity);
+
+  Product selectedImages(List<ProductImage>? selectedImages);
+
+  Product servingQuantity(double? servingQuantity);
+
+  Product servingSize(String? servingSize);
+
+  Product statesTags(List<String>? statesTags);
+
+  Product stores(String? stores);
+
+  Product storesTags(List<String>? storesTags);
+
+  Product tracesTags(List<String>? tracesTags);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Product(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Product(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Product call({
+    Additives? additives,
+    Allergens? allergens,
+    List<AttributeGroup>? attributeGroups,
+    String? barcode,
+    String? brands,
+    List<String>? brandsTags,
+    String? categories,
+    List<String>? categoriesTags,
+    Map<OpenFoodFactsLanguage, List<String>>? categoriesTagsInLanguages,
+    String? countries,
+    List<String>? countriesTags,
+    Map<OpenFoodFactsLanguage, List<String>>? countriesTagsInLanguages,
+    EcoscoreData? ecoscoreData,
+    String? ecoscoreGrade,
+    double? ecoscoreScore,
+    EnvironmentImpactLevels? environmentImpactLevels,
+    String? genericName,
+    String? imageFrontSmallUrl,
+    String? imageFrontUrl,
+    String? imageIngredientsSmallUrl,
+    String? imageIngredientsUrl,
+    String? imageNutritionSmallUrl,
+    String? imageNutritionUrl,
+    String? imagePackagingSmallUrl,
+    String? imagePackagingUrl,
+    List<ProductImage>? images,
+    List<Ingredient>? ingredients,
+    IngredientsAnalysisTags? ingredientsAnalysisTags,
+    List<String>? ingredientsTags,
+    Map<OpenFoodFactsLanguage, List<String>>? ingredientsTagsInLanguages,
+    String? ingredientsText,
+    Map<OpenFoodFactsLanguage, String>? ingredientsTextInLanguages,
+    String? labels,
+    List<String>? labelsTags,
+    Map<OpenFoodFactsLanguage, List<String>>? labelsTagsInLanguages,
+    OpenFoodFactsLanguage? lang,
+    DateTime? lastModified,
+    List<String>? miscTags,
+    bool? noNutritionData,
+    NutrientLevels? nutrientLevels,
+    String? nutrimentDataPer,
+    String? nutrimentEnergyUnit,
+    Nutriments? nutriments,
+    String? nutriscore,
+    String? packaging,
+    double? packagingQuantity,
+    List<String>? packagingTags,
+    String? productName,
+    Map<OpenFoodFactsLanguage, String>? productNameInLanguages,
+    String? quantity,
+    List<ProductImage>? selectedImages,
+    double? servingQuantity,
+    String? servingSize,
+    List<String>? statesTags,
+    String? stores,
+    List<String>? storesTags,
+    List<String>? tracesTags,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfProduct.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfProduct.copyWith.fieldName(...)`
+class _$ProductCWProxyImpl implements _$ProductCWProxy {
+  final Product _value;
+
+  const _$ProductCWProxyImpl(this._value);
+
+  @override
+  Product additives(Additives? additives) => this(additives: additives);
+
+  @override
+  Product allergens(Allergens? allergens) => this(allergens: allergens);
+
+  @override
+  Product attributeGroups(List<AttributeGroup>? attributeGroups) =>
+      this(attributeGroups: attributeGroups);
+
+  @override
+  Product barcode(String? barcode) => this(barcode: barcode);
+
+  @override
+  Product brands(String? brands) => this(brands: brands);
+
+  @override
+  Product brandsTags(List<String>? brandsTags) => this(brandsTags: brandsTags);
+
+  @override
+  Product categories(String? categories) => this(categories: categories);
+
+  @override
+  Product categoriesTags(List<String>? categoriesTags) =>
+      this(categoriesTags: categoriesTags);
+
+  @override
+  Product categoriesTagsInLanguages(
+          Map<OpenFoodFactsLanguage, List<String>>?
+              categoriesTagsInLanguages) =>
+      this(categoriesTagsInLanguages: categoriesTagsInLanguages);
+
+  @override
+  Product countries(String? countries) => this(countries: countries);
+
+  @override
+  Product countriesTags(List<String>? countriesTags) =>
+      this(countriesTags: countriesTags);
+
+  @override
+  Product countriesTagsInLanguages(
+          Map<OpenFoodFactsLanguage, List<String>>? countriesTagsInLanguages) =>
+      this(countriesTagsInLanguages: countriesTagsInLanguages);
+
+  @override
+  Product ecoscoreData(EcoscoreData? ecoscoreData) =>
+      this(ecoscoreData: ecoscoreData);
+
+  @override
+  Product ecoscoreGrade(String? ecoscoreGrade) =>
+      this(ecoscoreGrade: ecoscoreGrade);
+
+  @override
+  Product ecoscoreScore(double? ecoscoreScore) =>
+      this(ecoscoreScore: ecoscoreScore);
+
+  @override
+  Product environmentImpactLevels(
+          EnvironmentImpactLevels? environmentImpactLevels) =>
+      this(environmentImpactLevels: environmentImpactLevels);
+
+  @override
+  Product genericName(String? genericName) => this(genericName: genericName);
+
+  @override
+  Product imageFrontSmallUrl(String? imageFrontSmallUrl) =>
+      this(imageFrontSmallUrl: imageFrontSmallUrl);
+
+  @override
+  Product imageFrontUrl(String? imageFrontUrl) =>
+      this(imageFrontUrl: imageFrontUrl);
+
+  @override
+  Product imageIngredientsSmallUrl(String? imageIngredientsSmallUrl) =>
+      this(imageIngredientsSmallUrl: imageIngredientsSmallUrl);
+
+  @override
+  Product imageIngredientsUrl(String? imageIngredientsUrl) =>
+      this(imageIngredientsUrl: imageIngredientsUrl);
+
+  @override
+  Product imageNutritionSmallUrl(String? imageNutritionSmallUrl) =>
+      this(imageNutritionSmallUrl: imageNutritionSmallUrl);
+
+  @override
+  Product imageNutritionUrl(String? imageNutritionUrl) =>
+      this(imageNutritionUrl: imageNutritionUrl);
+
+  @override
+  Product imagePackagingSmallUrl(String? imagePackagingSmallUrl) =>
+      this(imagePackagingSmallUrl: imagePackagingSmallUrl);
+
+  @override
+  Product imagePackagingUrl(String? imagePackagingUrl) =>
+      this(imagePackagingUrl: imagePackagingUrl);
+
+  @override
+  Product images(List<ProductImage>? images) => this(images: images);
+
+  @override
+  Product ingredients(List<Ingredient>? ingredients) =>
+      this(ingredients: ingredients);
+
+  @override
+  Product ingredientsAnalysisTags(
+          IngredientsAnalysisTags? ingredientsAnalysisTags) =>
+      this(ingredientsAnalysisTags: ingredientsAnalysisTags);
+
+  @override
+  Product ingredientsTags(List<String>? ingredientsTags) =>
+      this(ingredientsTags: ingredientsTags);
+
+  @override
+  Product ingredientsTagsInLanguages(
+          Map<OpenFoodFactsLanguage, List<String>>?
+              ingredientsTagsInLanguages) =>
+      this(ingredientsTagsInLanguages: ingredientsTagsInLanguages);
+
+  @override
+  Product ingredientsText(String? ingredientsText) =>
+      this(ingredientsText: ingredientsText);
+
+  @override
+  Product ingredientsTextInLanguages(
+          Map<OpenFoodFactsLanguage, String>? ingredientsTextInLanguages) =>
+      this(ingredientsTextInLanguages: ingredientsTextInLanguages);
+
+  @override
+  Product labels(String? labels) => this(labels: labels);
+
+  @override
+  Product labelsTags(List<String>? labelsTags) => this(labelsTags: labelsTags);
+
+  @override
+  Product labelsTagsInLanguages(
+          Map<OpenFoodFactsLanguage, List<String>>? labelsTagsInLanguages) =>
+      this(labelsTagsInLanguages: labelsTagsInLanguages);
+
+  @override
+  Product lang(OpenFoodFactsLanguage? lang) => this(lang: lang);
+
+  @override
+  Product lastModified(DateTime? lastModified) =>
+      this(lastModified: lastModified);
+
+  @override
+  Product miscTags(List<String>? miscTags) => this(miscTags: miscTags);
+
+  @override
+  Product noNutritionData(bool? noNutritionData) =>
+      this(noNutritionData: noNutritionData);
+
+  @override
+  Product nutrientLevels(NutrientLevels? nutrientLevels) =>
+      this(nutrientLevels: nutrientLevels);
+
+  @override
+  Product nutrimentDataPer(String? nutrimentDataPer) =>
+      this(nutrimentDataPer: nutrimentDataPer);
+
+  @override
+  Product nutrimentEnergyUnit(String? nutrimentEnergyUnit) =>
+      this(nutrimentEnergyUnit: nutrimentEnergyUnit);
+
+  @override
+  Product nutriments(Nutriments? nutriments) => this(nutriments: nutriments);
+
+  @override
+  Product nutriscore(String? nutriscore) => this(nutriscore: nutriscore);
+
+  @override
+  Product packaging(String? packaging) => this(packaging: packaging);
+
+  @override
+  Product packagingQuantity(double? packagingQuantity) =>
+      this(packagingQuantity: packagingQuantity);
+
+  @override
+  Product packagingTags(List<String>? packagingTags) =>
+      this(packagingTags: packagingTags);
+
+  @override
+  Product productName(String? productName) => this(productName: productName);
+
+  @override
+  Product productNameInLanguages(
+          Map<OpenFoodFactsLanguage, String>? productNameInLanguages) =>
+      this(productNameInLanguages: productNameInLanguages);
+
+  @override
+  Product quantity(String? quantity) => this(quantity: quantity);
+
+  @override
+  Product selectedImages(List<ProductImage>? selectedImages) =>
+      this(selectedImages: selectedImages);
+
+  @override
+  Product servingQuantity(double? servingQuantity) =>
+      this(servingQuantity: servingQuantity);
+
+  @override
+  Product servingSize(String? servingSize) => this(servingSize: servingSize);
+
+  @override
+  Product statesTags(List<String>? statesTags) => this(statesTags: statesTags);
+
+  @override
+  Product stores(String? stores) => this(stores: stores);
+
+  @override
+  Product storesTags(List<String>? storesTags) => this(storesTags: storesTags);
+
+  @override
+  Product tracesTags(List<String>? tracesTags) => this(tracesTags: tracesTags);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Product(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Product(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Product call({
+    Object? additives = const $CopyWithPlaceholder(),
+    Object? allergens = const $CopyWithPlaceholder(),
+    Object? attributeGroups = const $CopyWithPlaceholder(),
+    Object? barcode = const $CopyWithPlaceholder(),
+    Object? brands = const $CopyWithPlaceholder(),
+    Object? brandsTags = const $CopyWithPlaceholder(),
+    Object? categories = const $CopyWithPlaceholder(),
+    Object? categoriesTags = const $CopyWithPlaceholder(),
+    Object? categoriesTagsInLanguages = const $CopyWithPlaceholder(),
+    Object? countries = const $CopyWithPlaceholder(),
+    Object? countriesTags = const $CopyWithPlaceholder(),
+    Object? countriesTagsInLanguages = const $CopyWithPlaceholder(),
+    Object? ecoscoreData = const $CopyWithPlaceholder(),
+    Object? ecoscoreGrade = const $CopyWithPlaceholder(),
+    Object? ecoscoreScore = const $CopyWithPlaceholder(),
+    Object? environmentImpactLevels = const $CopyWithPlaceholder(),
+    Object? genericName = const $CopyWithPlaceholder(),
+    Object? imageFrontSmallUrl = const $CopyWithPlaceholder(),
+    Object? imageFrontUrl = const $CopyWithPlaceholder(),
+    Object? imageIngredientsSmallUrl = const $CopyWithPlaceholder(),
+    Object? imageIngredientsUrl = const $CopyWithPlaceholder(),
+    Object? imageNutritionSmallUrl = const $CopyWithPlaceholder(),
+    Object? imageNutritionUrl = const $CopyWithPlaceholder(),
+    Object? imagePackagingSmallUrl = const $CopyWithPlaceholder(),
+    Object? imagePackagingUrl = const $CopyWithPlaceholder(),
+    Object? images = const $CopyWithPlaceholder(),
+    Object? ingredients = const $CopyWithPlaceholder(),
+    Object? ingredientsAnalysisTags = const $CopyWithPlaceholder(),
+    Object? ingredientsTags = const $CopyWithPlaceholder(),
+    Object? ingredientsTagsInLanguages = const $CopyWithPlaceholder(),
+    Object? ingredientsText = const $CopyWithPlaceholder(),
+    Object? ingredientsTextInLanguages = const $CopyWithPlaceholder(),
+    Object? labels = const $CopyWithPlaceholder(),
+    Object? labelsTags = const $CopyWithPlaceholder(),
+    Object? labelsTagsInLanguages = const $CopyWithPlaceholder(),
+    Object? lang = const $CopyWithPlaceholder(),
+    Object? lastModified = const $CopyWithPlaceholder(),
+    Object? miscTags = const $CopyWithPlaceholder(),
+    Object? noNutritionData = const $CopyWithPlaceholder(),
+    Object? nutrientLevels = const $CopyWithPlaceholder(),
+    Object? nutrimentDataPer = const $CopyWithPlaceholder(),
+    Object? nutrimentEnergyUnit = const $CopyWithPlaceholder(),
+    Object? nutriments = const $CopyWithPlaceholder(),
+    Object? nutriscore = const $CopyWithPlaceholder(),
+    Object? packaging = const $CopyWithPlaceholder(),
+    Object? packagingQuantity = const $CopyWithPlaceholder(),
+    Object? packagingTags = const $CopyWithPlaceholder(),
+    Object? productName = const $CopyWithPlaceholder(),
+    Object? productNameInLanguages = const $CopyWithPlaceholder(),
+    Object? quantity = const $CopyWithPlaceholder(),
+    Object? selectedImages = const $CopyWithPlaceholder(),
+    Object? servingQuantity = const $CopyWithPlaceholder(),
+    Object? servingSize = const $CopyWithPlaceholder(),
+    Object? statesTags = const $CopyWithPlaceholder(),
+    Object? stores = const $CopyWithPlaceholder(),
+    Object? storesTags = const $CopyWithPlaceholder(),
+    Object? tracesTags = const $CopyWithPlaceholder(),
+  }) {
+    return Product(
+      additives: additives == const $CopyWithPlaceholder()
+          ? _value.additives
+          // ignore: cast_nullable_to_non_nullable
+          : additives as Additives?,
+      allergens: allergens == const $CopyWithPlaceholder()
+          ? _value.allergens
+          // ignore: cast_nullable_to_non_nullable
+          : allergens as Allergens?,
+      attributeGroups: attributeGroups == const $CopyWithPlaceholder()
+          ? _value.attributeGroups
+          // ignore: cast_nullable_to_non_nullable
+          : attributeGroups as List<AttributeGroup>?,
+      barcode: barcode == const $CopyWithPlaceholder()
+          ? _value.barcode
+          // ignore: cast_nullable_to_non_nullable
+          : barcode as String?,
+      brands: brands == const $CopyWithPlaceholder()
+          ? _value.brands
+          // ignore: cast_nullable_to_non_nullable
+          : brands as String?,
+      brandsTags: brandsTags == const $CopyWithPlaceholder()
+          ? _value.brandsTags
+          // ignore: cast_nullable_to_non_nullable
+          : brandsTags as List<String>?,
+      categories: categories == const $CopyWithPlaceholder()
+          ? _value.categories
+          // ignore: cast_nullable_to_non_nullable
+          : categories as String?,
+      categoriesTags: categoriesTags == const $CopyWithPlaceholder()
+          ? _value.categoriesTags
+          // ignore: cast_nullable_to_non_nullable
+          : categoriesTags as List<String>?,
+      categoriesTagsInLanguages:
+          categoriesTagsInLanguages == const $CopyWithPlaceholder()
+              ? _value.categoriesTagsInLanguages
+              // ignore: cast_nullable_to_non_nullable
+              : categoriesTagsInLanguages
+                  as Map<OpenFoodFactsLanguage, List<String>>?,
+      countries: countries == const $CopyWithPlaceholder()
+          ? _value.countries
+          // ignore: cast_nullable_to_non_nullable
+          : countries as String?,
+      countriesTags: countriesTags == const $CopyWithPlaceholder()
+          ? _value.countriesTags
+          // ignore: cast_nullable_to_non_nullable
+          : countriesTags as List<String>?,
+      countriesTagsInLanguages:
+          countriesTagsInLanguages == const $CopyWithPlaceholder()
+              ? _value.countriesTagsInLanguages
+              // ignore: cast_nullable_to_non_nullable
+              : countriesTagsInLanguages
+                  as Map<OpenFoodFactsLanguage, List<String>>?,
+      ecoscoreData: ecoscoreData == const $CopyWithPlaceholder()
+          ? _value.ecoscoreData
+          // ignore: cast_nullable_to_non_nullable
+          : ecoscoreData as EcoscoreData?,
+      ecoscoreGrade: ecoscoreGrade == const $CopyWithPlaceholder()
+          ? _value.ecoscoreGrade
+          // ignore: cast_nullable_to_non_nullable
+          : ecoscoreGrade as String?,
+      ecoscoreScore: ecoscoreScore == const $CopyWithPlaceholder()
+          ? _value.ecoscoreScore
+          // ignore: cast_nullable_to_non_nullable
+          : ecoscoreScore as double?,
+      environmentImpactLevels:
+          environmentImpactLevels == const $CopyWithPlaceholder()
+              ? _value.environmentImpactLevels
+              // ignore: cast_nullable_to_non_nullable
+              : environmentImpactLevels as EnvironmentImpactLevels?,
+      genericName: genericName == const $CopyWithPlaceholder()
+          ? _value.genericName
+          // ignore: cast_nullable_to_non_nullable
+          : genericName as String?,
+      imageFrontSmallUrl: imageFrontSmallUrl == const $CopyWithPlaceholder()
+          ? _value.imageFrontSmallUrl
+          // ignore: cast_nullable_to_non_nullable
+          : imageFrontSmallUrl as String?,
+      imageFrontUrl: imageFrontUrl == const $CopyWithPlaceholder()
+          ? _value.imageFrontUrl
+          // ignore: cast_nullable_to_non_nullable
+          : imageFrontUrl as String?,
+      imageIngredientsSmallUrl:
+          imageIngredientsSmallUrl == const $CopyWithPlaceholder()
+              ? _value.imageIngredientsSmallUrl
+              // ignore: cast_nullable_to_non_nullable
+              : imageIngredientsSmallUrl as String?,
+      imageIngredientsUrl: imageIngredientsUrl == const $CopyWithPlaceholder()
+          ? _value.imageIngredientsUrl
+          // ignore: cast_nullable_to_non_nullable
+          : imageIngredientsUrl as String?,
+      imageNutritionSmallUrl:
+          imageNutritionSmallUrl == const $CopyWithPlaceholder()
+              ? _value.imageNutritionSmallUrl
+              // ignore: cast_nullable_to_non_nullable
+              : imageNutritionSmallUrl as String?,
+      imageNutritionUrl: imageNutritionUrl == const $CopyWithPlaceholder()
+          ? _value.imageNutritionUrl
+          // ignore: cast_nullable_to_non_nullable
+          : imageNutritionUrl as String?,
+      imagePackagingSmallUrl:
+          imagePackagingSmallUrl == const $CopyWithPlaceholder()
+              ? _value.imagePackagingSmallUrl
+              // ignore: cast_nullable_to_non_nullable
+              : imagePackagingSmallUrl as String?,
+      imagePackagingUrl: imagePackagingUrl == const $CopyWithPlaceholder()
+          ? _value.imagePackagingUrl
+          // ignore: cast_nullable_to_non_nullable
+          : imagePackagingUrl as String?,
+      images: images == const $CopyWithPlaceholder()
+          ? _value.images
+          // ignore: cast_nullable_to_non_nullable
+          : images as List<ProductImage>?,
+      ingredients: ingredients == const $CopyWithPlaceholder()
+          ? _value.ingredients
+          // ignore: cast_nullable_to_non_nullable
+          : ingredients as List<Ingredient>?,
+      ingredientsAnalysisTags:
+          ingredientsAnalysisTags == const $CopyWithPlaceholder()
+              ? _value.ingredientsAnalysisTags
+              // ignore: cast_nullable_to_non_nullable
+              : ingredientsAnalysisTags as IngredientsAnalysisTags?,
+      ingredientsTags: ingredientsTags == const $CopyWithPlaceholder()
+          ? _value.ingredientsTags
+          // ignore: cast_nullable_to_non_nullable
+          : ingredientsTags as List<String>?,
+      ingredientsTagsInLanguages:
+          ingredientsTagsInLanguages == const $CopyWithPlaceholder()
+              ? _value.ingredientsTagsInLanguages
+              // ignore: cast_nullable_to_non_nullable
+              : ingredientsTagsInLanguages
+                  as Map<OpenFoodFactsLanguage, List<String>>?,
+      ingredientsText: ingredientsText == const $CopyWithPlaceholder()
+          ? _value.ingredientsText
+          // ignore: cast_nullable_to_non_nullable
+          : ingredientsText as String?,
+      ingredientsTextInLanguages: ingredientsTextInLanguages ==
+              const $CopyWithPlaceholder()
+          ? _value.ingredientsTextInLanguages
+          // ignore: cast_nullable_to_non_nullable
+          : ingredientsTextInLanguages as Map<OpenFoodFactsLanguage, String>?,
+      labels: labels == const $CopyWithPlaceholder()
+          ? _value.labels
+          // ignore: cast_nullable_to_non_nullable
+          : labels as String?,
+      labelsTags: labelsTags == const $CopyWithPlaceholder()
+          ? _value.labelsTags
+          // ignore: cast_nullable_to_non_nullable
+          : labelsTags as List<String>?,
+      labelsTagsInLanguages: labelsTagsInLanguages ==
+              const $CopyWithPlaceholder()
+          ? _value.labelsTagsInLanguages
+          // ignore: cast_nullable_to_non_nullable
+          : labelsTagsInLanguages as Map<OpenFoodFactsLanguage, List<String>>?,
+      lang: lang == const $CopyWithPlaceholder()
+          ? _value.lang
+          // ignore: cast_nullable_to_non_nullable
+          : lang as OpenFoodFactsLanguage?,
+      lastModified: lastModified == const $CopyWithPlaceholder()
+          ? _value.lastModified
+          // ignore: cast_nullable_to_non_nullable
+          : lastModified as DateTime?,
+      miscTags: miscTags == const $CopyWithPlaceholder()
+          ? _value.miscTags
+          // ignore: cast_nullable_to_non_nullable
+          : miscTags as List<String>?,
+      noNutritionData: noNutritionData == const $CopyWithPlaceholder()
+          ? _value.noNutritionData
+          // ignore: cast_nullable_to_non_nullable
+          : noNutritionData as bool?,
+      nutrientLevels: nutrientLevels == const $CopyWithPlaceholder()
+          ? _value.nutrientLevels
+          // ignore: cast_nullable_to_non_nullable
+          : nutrientLevels as NutrientLevels?,
+      nutrimentDataPer: nutrimentDataPer == const $CopyWithPlaceholder()
+          ? _value.nutrimentDataPer
+          // ignore: cast_nullable_to_non_nullable
+          : nutrimentDataPer as String?,
+      nutrimentEnergyUnit: nutrimentEnergyUnit == const $CopyWithPlaceholder()
+          ? _value.nutrimentEnergyUnit
+          // ignore: cast_nullable_to_non_nullable
+          : nutrimentEnergyUnit as String?,
+      nutriments: nutriments == const $CopyWithPlaceholder()
+          ? _value.nutriments
+          // ignore: cast_nullable_to_non_nullable
+          : nutriments as Nutriments?,
+      nutriscore: nutriscore == const $CopyWithPlaceholder()
+          ? _value.nutriscore
+          // ignore: cast_nullable_to_non_nullable
+          : nutriscore as String?,
+      packaging: packaging == const $CopyWithPlaceholder()
+          ? _value.packaging
+          // ignore: cast_nullable_to_non_nullable
+          : packaging as String?,
+      packagingQuantity: packagingQuantity == const $CopyWithPlaceholder()
+          ? _value.packagingQuantity
+          // ignore: cast_nullable_to_non_nullable
+          : packagingQuantity as double?,
+      packagingTags: packagingTags == const $CopyWithPlaceholder()
+          ? _value.packagingTags
+          // ignore: cast_nullable_to_non_nullable
+          : packagingTags as List<String>?,
+      productName: productName == const $CopyWithPlaceholder()
+          ? _value.productName
+          // ignore: cast_nullable_to_non_nullable
+          : productName as String?,
+      productNameInLanguages:
+          productNameInLanguages == const $CopyWithPlaceholder()
+              ? _value.productNameInLanguages
+              // ignore: cast_nullable_to_non_nullable
+              : productNameInLanguages as Map<OpenFoodFactsLanguage, String>?,
+      quantity: quantity == const $CopyWithPlaceholder()
+          ? _value.quantity
+          // ignore: cast_nullable_to_non_nullable
+          : quantity as String?,
+      selectedImages: selectedImages == const $CopyWithPlaceholder()
+          ? _value.selectedImages
+          // ignore: cast_nullable_to_non_nullable
+          : selectedImages as List<ProductImage>?,
+      servingQuantity: servingQuantity == const $CopyWithPlaceholder()
+          ? _value.servingQuantity
+          // ignore: cast_nullable_to_non_nullable
+          : servingQuantity as double?,
+      servingSize: servingSize == const $CopyWithPlaceholder()
+          ? _value.servingSize
+          // ignore: cast_nullable_to_non_nullable
+          : servingSize as String?,
+      statesTags: statesTags == const $CopyWithPlaceholder()
+          ? _value.statesTags
+          // ignore: cast_nullable_to_non_nullable
+          : statesTags as List<String>?,
+      stores: stores == const $CopyWithPlaceholder()
+          ? _value.stores
+          // ignore: cast_nullable_to_non_nullable
+          : stores as String?,
+      storesTags: storesTags == const $CopyWithPlaceholder()
+          ? _value.storesTags
+          // ignore: cast_nullable_to_non_nullable
+          : storesTags as List<String>?,
+      tracesTags: tracesTags == const $CopyWithPlaceholder()
+          ? _value.tracesTags
+          // ignore: cast_nullable_to_non_nullable
+          : tracesTags as List<String>?,
+    );
+  }
+}
+
+extension $ProductCopyWith on Product {
+  /// Returns a callable class that can be used as follows: `instanceOfProduct.copyWith(...)` or like so:`instanceOfProduct.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$ProductCWProxy get copyWith => _$ProductCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
@@ -144,7 +879,7 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('countries_tags', instance.countriesTags);
   writeNotNull('countries_tags_in_languages',
       LanguageHelper.toJsonStringsListMap(instance.countriesTagsInLanguages));
-  writeNotNull('lang', LanguageHelper.toJson(instance.lang));
+  val['lang'] = LanguageHelper.toJson(instance.lang);
   writeNotNull('quantity', instance.quantity);
   writeNotNull('image_front_url', instance.imageFrontUrl);
   writeNotNull('image_front_small_url', instance.imageFrontSmallUrl);
@@ -158,9 +893,9 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('serving_size', instance.servingSize);
   writeNotNull('serving_quantity', instance.servingQuantity);
   writeNotNull('product_quantity', instance.packagingQuantity);
-  writeNotNull('selected_images',
-      JsonHelper.selectedImagesToJson(instance.selectedImages));
-  writeNotNull('images', JsonHelper.imagesToJson(instance.images));
+  val['selected_images'] =
+      JsonHelper.selectedImagesToJson(instance.selectedImages);
+  val['images'] = JsonHelper.imagesToJson(instance.images);
   writeNotNull(
       'ingredients', JsonHelper.ingredientsToJson(instance.ingredients));
   writeNotNull('ingredients_text', instance.ingredientsText);
@@ -172,8 +907,8 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   val['imagesFreshnessInLanguages'] = instance.imagesFreshnessInLanguages?.map(
       (k, e) => MapEntry(_$OpenFoodFactsLanguageEnumMap[k]!,
           e.map((k, e) => MapEntry(_$ImageFieldEnumMap[k]!, e))));
-  writeNotNull('ingredients_analysis_tags',
-      IngredientsAnalysisTags.toJson(instance.ingredientsAnalysisTags));
+  val['ingredients_analysis_tags'] =
+      IngredientsAnalysisTags.toJson(instance.ingredientsAnalysisTags);
   writeNotNull('additives_tags', Additives.additivesToJson(instance.additives));
   writeNotNull('environment_impact_level_tags',
       EnvironmentImpactLevels.toJson(instance.environmentImpactLevels));
@@ -220,7 +955,7 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('link', instance.website);
   val['no_nutrition_data'] =
       JsonHelper.checkboxToJSON(instance.noNutritionData);
-  writeNotNull('nutriments', Nutriments.toJsonHelper(instance.nutriments));
+  val['nutriments'] = Nutriments.toJsonHelper(instance.nutriments);
   return val;
 }
 

--- a/lib/model/ProductList.dart
+++ b/lib/model/ProductList.dart
@@ -1,9 +1,12 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'ProductList.g.dart';
 
 /// Folksonomy: current value for a product and a tag key.
+@CopyWith()
 @JsonSerializable()
 class ProductList extends JsonObject {
   @JsonKey(name: 'product')

--- a/lib/model/ProductList.g.dart
+++ b/lib/model/ProductList.g.dart
@@ -3,6 +3,81 @@
 part of 'ProductList.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$ProductListCWProxy {
+  ProductList barcode(String barcode);
+
+  ProductList key(String key);
+
+  ProductList value(String value);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `ProductList(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// ProductList(...).copyWith(id: 12, name: "My name")
+  /// ````
+  ProductList call({
+    String? barcode,
+    String? key,
+    String? value,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfProductList.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfProductList.copyWith.fieldName(...)`
+class _$ProductListCWProxyImpl implements _$ProductListCWProxy {
+  final ProductList _value;
+
+  const _$ProductListCWProxyImpl(this._value);
+
+  @override
+  ProductList barcode(String barcode) => this(barcode: barcode);
+
+  @override
+  ProductList key(String key) => this(key: key);
+
+  @override
+  ProductList value(String value) => this(value: value);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `ProductList(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// ProductList(...).copyWith(id: 12, name: "My name")
+  /// ````
+  ProductList call({
+    Object? barcode = const $CopyWithPlaceholder(),
+    Object? key = const $CopyWithPlaceholder(),
+    Object? value = const $CopyWithPlaceholder(),
+  }) {
+    return ProductList(
+      barcode: barcode == const $CopyWithPlaceholder() || barcode == null
+          ? _value.barcode
+          // ignore: cast_nullable_to_non_nullable
+          : barcode as String,
+      key: key == const $CopyWithPlaceholder() || key == null
+          ? _value.key
+          // ignore: cast_nullable_to_non_nullable
+          : key as String,
+      value: value == const $CopyWithPlaceholder() || value == null
+          ? _value.value
+          // ignore: cast_nullable_to_non_nullable
+          : value as String,
+    );
+  }
+}
+
+extension $ProductListCopyWith on ProductList {
+  /// Returns a callable class that can be used as follows: `instanceOfProductList.copyWith(...)` or like so:`instanceOfProductList.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$ProductListCWProxy get copyWith => _$ProductListCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/ProductResult.dart
+++ b/lib/model/ProductResult.dart
@@ -1,9 +1,12 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 import 'Product.dart';
 
 part 'ProductResult.g.dart';
 
+@CopyWith()
 @JsonSerializable()
 class ProductResult extends JsonObject {
   final int? status;

--- a/lib/model/ProductResult.g.dart
+++ b/lib/model/ProductResult.g.dart
@@ -3,6 +3,93 @@
 part of 'ProductResult.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$ProductResultCWProxy {
+  ProductResult barcode(String? barcode);
+
+  ProductResult product(Product? product);
+
+  ProductResult status(int? status);
+
+  ProductResult statusVerbose(String? statusVerbose);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `ProductResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// ProductResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  ProductResult call({
+    String? barcode,
+    Product? product,
+    int? status,
+    String? statusVerbose,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfProductResult.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfProductResult.copyWith.fieldName(...)`
+class _$ProductResultCWProxyImpl implements _$ProductResultCWProxy {
+  final ProductResult _value;
+
+  const _$ProductResultCWProxyImpl(this._value);
+
+  @override
+  ProductResult barcode(String? barcode) => this(barcode: barcode);
+
+  @override
+  ProductResult product(Product? product) => this(product: product);
+
+  @override
+  ProductResult status(int? status) => this(status: status);
+
+  @override
+  ProductResult statusVerbose(String? statusVerbose) =>
+      this(statusVerbose: statusVerbose);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `ProductResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// ProductResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  ProductResult call({
+    Object? barcode = const $CopyWithPlaceholder(),
+    Object? product = const $CopyWithPlaceholder(),
+    Object? status = const $CopyWithPlaceholder(),
+    Object? statusVerbose = const $CopyWithPlaceholder(),
+  }) {
+    return ProductResult(
+      barcode: barcode == const $CopyWithPlaceholder()
+          ? _value.barcode
+          // ignore: cast_nullable_to_non_nullable
+          : barcode as String?,
+      product: product == const $CopyWithPlaceholder()
+          ? _value.product
+          // ignore: cast_nullable_to_non_nullable
+          : product as Product?,
+      status: status == const $CopyWithPlaceholder()
+          ? _value.status
+          // ignore: cast_nullable_to_non_nullable
+          : status as int?,
+      statusVerbose: statusVerbose == const $CopyWithPlaceholder()
+          ? _value.statusVerbose
+          // ignore: cast_nullable_to_non_nullable
+          : statusVerbose as String?,
+    );
+  }
+}
+
+extension $ProductResultCopyWith on ProductResult {
+  /// Returns a callable class that can be used as follows: `instanceOfProductResult.copyWith(...)` or like so:`instanceOfProductResult.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$ProductResultCWProxy get copyWith => _$ProductResultCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/ProductStats.dart
+++ b/lib/model/ProductStats.dart
@@ -1,10 +1,13 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:openfoodfacts/utils/JsonHelper.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'ProductStats.g.dart';
 
 /// Folksonomy: statistics about the tag keys on a product.
+@CopyWith()
 @JsonSerializable()
 class ProductStats extends JsonObject {
   @JsonKey(name: 'product')

--- a/lib/model/ProductStats.g.dart
+++ b/lib/model/ProductStats.g.dart
@@ -3,6 +3,96 @@
 part of 'ProductStats.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$ProductStatsCWProxy {
+  ProductStats barcode(String barcode);
+
+  ProductStats lastEdit(DateTime lastEdit);
+
+  ProductStats numberOfEditors(int numberOfEditors);
+
+  ProductStats numberOfKeys(int numberOfKeys);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `ProductStats(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// ProductStats(...).copyWith(id: 12, name: "My name")
+  /// ````
+  ProductStats call({
+    String? barcode,
+    DateTime? lastEdit,
+    int? numberOfEditors,
+    int? numberOfKeys,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfProductStats.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfProductStats.copyWith.fieldName(...)`
+class _$ProductStatsCWProxyImpl implements _$ProductStatsCWProxy {
+  final ProductStats _value;
+
+  const _$ProductStatsCWProxyImpl(this._value);
+
+  @override
+  ProductStats barcode(String barcode) => this(barcode: barcode);
+
+  @override
+  ProductStats lastEdit(DateTime lastEdit) => this(lastEdit: lastEdit);
+
+  @override
+  ProductStats numberOfEditors(int numberOfEditors) =>
+      this(numberOfEditors: numberOfEditors);
+
+  @override
+  ProductStats numberOfKeys(int numberOfKeys) =>
+      this(numberOfKeys: numberOfKeys);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `ProductStats(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// ProductStats(...).copyWith(id: 12, name: "My name")
+  /// ````
+  ProductStats call({
+    Object? barcode = const $CopyWithPlaceholder(),
+    Object? lastEdit = const $CopyWithPlaceholder(),
+    Object? numberOfEditors = const $CopyWithPlaceholder(),
+    Object? numberOfKeys = const $CopyWithPlaceholder(),
+  }) {
+    return ProductStats(
+      barcode: barcode == const $CopyWithPlaceholder() || barcode == null
+          ? _value.barcode
+          // ignore: cast_nullable_to_non_nullable
+          : barcode as String,
+      lastEdit: lastEdit == const $CopyWithPlaceholder() || lastEdit == null
+          ? _value.lastEdit
+          // ignore: cast_nullable_to_non_nullable
+          : lastEdit as DateTime,
+      numberOfEditors: numberOfEditors == const $CopyWithPlaceholder() ||
+              numberOfEditors == null
+          ? _value.numberOfEditors
+          // ignore: cast_nullable_to_non_nullable
+          : numberOfEditors as int,
+      numberOfKeys:
+          numberOfKeys == const $CopyWithPlaceholder() || numberOfKeys == null
+              ? _value.numberOfKeys
+              // ignore: cast_nullable_to_non_nullable
+              : numberOfKeys as int,
+    );
+  }
+}
+
+extension $ProductStatsCopyWith on ProductStats {
+  /// Returns a callable class that can be used as follows: `instanceOfProductStats.copyWith(...)` or like so:`instanceOfProductStats.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$ProductStatsCWProxy get copyWith => _$ProductStatsCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/ProductTag.dart
+++ b/lib/model/ProductTag.dart
@@ -1,10 +1,13 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:openfoodfacts/utils/JsonHelper.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'ProductTag.g.dart';
 
 /// Folksonomy product tag: for this barcode, that value is set for that key.
+@CopyWith()
 @JsonSerializable()
 class ProductTag extends JsonObject {
   @JsonKey(name: 'product')

--- a/lib/model/ProductTag.g.dart
+++ b/lib/model/ProductTag.g.dart
@@ -3,6 +3,136 @@
 part of 'ProductTag.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$ProductTagCWProxy {
+  ProductTag barcode(String barcode);
+
+  ProductTag comment(String comment);
+
+  ProductTag editor(String editor);
+
+  ProductTag key(String key);
+
+  ProductTag lastEdit(DateTime lastEdit);
+
+  ProductTag owner(String owner);
+
+  ProductTag value(String value);
+
+  ProductTag version(int version);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `ProductTag(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// ProductTag(...).copyWith(id: 12, name: "My name")
+  /// ````
+  ProductTag call({
+    String? barcode,
+    String? comment,
+    String? editor,
+    String? key,
+    DateTime? lastEdit,
+    String? owner,
+    String? value,
+    int? version,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfProductTag.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfProductTag.copyWith.fieldName(...)`
+class _$ProductTagCWProxyImpl implements _$ProductTagCWProxy {
+  final ProductTag _value;
+
+  const _$ProductTagCWProxyImpl(this._value);
+
+  @override
+  ProductTag barcode(String barcode) => this(barcode: barcode);
+
+  @override
+  ProductTag comment(String comment) => this(comment: comment);
+
+  @override
+  ProductTag editor(String editor) => this(editor: editor);
+
+  @override
+  ProductTag key(String key) => this(key: key);
+
+  @override
+  ProductTag lastEdit(DateTime lastEdit) => this(lastEdit: lastEdit);
+
+  @override
+  ProductTag owner(String owner) => this(owner: owner);
+
+  @override
+  ProductTag value(String value) => this(value: value);
+
+  @override
+  ProductTag version(int version) => this(version: version);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `ProductTag(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// ProductTag(...).copyWith(id: 12, name: "My name")
+  /// ````
+  ProductTag call({
+    Object? barcode = const $CopyWithPlaceholder(),
+    Object? comment = const $CopyWithPlaceholder(),
+    Object? editor = const $CopyWithPlaceholder(),
+    Object? key = const $CopyWithPlaceholder(),
+    Object? lastEdit = const $CopyWithPlaceholder(),
+    Object? owner = const $CopyWithPlaceholder(),
+    Object? value = const $CopyWithPlaceholder(),
+    Object? version = const $CopyWithPlaceholder(),
+  }) {
+    return ProductTag(
+      barcode: barcode == const $CopyWithPlaceholder() || barcode == null
+          ? _value.barcode
+          // ignore: cast_nullable_to_non_nullable
+          : barcode as String,
+      comment: comment == const $CopyWithPlaceholder() || comment == null
+          ? _value.comment
+          // ignore: cast_nullable_to_non_nullable
+          : comment as String,
+      editor: editor == const $CopyWithPlaceholder() || editor == null
+          ? _value.editor
+          // ignore: cast_nullable_to_non_nullable
+          : editor as String,
+      key: key == const $CopyWithPlaceholder() || key == null
+          ? _value.key
+          // ignore: cast_nullable_to_non_nullable
+          : key as String,
+      lastEdit: lastEdit == const $CopyWithPlaceholder() || lastEdit == null
+          ? _value.lastEdit
+          // ignore: cast_nullable_to_non_nullable
+          : lastEdit as DateTime,
+      owner: owner == const $CopyWithPlaceholder() || owner == null
+          ? _value.owner
+          // ignore: cast_nullable_to_non_nullable
+          : owner as String,
+      value: value == const $CopyWithPlaceholder() || value == null
+          ? _value.value
+          // ignore: cast_nullable_to_non_nullable
+          : value as String,
+      version: version == const $CopyWithPlaceholder() || version == null
+          ? _value.version
+          // ignore: cast_nullable_to_non_nullable
+          : version as int,
+    );
+  }
+}
+
+extension $ProductTagCopyWith on ProductTag {
+  /// Returns a callable class that can be used as follows: `instanceOfProductTag.copyWith(...)` or like so:`instanceOfProductTag.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$ProductTagCWProxy get copyWith => _$ProductTagCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/RobotoffQuestion.dart
+++ b/lib/model/RobotoffQuestion.dart
@@ -1,9 +1,12 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:openfoodfacts/model/Insight.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'RobotoffQuestion.g.dart';
 
+@CopyWith()
 @JsonSerializable()
 class RobotoffQuestionResult extends JsonObject {
   final String? status;
@@ -19,6 +22,7 @@ class RobotoffQuestionResult extends JsonObject {
   Map<String, dynamic> toJson() => _$RobotoffQuestionResultToJson(this);
 }
 
+@CopyWith()
 @JsonSerializable()
 class RobotoffQuestion extends JsonObject {
   final String? barcode;

--- a/lib/model/RobotoffQuestion.g.dart
+++ b/lib/model/RobotoffQuestion.g.dart
@@ -3,6 +3,189 @@
 part of 'RobotoffQuestion.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$RobotoffQuestionResultCWProxy {
+  RobotoffQuestionResult questions(List<RobotoffQuestion>? questions);
+
+  RobotoffQuestionResult status(String? status);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `RobotoffQuestionResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// RobotoffQuestionResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  RobotoffQuestionResult call({
+    List<RobotoffQuestion>? questions,
+    String? status,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfRobotoffQuestionResult.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfRobotoffQuestionResult.copyWith.fieldName(...)`
+class _$RobotoffQuestionResultCWProxyImpl
+    implements _$RobotoffQuestionResultCWProxy {
+  final RobotoffQuestionResult _value;
+
+  const _$RobotoffQuestionResultCWProxyImpl(this._value);
+
+  @override
+  RobotoffQuestionResult questions(List<RobotoffQuestion>? questions) =>
+      this(questions: questions);
+
+  @override
+  RobotoffQuestionResult status(String? status) => this(status: status);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `RobotoffQuestionResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// RobotoffQuestionResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  RobotoffQuestionResult call({
+    Object? questions = const $CopyWithPlaceholder(),
+    Object? status = const $CopyWithPlaceholder(),
+  }) {
+    return RobotoffQuestionResult(
+      questions: questions == const $CopyWithPlaceholder()
+          ? _value.questions
+          // ignore: cast_nullable_to_non_nullable
+          : questions as List<RobotoffQuestion>?,
+      status: status == const $CopyWithPlaceholder()
+          ? _value.status
+          // ignore: cast_nullable_to_non_nullable
+          : status as String?,
+    );
+  }
+}
+
+extension $RobotoffQuestionResultCopyWith on RobotoffQuestionResult {
+  /// Returns a callable class that can be used as follows: `instanceOfRobotoffQuestionResult.copyWith(...)` or like so:`instanceOfRobotoffQuestionResult.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$RobotoffQuestionResultCWProxy get copyWith =>
+      _$RobotoffQuestionResultCWProxyImpl(this);
+}
+
+abstract class _$RobotoffQuestionCWProxy {
+  RobotoffQuestion barcode(String? barcode);
+
+  RobotoffQuestion imageUrl(String? imageUrl);
+
+  RobotoffQuestion insightId(String? insightId);
+
+  RobotoffQuestion insightType(InsightType? insightType);
+
+  RobotoffQuestion question(String? question);
+
+  RobotoffQuestion type(String? type);
+
+  RobotoffQuestion value(String? value);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `RobotoffQuestion(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// RobotoffQuestion(...).copyWith(id: 12, name: "My name")
+  /// ````
+  RobotoffQuestion call({
+    String? barcode,
+    String? imageUrl,
+    String? insightId,
+    InsightType? insightType,
+    String? question,
+    String? type,
+    String? value,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfRobotoffQuestion.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfRobotoffQuestion.copyWith.fieldName(...)`
+class _$RobotoffQuestionCWProxyImpl implements _$RobotoffQuestionCWProxy {
+  final RobotoffQuestion _value;
+
+  const _$RobotoffQuestionCWProxyImpl(this._value);
+
+  @override
+  RobotoffQuestion barcode(String? barcode) => this(barcode: barcode);
+
+  @override
+  RobotoffQuestion imageUrl(String? imageUrl) => this(imageUrl: imageUrl);
+
+  @override
+  RobotoffQuestion insightId(String? insightId) => this(insightId: insightId);
+
+  @override
+  RobotoffQuestion insightType(InsightType? insightType) =>
+      this(insightType: insightType);
+
+  @override
+  RobotoffQuestion question(String? question) => this(question: question);
+
+  @override
+  RobotoffQuestion type(String? type) => this(type: type);
+
+  @override
+  RobotoffQuestion value(String? value) => this(value: value);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `RobotoffQuestion(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// RobotoffQuestion(...).copyWith(id: 12, name: "My name")
+  /// ````
+  RobotoffQuestion call({
+    Object? barcode = const $CopyWithPlaceholder(),
+    Object? imageUrl = const $CopyWithPlaceholder(),
+    Object? insightId = const $CopyWithPlaceholder(),
+    Object? insightType = const $CopyWithPlaceholder(),
+    Object? question = const $CopyWithPlaceholder(),
+    Object? type = const $CopyWithPlaceholder(),
+    Object? value = const $CopyWithPlaceholder(),
+  }) {
+    return RobotoffQuestion(
+      barcode: barcode == const $CopyWithPlaceholder()
+          ? _value.barcode
+          // ignore: cast_nullable_to_non_nullable
+          : barcode as String?,
+      imageUrl: imageUrl == const $CopyWithPlaceholder()
+          ? _value.imageUrl
+          // ignore: cast_nullable_to_non_nullable
+          : imageUrl as String?,
+      insightId: insightId == const $CopyWithPlaceholder()
+          ? _value.insightId
+          // ignore: cast_nullable_to_non_nullable
+          : insightId as String?,
+      insightType: insightType == const $CopyWithPlaceholder()
+          ? _value.insightType
+          // ignore: cast_nullable_to_non_nullable
+          : insightType as InsightType?,
+      question: question == const $CopyWithPlaceholder()
+          ? _value.question
+          // ignore: cast_nullable_to_non_nullable
+          : question as String?,
+      type: type == const $CopyWithPlaceholder()
+          ? _value.type
+          // ignore: cast_nullable_to_non_nullable
+          : type as String?,
+      value: value == const $CopyWithPlaceholder()
+          ? _value.value
+          // ignore: cast_nullable_to_non_nullable
+          : value as String?,
+    );
+  }
+}
+
+extension $RobotoffQuestionCopyWith on RobotoffQuestion {
+  /// Returns a callable class that can be used as follows: `instanceOfRobotoffQuestion.copyWith(...)` or like so:`instanceOfRobotoffQuestion.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$RobotoffQuestionCWProxy get copyWith => _$RobotoffQuestionCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/SearchResult.dart
+++ b/lib/model/SearchResult.dart
@@ -1,9 +1,12 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 import 'Product.dart';
 
 part 'SearchResult.g.dart';
 
+@CopyWith()
 @JsonSerializable()
 class SearchResult extends JsonObject {
   @JsonKey(name: 'page', fromJson: JsonObject.parseInt)

--- a/lib/model/SearchResult.g.dart
+++ b/lib/model/SearchResult.g.dart
@@ -3,6 +3,103 @@
 part of 'SearchResult.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$SearchResultCWProxy {
+  SearchResult count(int? count);
+
+  SearchResult page(int? page);
+
+  SearchResult pageSize(int? pageSize);
+
+  SearchResult products(List<Product>? products);
+
+  SearchResult skip(int? skip);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `SearchResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// SearchResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  SearchResult call({
+    int? count,
+    int? page,
+    int? pageSize,
+    List<Product>? products,
+    int? skip,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfSearchResult.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfSearchResult.copyWith.fieldName(...)`
+class _$SearchResultCWProxyImpl implements _$SearchResultCWProxy {
+  final SearchResult _value;
+
+  const _$SearchResultCWProxyImpl(this._value);
+
+  @override
+  SearchResult count(int? count) => this(count: count);
+
+  @override
+  SearchResult page(int? page) => this(page: page);
+
+  @override
+  SearchResult pageSize(int? pageSize) => this(pageSize: pageSize);
+
+  @override
+  SearchResult products(List<Product>? products) => this(products: products);
+
+  @override
+  SearchResult skip(int? skip) => this(skip: skip);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `SearchResult(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// SearchResult(...).copyWith(id: 12, name: "My name")
+  /// ````
+  SearchResult call({
+    Object? count = const $CopyWithPlaceholder(),
+    Object? page = const $CopyWithPlaceholder(),
+    Object? pageSize = const $CopyWithPlaceholder(),
+    Object? products = const $CopyWithPlaceholder(),
+    Object? skip = const $CopyWithPlaceholder(),
+  }) {
+    return SearchResult(
+      count: count == const $CopyWithPlaceholder()
+          ? _value.count
+          // ignore: cast_nullable_to_non_nullable
+          : count as int?,
+      page: page == const $CopyWithPlaceholder()
+          ? _value.page
+          // ignore: cast_nullable_to_non_nullable
+          : page as int?,
+      pageSize: pageSize == const $CopyWithPlaceholder()
+          ? _value.pageSize
+          // ignore: cast_nullable_to_non_nullable
+          : pageSize as int?,
+      products: products == const $CopyWithPlaceholder()
+          ? _value.products
+          // ignore: cast_nullable_to_non_nullable
+          : products as List<Product>?,
+      skip: skip == const $CopyWithPlaceholder()
+          ? _value.skip
+          // ignore: cast_nullable_to_non_nullable
+          : skip as int?,
+    );
+  }
+}
+
+extension $SearchResultCopyWith on SearchResult {
+  /// Returns a callable class that can be used as follows: `instanceOfSearchResult.copyWith(...)` or like so:`instanceOfSearchResult.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$SearchResultCWProxy get copyWith => _$SearchResultCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/SpellingCorrections.dart
+++ b/lib/model/SpellingCorrections.dart
@@ -1,3 +1,4 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 
@@ -12,7 +13,7 @@ class SpellingCorrection extends JsonObject {
   @JsonKey(name: 'corrections', includeIfNull: false)
   List<TermCorrections>? termCorrections;
 
-  SpellingCorrection(this.corrected, this.input, this.termCorrections);
+  SpellingCorrection({this.corrected, this.input, this.termCorrections});
 
   factory SpellingCorrection.fromJson(Map<String, dynamic> json) =>
       _$SpellingCorrectionFromJson(json);
@@ -21,6 +22,7 @@ class SpellingCorrection extends JsonObject {
   Map<String, dynamic> toJson() => _$SpellingCorrectionToJson(this);
 }
 
+@CopyWith()
 @JsonSerializable()
 class TermCorrections extends JsonObject {
   @JsonKey(name: 'term_corrections')
@@ -28,7 +30,7 @@ class TermCorrections extends JsonObject {
   @JsonKey()
   double? score;
 
-  TermCorrections(this.corrections, this.score);
+  TermCorrections({this.corrections, this.score});
 
   factory TermCorrections.fromJson(Map<String, dynamic> json) =>
       _$TermCorrectionsFromJson(json);
@@ -37,6 +39,7 @@ class TermCorrections extends JsonObject {
   Map<String, dynamic> toJson() => _$TermCorrectionsToJson(this);
 }
 
+@CopyWith()
 @JsonSerializable()
 class Correction extends JsonObject {
   @JsonKey(includeIfNull: false)
@@ -50,8 +53,13 @@ class Correction extends JsonObject {
   @JsonKey(name: 'is_valid')
   bool? isValid;
 
-  Correction(this.correction, this.original, this.startOffset, this.endOffset,
-      this.isValid);
+  Correction({
+    this.correction,
+    this.original,
+    this.startOffset,
+    this.endOffset,
+    this.isValid,
+  });
 
   factory Correction.fromJson(Map<String, dynamic> json) =>
       _$CorrectionFromJson(json);

--- a/lib/model/SpellingCorrections.g.dart
+++ b/lib/model/SpellingCorrections.g.dart
@@ -3,14 +3,172 @@
 part of 'SpellingCorrections.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TermCorrectionsCWProxy {
+  TermCorrections corrections(List<Correction>? corrections);
+
+  TermCorrections score(double? score);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TermCorrections(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TermCorrections(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TermCorrections call({
+    List<Correction>? corrections,
+    double? score,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTermCorrections.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTermCorrections.copyWith.fieldName(...)`
+class _$TermCorrectionsCWProxyImpl implements _$TermCorrectionsCWProxy {
+  final TermCorrections _value;
+
+  const _$TermCorrectionsCWProxyImpl(this._value);
+
+  @override
+  TermCorrections corrections(List<Correction>? corrections) =>
+      this(corrections: corrections);
+
+  @override
+  TermCorrections score(double? score) => this(score: score);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TermCorrections(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TermCorrections(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TermCorrections call({
+    Object? corrections = const $CopyWithPlaceholder(),
+    Object? score = const $CopyWithPlaceholder(),
+  }) {
+    return TermCorrections(
+      corrections: corrections == const $CopyWithPlaceholder()
+          ? _value.corrections
+          // ignore: cast_nullable_to_non_nullable
+          : corrections as List<Correction>?,
+      score: score == const $CopyWithPlaceholder()
+          ? _value.score
+          // ignore: cast_nullable_to_non_nullable
+          : score as double?,
+    );
+  }
+}
+
+extension $TermCorrectionsCopyWith on TermCorrections {
+  /// Returns a callable class that can be used as follows: `instanceOfTermCorrections.copyWith(...)` or like so:`instanceOfTermCorrections.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TermCorrectionsCWProxy get copyWith => _$TermCorrectionsCWProxyImpl(this);
+}
+
+abstract class _$CorrectionCWProxy {
+  Correction correction(String? correction);
+
+  Correction endOffset(int? endOffset);
+
+  Correction isValid(bool? isValid);
+
+  Correction original(String? original);
+
+  Correction startOffset(int? startOffset);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Correction(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Correction(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Correction call({
+    String? correction,
+    int? endOffset,
+    bool? isValid,
+    String? original,
+    int? startOffset,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfCorrection.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfCorrection.copyWith.fieldName(...)`
+class _$CorrectionCWProxyImpl implements _$CorrectionCWProxy {
+  final Correction _value;
+
+  const _$CorrectionCWProxyImpl(this._value);
+
+  @override
+  Correction correction(String? correction) => this(correction: correction);
+
+  @override
+  Correction endOffset(int? endOffset) => this(endOffset: endOffset);
+
+  @override
+  Correction isValid(bool? isValid) => this(isValid: isValid);
+
+  @override
+  Correction original(String? original) => this(original: original);
+
+  @override
+  Correction startOffset(int? startOffset) => this(startOffset: startOffset);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Correction(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Correction(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Correction call({
+    Object? correction = const $CopyWithPlaceholder(),
+    Object? endOffset = const $CopyWithPlaceholder(),
+    Object? isValid = const $CopyWithPlaceholder(),
+    Object? original = const $CopyWithPlaceholder(),
+    Object? startOffset = const $CopyWithPlaceholder(),
+  }) {
+    return Correction(
+      correction: correction == const $CopyWithPlaceholder()
+          ? _value.correction
+          // ignore: cast_nullable_to_non_nullable
+          : correction as String?,
+      endOffset: endOffset == const $CopyWithPlaceholder()
+          ? _value.endOffset
+          // ignore: cast_nullable_to_non_nullable
+          : endOffset as int?,
+      isValid: isValid == const $CopyWithPlaceholder()
+          ? _value.isValid
+          // ignore: cast_nullable_to_non_nullable
+          : isValid as bool?,
+      original: original == const $CopyWithPlaceholder()
+          ? _value.original
+          // ignore: cast_nullable_to_non_nullable
+          : original as String?,
+      startOffset: startOffset == const $CopyWithPlaceholder()
+          ? _value.startOffset
+          // ignore: cast_nullable_to_non_nullable
+          : startOffset as int?,
+    );
+  }
+}
+
+extension $CorrectionCopyWith on Correction {
+  /// Returns a callable class that can be used as follows: `instanceOfCorrection.copyWith(...)` or like so:`instanceOfCorrection.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$CorrectionCWProxy get copyWith => _$CorrectionCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 SpellingCorrection _$SpellingCorrectionFromJson(Map<String, dynamic> json) =>
     SpellingCorrection(
-      json['corrected'] as String?,
-      json['text'] as String?,
-      (json['corrections'] as List<dynamic>?)
+      corrected: json['corrected'] as String?,
+      input: json['text'] as String?,
+      termCorrections: (json['corrections'] as List<dynamic>?)
           ?.map((e) => TermCorrections.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
@@ -32,10 +190,10 @@ Map<String, dynamic> _$SpellingCorrectionToJson(SpellingCorrection instance) {
 
 TermCorrections _$TermCorrectionsFromJson(Map<String, dynamic> json) =>
     TermCorrections(
-      (json['term_corrections'] as List<dynamic>?)
+      corrections: (json['term_corrections'] as List<dynamic>?)
           ?.map((e) => Correction.fromJson(e as Map<String, dynamic>))
           .toList(),
-      (json['score'] as num?)?.toDouble(),
+      score: (json['score'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _$TermCorrectionsToJson(TermCorrections instance) =>
@@ -45,11 +203,11 @@ Map<String, dynamic> _$TermCorrectionsToJson(TermCorrections instance) =>
     };
 
 Correction _$CorrectionFromJson(Map<String, dynamic> json) => Correction(
-      json['correction'] as String?,
-      json['original'] as String?,
-      json['start_offset'] as int?,
-      json['end_offset'] as int?,
-      json['is_valid'] as bool?,
+      correction: json['correction'] as String?,
+      original: json['original'] as String?,
+      startOffset: json['start_offset'] as int?,
+      endOffset: json['end_offset'] as int?,
+      isValid: json['is_valid'] as bool?,
     );
 
 Map<String, dynamic> _$CorrectionToJson(Correction instance) {

--- a/lib/model/Status.dart
+++ b/lib/model/Status.dart
@@ -1,10 +1,13 @@
 import 'dart:convert';
 
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'Status.g.dart';
 
+@CopyWith()
 @JsonSerializable()
 class Status extends JsonObject {
   static const WRONG_USER_OR_PASSWORD_ERROR_MESSAGE =

--- a/lib/model/Status.g.dart
+++ b/lib/model/Status.g.dart
@@ -3,6 +3,104 @@
 part of 'Status.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$StatusCWProxy {
+  Status body(String? body);
+
+  Status error(String? error);
+
+  Status imageId(int? imageId);
+
+  Status status(dynamic status);
+
+  Status statusVerbose(String? statusVerbose);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Status(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Status(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Status call({
+    String? body,
+    String? error,
+    int? imageId,
+    dynamic? status,
+    String? statusVerbose,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfStatus.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfStatus.copyWith.fieldName(...)`
+class _$StatusCWProxyImpl implements _$StatusCWProxy {
+  final Status _value;
+
+  const _$StatusCWProxyImpl(this._value);
+
+  @override
+  Status body(String? body) => this(body: body);
+
+  @override
+  Status error(String? error) => this(error: error);
+
+  @override
+  Status imageId(int? imageId) => this(imageId: imageId);
+
+  @override
+  Status status(dynamic status) => this(status: status);
+
+  @override
+  Status statusVerbose(String? statusVerbose) =>
+      this(statusVerbose: statusVerbose);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `Status(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// Status(...).copyWith(id: 12, name: "My name")
+  /// ````
+  Status call({
+    Object? body = const $CopyWithPlaceholder(),
+    Object? error = const $CopyWithPlaceholder(),
+    Object? imageId = const $CopyWithPlaceholder(),
+    Object? status = const $CopyWithPlaceholder(),
+    Object? statusVerbose = const $CopyWithPlaceholder(),
+  }) {
+    return Status(
+      body: body == const $CopyWithPlaceholder()
+          ? _value.body
+          // ignore: cast_nullable_to_non_nullable
+          : body as String?,
+      error: error == const $CopyWithPlaceholder()
+          ? _value.error
+          // ignore: cast_nullable_to_non_nullable
+          : error as String?,
+      imageId: imageId == const $CopyWithPlaceholder()
+          ? _value.imageId
+          // ignore: cast_nullable_to_non_nullable
+          : imageId as int?,
+      status: status == const $CopyWithPlaceholder() || status == null
+          ? _value.status
+          // ignore: cast_nullable_to_non_nullable
+          : status as dynamic,
+      statusVerbose: statusVerbose == const $CopyWithPlaceholder()
+          ? _value.statusVerbose
+          // ignore: cast_nullable_to_non_nullable
+          : statusVerbose as String?,
+    );
+  }
+}
+
+extension $StatusCopyWith on Status {
+  /// Returns a callable class that can be used as follows: `instanceOfStatus.copyWith(...)` or like so:`instanceOfStatus.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$StatusCWProxy get copyWith => _$StatusCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/lib/model/TaxonomyAdditive.dart
+++ b/lib/model/TaxonomyAdditive.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyAdditive.g.dart';
 
@@ -62,9 +63,10 @@ enum TaxonomyAdditiveField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyAdditive extends JsonObject {
-  TaxonomyAdditive(
+  TaxonomyAdditive({
     this.additivesClasses,
     this.carbonFootprintFrFoodgesIngredient,
     this.carbonFootprintFrFoodgesValue,
@@ -94,7 +96,7 @@ class TaxonomyAdditive extends JsonObject {
     this.vegan,
     this.vegetarian,
     this.wikidata,
-  );
+  });
 
   factory TaxonomyAdditive.fromJson(Map<String, dynamic> json) {
     return _$TaxonomyAdditiveFromJson(json);

--- a/lib/model/TaxonomyAdditive.g.dart
+++ b/lib/model/TaxonomyAdditive.g.dart
@@ -3,47 +3,533 @@
 part of 'TaxonomyAdditive.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyAdditiveCWProxy {
+  TaxonomyAdditive additivesClasses(
+      Map<OpenFoodFactsLanguage, String>? additivesClasses);
+
+  TaxonomyAdditive carbonFootprintFrFoodgesIngredient(
+      Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesIngredient);
+
+  TaxonomyAdditive carbonFootprintFrFoodgesValue(
+      Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesValue);
+
+  TaxonomyAdditive children(List<String>? children);
+
+  TaxonomyAdditive colourIndex(Map<OpenFoodFactsLanguage, String>? colourIndex);
+
+  TaxonomyAdditive comment(Map<OpenFoodFactsLanguage, String>? comment);
+
+  TaxonomyAdditive defaultAdditiveClass(
+      Map<OpenFoodFactsLanguage, String>? defaultAdditiveClass);
+
+  TaxonomyAdditive description(Map<OpenFoodFactsLanguage, String>? description);
+
+  TaxonomyAdditive eNumber(Map<OpenFoodFactsLanguage, String>? eNumber);
+
+  TaxonomyAdditive efsa(Map<OpenFoodFactsLanguage, String>? efsa);
+
+  TaxonomyAdditive efsaEvaluation(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluation);
+
+  TaxonomyAdditive efsaEvaluationAdi(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdi);
+
+  TaxonomyAdditive efsaEvaluationAdiEstablished(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdiEstablished);
+
+  TaxonomyAdditive efsaEvaluationDate(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationDate);
+
+  TaxonomyAdditive efsaEvaluationExposure95thGreaterThanAdi(
+      Map<OpenFoodFactsLanguage, String>?
+          efsaEvaluationExposure95thGreaterThanAdi);
+
+  TaxonomyAdditive efsaEvaluationExposure95thGreaterThanNoael(
+      Map<OpenFoodFactsLanguage, String>?
+          efsaEvaluationExposure95thGreaterThanNoael);
+
+  TaxonomyAdditive efsaEvaluationExposureMeanGreaterThanAdi(
+      Map<OpenFoodFactsLanguage, String>?
+          efsaEvaluationExposureMeanGreaterThanAdi);
+
+  TaxonomyAdditive efsaEvaluationExposureMeanGreaterThanNoael(
+      Map<OpenFoodFactsLanguage, String>?
+          efsaEvaluationExposureMeanGreaterThanNoael);
+
+  TaxonomyAdditive efsaEvaluationOverexposureRisk(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationOverexposureRisk);
+
+  TaxonomyAdditive efsaEvaluationSafetyAssessed(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationSafetyAssessed);
+
+  TaxonomyAdditive efsaEvaluationUrl(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationUrl);
+
+  TaxonomyAdditive fromPalmOil(Map<OpenFoodFactsLanguage, String>? fromPalmOil);
+
+  TaxonomyAdditive mandatoryAdditiveClass(
+      Map<OpenFoodFactsLanguage, String>? mandatoryAdditiveClass);
+
+  TaxonomyAdditive name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyAdditive organicEu(Map<OpenFoodFactsLanguage, String>? organicEu);
+
+  TaxonomyAdditive parents(List<String>? parents);
+
+  TaxonomyAdditive vegan(Map<OpenFoodFactsLanguage, String>? vegan);
+
+  TaxonomyAdditive vegetarian(Map<OpenFoodFactsLanguage, String>? vegetarian);
+
+  TaxonomyAdditive wikidata(Map<OpenFoodFactsLanguage, String>? wikidata);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyAdditive(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyAdditive(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyAdditive call({
+    Map<OpenFoodFactsLanguage, String>? additivesClasses,
+    Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesIngredient,
+    Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesValue,
+    List<String>? children,
+    Map<OpenFoodFactsLanguage, String>? colourIndex,
+    Map<OpenFoodFactsLanguage, String>? comment,
+    Map<OpenFoodFactsLanguage, String>? defaultAdditiveClass,
+    Map<OpenFoodFactsLanguage, String>? description,
+    Map<OpenFoodFactsLanguage, String>? eNumber,
+    Map<OpenFoodFactsLanguage, String>? efsa,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluation,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdi,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdiEstablished,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationDate,
+    Map<OpenFoodFactsLanguage, String>?
+        efsaEvaluationExposure95thGreaterThanAdi,
+    Map<OpenFoodFactsLanguage, String>?
+        efsaEvaluationExposure95thGreaterThanNoael,
+    Map<OpenFoodFactsLanguage, String>?
+        efsaEvaluationExposureMeanGreaterThanAdi,
+    Map<OpenFoodFactsLanguage, String>?
+        efsaEvaluationExposureMeanGreaterThanNoael,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationOverexposureRisk,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationSafetyAssessed,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationUrl,
+    Map<OpenFoodFactsLanguage, String>? fromPalmOil,
+    Map<OpenFoodFactsLanguage, String>? mandatoryAdditiveClass,
+    Map<OpenFoodFactsLanguage, String>? name,
+    Map<OpenFoodFactsLanguage, String>? organicEu,
+    List<String>? parents,
+    Map<OpenFoodFactsLanguage, String>? vegan,
+    Map<OpenFoodFactsLanguage, String>? vegetarian,
+    Map<OpenFoodFactsLanguage, String>? wikidata,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyAdditive.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyAdditive.copyWith.fieldName(...)`
+class _$TaxonomyAdditiveCWProxyImpl implements _$TaxonomyAdditiveCWProxy {
+  final TaxonomyAdditive _value;
+
+  const _$TaxonomyAdditiveCWProxyImpl(this._value);
+
+  @override
+  TaxonomyAdditive additivesClasses(
+          Map<OpenFoodFactsLanguage, String>? additivesClasses) =>
+      this(additivesClasses: additivesClasses);
+
+  @override
+  TaxonomyAdditive carbonFootprintFrFoodgesIngredient(
+          Map<OpenFoodFactsLanguage, String>?
+              carbonFootprintFrFoodgesIngredient) =>
+      this(
+          carbonFootprintFrFoodgesIngredient:
+              carbonFootprintFrFoodgesIngredient);
+
+  @override
+  TaxonomyAdditive carbonFootprintFrFoodgesValue(
+          Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesValue) =>
+      this(carbonFootprintFrFoodgesValue: carbonFootprintFrFoodgesValue);
+
+  @override
+  TaxonomyAdditive children(List<String>? children) => this(children: children);
+
+  @override
+  TaxonomyAdditive colourIndex(
+          Map<OpenFoodFactsLanguage, String>? colourIndex) =>
+      this(colourIndex: colourIndex);
+
+  @override
+  TaxonomyAdditive comment(Map<OpenFoodFactsLanguage, String>? comment) =>
+      this(comment: comment);
+
+  @override
+  TaxonomyAdditive defaultAdditiveClass(
+          Map<OpenFoodFactsLanguage, String>? defaultAdditiveClass) =>
+      this(defaultAdditiveClass: defaultAdditiveClass);
+
+  @override
+  TaxonomyAdditive description(
+          Map<OpenFoodFactsLanguage, String>? description) =>
+      this(description: description);
+
+  @override
+  TaxonomyAdditive eNumber(Map<OpenFoodFactsLanguage, String>? eNumber) =>
+      this(eNumber: eNumber);
+
+  @override
+  TaxonomyAdditive efsa(Map<OpenFoodFactsLanguage, String>? efsa) =>
+      this(efsa: efsa);
+
+  @override
+  TaxonomyAdditive efsaEvaluation(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluation) =>
+      this(efsaEvaluation: efsaEvaluation);
+
+  @override
+  TaxonomyAdditive efsaEvaluationAdi(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdi) =>
+      this(efsaEvaluationAdi: efsaEvaluationAdi);
+
+  @override
+  TaxonomyAdditive efsaEvaluationAdiEstablished(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdiEstablished) =>
+      this(efsaEvaluationAdiEstablished: efsaEvaluationAdiEstablished);
+
+  @override
+  TaxonomyAdditive efsaEvaluationDate(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationDate) =>
+      this(efsaEvaluationDate: efsaEvaluationDate);
+
+  @override
+  TaxonomyAdditive efsaEvaluationExposure95thGreaterThanAdi(
+          Map<OpenFoodFactsLanguage, String>?
+              efsaEvaluationExposure95thGreaterThanAdi) =>
+      this(
+          efsaEvaluationExposure95thGreaterThanAdi:
+              efsaEvaluationExposure95thGreaterThanAdi);
+
+  @override
+  TaxonomyAdditive efsaEvaluationExposure95thGreaterThanNoael(
+          Map<OpenFoodFactsLanguage, String>?
+              efsaEvaluationExposure95thGreaterThanNoael) =>
+      this(
+          efsaEvaluationExposure95thGreaterThanNoael:
+              efsaEvaluationExposure95thGreaterThanNoael);
+
+  @override
+  TaxonomyAdditive efsaEvaluationExposureMeanGreaterThanAdi(
+          Map<OpenFoodFactsLanguage, String>?
+              efsaEvaluationExposureMeanGreaterThanAdi) =>
+      this(
+          efsaEvaluationExposureMeanGreaterThanAdi:
+              efsaEvaluationExposureMeanGreaterThanAdi);
+
+  @override
+  TaxonomyAdditive efsaEvaluationExposureMeanGreaterThanNoael(
+          Map<OpenFoodFactsLanguage, String>?
+              efsaEvaluationExposureMeanGreaterThanNoael) =>
+      this(
+          efsaEvaluationExposureMeanGreaterThanNoael:
+              efsaEvaluationExposureMeanGreaterThanNoael);
+
+  @override
+  TaxonomyAdditive efsaEvaluationOverexposureRisk(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationOverexposureRisk) =>
+      this(efsaEvaluationOverexposureRisk: efsaEvaluationOverexposureRisk);
+
+  @override
+  TaxonomyAdditive efsaEvaluationSafetyAssessed(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationSafetyAssessed) =>
+      this(efsaEvaluationSafetyAssessed: efsaEvaluationSafetyAssessed);
+
+  @override
+  TaxonomyAdditive efsaEvaluationUrl(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationUrl) =>
+      this(efsaEvaluationUrl: efsaEvaluationUrl);
+
+  @override
+  TaxonomyAdditive fromPalmOil(
+          Map<OpenFoodFactsLanguage, String>? fromPalmOil) =>
+      this(fromPalmOil: fromPalmOil);
+
+  @override
+  TaxonomyAdditive mandatoryAdditiveClass(
+          Map<OpenFoodFactsLanguage, String>? mandatoryAdditiveClass) =>
+      this(mandatoryAdditiveClass: mandatoryAdditiveClass);
+
+  @override
+  TaxonomyAdditive name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyAdditive organicEu(Map<OpenFoodFactsLanguage, String>? organicEu) =>
+      this(organicEu: organicEu);
+
+  @override
+  TaxonomyAdditive parents(List<String>? parents) => this(parents: parents);
+
+  @override
+  TaxonomyAdditive vegan(Map<OpenFoodFactsLanguage, String>? vegan) =>
+      this(vegan: vegan);
+
+  @override
+  TaxonomyAdditive vegetarian(Map<OpenFoodFactsLanguage, String>? vegetarian) =>
+      this(vegetarian: vegetarian);
+
+  @override
+  TaxonomyAdditive wikidata(Map<OpenFoodFactsLanguage, String>? wikidata) =>
+      this(wikidata: wikidata);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyAdditive(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyAdditive(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyAdditive call({
+    Object? additivesClasses = const $CopyWithPlaceholder(),
+    Object? carbonFootprintFrFoodgesIngredient = const $CopyWithPlaceholder(),
+    Object? carbonFootprintFrFoodgesValue = const $CopyWithPlaceholder(),
+    Object? children = const $CopyWithPlaceholder(),
+    Object? colourIndex = const $CopyWithPlaceholder(),
+    Object? comment = const $CopyWithPlaceholder(),
+    Object? defaultAdditiveClass = const $CopyWithPlaceholder(),
+    Object? description = const $CopyWithPlaceholder(),
+    Object? eNumber = const $CopyWithPlaceholder(),
+    Object? efsa = const $CopyWithPlaceholder(),
+    Object? efsaEvaluation = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationAdi = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationAdiEstablished = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationDate = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationExposure95thGreaterThanAdi =
+        const $CopyWithPlaceholder(),
+    Object? efsaEvaluationExposure95thGreaterThanNoael =
+        const $CopyWithPlaceholder(),
+    Object? efsaEvaluationExposureMeanGreaterThanAdi =
+        const $CopyWithPlaceholder(),
+    Object? efsaEvaluationExposureMeanGreaterThanNoael =
+        const $CopyWithPlaceholder(),
+    Object? efsaEvaluationOverexposureRisk = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationSafetyAssessed = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationUrl = const $CopyWithPlaceholder(),
+    Object? fromPalmOil = const $CopyWithPlaceholder(),
+    Object? mandatoryAdditiveClass = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? organicEu = const $CopyWithPlaceholder(),
+    Object? parents = const $CopyWithPlaceholder(),
+    Object? vegan = const $CopyWithPlaceholder(),
+    Object? vegetarian = const $CopyWithPlaceholder(),
+    Object? wikidata = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyAdditive(
+      additivesClasses: additivesClasses == const $CopyWithPlaceholder()
+          ? _value.additivesClasses
+          // ignore: cast_nullable_to_non_nullable
+          : additivesClasses as Map<OpenFoodFactsLanguage, String>?,
+      carbonFootprintFrFoodgesIngredient:
+          carbonFootprintFrFoodgesIngredient == const $CopyWithPlaceholder()
+              ? _value.carbonFootprintFrFoodgesIngredient
+              // ignore: cast_nullable_to_non_nullable
+              : carbonFootprintFrFoodgesIngredient
+                  as Map<OpenFoodFactsLanguage, String>?,
+      carbonFootprintFrFoodgesValue:
+          carbonFootprintFrFoodgesValue == const $CopyWithPlaceholder()
+              ? _value.carbonFootprintFrFoodgesValue
+              // ignore: cast_nullable_to_non_nullable
+              : carbonFootprintFrFoodgesValue
+                  as Map<OpenFoodFactsLanguage, String>?,
+      children: children == const $CopyWithPlaceholder()
+          ? _value.children
+          // ignore: cast_nullable_to_non_nullable
+          : children as List<String>?,
+      colourIndex: colourIndex == const $CopyWithPlaceholder()
+          ? _value.colourIndex
+          // ignore: cast_nullable_to_non_nullable
+          : colourIndex as Map<OpenFoodFactsLanguage, String>?,
+      comment: comment == const $CopyWithPlaceholder()
+          ? _value.comment
+          // ignore: cast_nullable_to_non_nullable
+          : comment as Map<OpenFoodFactsLanguage, String>?,
+      defaultAdditiveClass: defaultAdditiveClass == const $CopyWithPlaceholder()
+          ? _value.defaultAdditiveClass
+          // ignore: cast_nullable_to_non_nullable
+          : defaultAdditiveClass as Map<OpenFoodFactsLanguage, String>?,
+      description: description == const $CopyWithPlaceholder()
+          ? _value.description
+          // ignore: cast_nullable_to_non_nullable
+          : description as Map<OpenFoodFactsLanguage, String>?,
+      eNumber: eNumber == const $CopyWithPlaceholder()
+          ? _value.eNumber
+          // ignore: cast_nullable_to_non_nullable
+          : eNumber as Map<OpenFoodFactsLanguage, String>?,
+      efsa: efsa == const $CopyWithPlaceholder()
+          ? _value.efsa
+          // ignore: cast_nullable_to_non_nullable
+          : efsa as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluation: efsaEvaluation == const $CopyWithPlaceholder()
+          ? _value.efsaEvaluation
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluation as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationAdi: efsaEvaluationAdi == const $CopyWithPlaceholder()
+          ? _value.efsaEvaluationAdi
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluationAdi as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationAdiEstablished: efsaEvaluationAdiEstablished ==
+              const $CopyWithPlaceholder()
+          ? _value.efsaEvaluationAdiEstablished
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluationAdiEstablished as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationDate: efsaEvaluationDate == const $CopyWithPlaceholder()
+          ? _value.efsaEvaluationDate
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluationDate as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationExposure95thGreaterThanAdi:
+          efsaEvaluationExposure95thGreaterThanAdi ==
+                  const $CopyWithPlaceholder()
+              ? _value.efsaEvaluationExposure95thGreaterThanAdi
+              // ignore: cast_nullable_to_non_nullable
+              : efsaEvaluationExposure95thGreaterThanAdi
+                  as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationExposure95thGreaterThanNoael:
+          efsaEvaluationExposure95thGreaterThanNoael ==
+                  const $CopyWithPlaceholder()
+              ? _value.efsaEvaluationExposure95thGreaterThanNoael
+              // ignore: cast_nullable_to_non_nullable
+              : efsaEvaluationExposure95thGreaterThanNoael
+                  as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationExposureMeanGreaterThanAdi:
+          efsaEvaluationExposureMeanGreaterThanAdi ==
+                  const $CopyWithPlaceholder()
+              ? _value.efsaEvaluationExposureMeanGreaterThanAdi
+              // ignore: cast_nullable_to_non_nullable
+              : efsaEvaluationExposureMeanGreaterThanAdi
+                  as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationExposureMeanGreaterThanNoael:
+          efsaEvaluationExposureMeanGreaterThanNoael ==
+                  const $CopyWithPlaceholder()
+              ? _value.efsaEvaluationExposureMeanGreaterThanNoael
+              // ignore: cast_nullable_to_non_nullable
+              : efsaEvaluationExposureMeanGreaterThanNoael
+                  as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationOverexposureRisk:
+          efsaEvaluationOverexposureRisk == const $CopyWithPlaceholder()
+              ? _value.efsaEvaluationOverexposureRisk
+              // ignore: cast_nullable_to_non_nullable
+              : efsaEvaluationOverexposureRisk
+                  as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationSafetyAssessed: efsaEvaluationSafetyAssessed ==
+              const $CopyWithPlaceholder()
+          ? _value.efsaEvaluationSafetyAssessed
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluationSafetyAssessed as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationUrl: efsaEvaluationUrl == const $CopyWithPlaceholder()
+          ? _value.efsaEvaluationUrl
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluationUrl as Map<OpenFoodFactsLanguage, String>?,
+      fromPalmOil: fromPalmOil == const $CopyWithPlaceholder()
+          ? _value.fromPalmOil
+          // ignore: cast_nullable_to_non_nullable
+          : fromPalmOil as Map<OpenFoodFactsLanguage, String>?,
+      mandatoryAdditiveClass:
+          mandatoryAdditiveClass == const $CopyWithPlaceholder()
+              ? _value.mandatoryAdditiveClass
+              // ignore: cast_nullable_to_non_nullable
+              : mandatoryAdditiveClass as Map<OpenFoodFactsLanguage, String>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      organicEu: organicEu == const $CopyWithPlaceholder()
+          ? _value.organicEu
+          // ignore: cast_nullable_to_non_nullable
+          : organicEu as Map<OpenFoodFactsLanguage, String>?,
+      parents: parents == const $CopyWithPlaceholder()
+          ? _value.parents
+          // ignore: cast_nullable_to_non_nullable
+          : parents as List<String>?,
+      vegan: vegan == const $CopyWithPlaceholder()
+          ? _value.vegan
+          // ignore: cast_nullable_to_non_nullable
+          : vegan as Map<OpenFoodFactsLanguage, String>?,
+      vegetarian: vegetarian == const $CopyWithPlaceholder()
+          ? _value.vegetarian
+          // ignore: cast_nullable_to_non_nullable
+          : vegetarian as Map<OpenFoodFactsLanguage, String>?,
+      wikidata: wikidata == const $CopyWithPlaceholder()
+          ? _value.wikidata
+          // ignore: cast_nullable_to_non_nullable
+          : wikidata as Map<OpenFoodFactsLanguage, String>?,
+    );
+  }
+}
+
+extension $TaxonomyAdditiveCopyWith on TaxonomyAdditive {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyAdditive.copyWith(...)` or like so:`instanceOfTaxonomyAdditive.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyAdditiveCWProxy get copyWith => _$TaxonomyAdditiveCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyAdditive _$TaxonomyAdditiveFromJson(Map<String, dynamic> json) =>
     TaxonomyAdditive(
-      LanguageHelper.fromJsonStringMap(json['additives_classes']),
-      LanguageHelper.fromJsonStringMap(
+      additivesClasses:
+          LanguageHelper.fromJsonStringMap(json['additives_classes']),
+      carbonFootprintFrFoodgesIngredient: LanguageHelper.fromJsonStringMap(
           json['carbon_footprint_fr_foodges_ingredient']),
-      LanguageHelper.fromJsonStringMap(
+      carbonFootprintFrFoodgesValue: LanguageHelper.fromJsonStringMap(
           json['carbon_footprint_fr_foodges_value']),
-      (json['children'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      LanguageHelper.fromJsonStringMap(json['colour_index']),
-      LanguageHelper.fromJsonStringMap(json['comment']),
-      LanguageHelper.fromJsonStringMap(json['default_additive_class']),
-      LanguageHelper.fromJsonStringMap(json['description']),
-      LanguageHelper.fromJsonStringMap(json['e_number']),
-      LanguageHelper.fromJsonStringMap(json['efsa']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation_adi']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation_adi_established']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation_date']),
-      LanguageHelper.fromJsonStringMap(
-          json['efsa_evaluation_exposure_95th_greater_than_adi']),
-      LanguageHelper.fromJsonStringMap(
-          json['efsa_evaluation_exposure_95th_greater_than_noael']),
-      LanguageHelper.fromJsonStringMap(
-          json['efsa_evaluation_exposure_mean_greater_than_adi']),
-      LanguageHelper.fromJsonStringMap(
-          json['efsa_evaluation_exposure_mean_greater_than_noael']),
-      LanguageHelper.fromJsonStringMap(
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      colourIndex: LanguageHelper.fromJsonStringMap(json['colour_index']),
+      comment: LanguageHelper.fromJsonStringMap(json['comment']),
+      defaultAdditiveClass:
+          LanguageHelper.fromJsonStringMap(json['default_additive_class']),
+      description: LanguageHelper.fromJsonStringMap(json['description']),
+      eNumber: LanguageHelper.fromJsonStringMap(json['e_number']),
+      efsa: LanguageHelper.fromJsonStringMap(json['efsa']),
+      efsaEvaluation: LanguageHelper.fromJsonStringMap(json['efsa_evaluation']),
+      efsaEvaluationAdi:
+          LanguageHelper.fromJsonStringMap(json['efsa_evaluation_adi']),
+      efsaEvaluationAdiEstablished: LanguageHelper.fromJsonStringMap(
+          json['efsa_evaluation_adi_established']),
+      efsaEvaluationDate:
+          LanguageHelper.fromJsonStringMap(json['efsa_evaluation_date']),
+      efsaEvaluationExposure95thGreaterThanAdi:
+          LanguageHelper.fromJsonStringMap(
+              json['efsa_evaluation_exposure_95th_greater_than_adi']),
+      efsaEvaluationExposure95thGreaterThanNoael:
+          LanguageHelper.fromJsonStringMap(
+              json['efsa_evaluation_exposure_95th_greater_than_noael']),
+      efsaEvaluationExposureMeanGreaterThanAdi:
+          LanguageHelper.fromJsonStringMap(
+              json['efsa_evaluation_exposure_mean_greater_than_adi']),
+      efsaEvaluationExposureMeanGreaterThanNoael:
+          LanguageHelper.fromJsonStringMap(
+              json['efsa_evaluation_exposure_mean_greater_than_noael']),
+      efsaEvaluationOverexposureRisk: LanguageHelper.fromJsonStringMap(
           json['efsa_evaluation_overexposure_risk']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation_safety_assessed']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation_url']),
-      LanguageHelper.fromJsonStringMap(json['from_palm_oil']),
-      LanguageHelper.fromJsonStringMap(json['mandatory_additive_class']),
-      LanguageHelper.fromJsonStringMap(json['name']),
-      LanguageHelper.fromJsonStringMap(json['organic_eu']),
-      (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      LanguageHelper.fromJsonStringMap(json['vegan']),
-      LanguageHelper.fromJsonStringMap(json['vegetarian']),
-      LanguageHelper.fromJsonStringMap(json['wikidata']),
+      efsaEvaluationSafetyAssessed: LanguageHelper.fromJsonStringMap(
+          json['efsa_evaluation_safety_assessed']),
+      efsaEvaluationUrl:
+          LanguageHelper.fromJsonStringMap(json['efsa_evaluation_url']),
+      fromPalmOil: LanguageHelper.fromJsonStringMap(json['from_palm_oil']),
+      mandatoryAdditiveClass:
+          LanguageHelper.fromJsonStringMap(json['mandatory_additive_class']),
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      organicEu: LanguageHelper.fromJsonStringMap(json['organic_eu']),
+      parents:
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      vegan: LanguageHelper.fromJsonStringMap(json['vegan']),
+      vegetarian: LanguageHelper.fromJsonStringMap(json['vegetarian']),
+      wikidata: LanguageHelper.fromJsonStringMap(json['wikidata']),
     );
 
 Map<String, dynamic> _$TaxonomyAdditiveToJson(TaxonomyAdditive instance) {

--- a/lib/model/TaxonomyAllergen.dart
+++ b/lib/model/TaxonomyAllergen.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyAllergen.g.dart';
 
@@ -31,13 +32,14 @@ enum TaxonomyAllergenField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyAllergen extends JsonObject {
-  TaxonomyAllergen(
+  TaxonomyAllergen({
     this.name,
     this.synonyms,
     this.wikidata,
-  );
+  });
 
   factory TaxonomyAllergen.fromJson(Map<String, dynamic> json) {
     return _$TaxonomyAllergenFromJson(json);

--- a/lib/model/TaxonomyAllergen.g.dart
+++ b/lib/model/TaxonomyAllergen.g.dart
@@ -3,14 +3,93 @@
 part of 'TaxonomyAllergen.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyAllergenCWProxy {
+  TaxonomyAllergen name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyAllergen synonyms(Map<OpenFoodFactsLanguage, List<String>>? synonyms);
+
+  TaxonomyAllergen wikidata(Map<OpenFoodFactsLanguage, String>? wikidata);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyAllergen(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyAllergen(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyAllergen call({
+    Map<OpenFoodFactsLanguage, String>? name,
+    Map<OpenFoodFactsLanguage, List<String>>? synonyms,
+    Map<OpenFoodFactsLanguage, String>? wikidata,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyAllergen.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyAllergen.copyWith.fieldName(...)`
+class _$TaxonomyAllergenCWProxyImpl implements _$TaxonomyAllergenCWProxy {
+  final TaxonomyAllergen _value;
+
+  const _$TaxonomyAllergenCWProxyImpl(this._value);
+
+  @override
+  TaxonomyAllergen name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyAllergen synonyms(
+          Map<OpenFoodFactsLanguage, List<String>>? synonyms) =>
+      this(synonyms: synonyms);
+
+  @override
+  TaxonomyAllergen wikidata(Map<OpenFoodFactsLanguage, String>? wikidata) =>
+      this(wikidata: wikidata);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyAllergen(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyAllergen(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyAllergen call({
+    Object? name = const $CopyWithPlaceholder(),
+    Object? synonyms = const $CopyWithPlaceholder(),
+    Object? wikidata = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyAllergen(
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      synonyms: synonyms == const $CopyWithPlaceholder()
+          ? _value.synonyms
+          // ignore: cast_nullable_to_non_nullable
+          : synonyms as Map<OpenFoodFactsLanguage, List<String>>?,
+      wikidata: wikidata == const $CopyWithPlaceholder()
+          ? _value.wikidata
+          // ignore: cast_nullable_to_non_nullable
+          : wikidata as Map<OpenFoodFactsLanguage, String>?,
+    );
+  }
+}
+
+extension $TaxonomyAllergenCopyWith on TaxonomyAllergen {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyAllergen.copyWith(...)` or like so:`instanceOfTaxonomyAllergen.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyAllergenCWProxy get copyWith => _$TaxonomyAllergenCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyAllergen _$TaxonomyAllergenFromJson(Map<String, dynamic> json) =>
     TaxonomyAllergen(
-      LanguageHelper.fromJsonStringMap(json['name']),
-      LanguageHelper.fromJsonStringsListMap(json['synonyms']),
-      LanguageHelper.fromJsonStringMap(json['wikidata']),
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      synonyms: LanguageHelper.fromJsonStringsListMap(json['synonyms']),
+      wikidata: LanguageHelper.fromJsonStringMap(json['wikidata']),
     );
 
 Map<String, dynamic> _$TaxonomyAllergenToJson(TaxonomyAllergen instance) {

--- a/lib/model/TaxonomyCategory.dart
+++ b/lib/model/TaxonomyCategory.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyCategory.g.dart';
 
@@ -58,9 +59,10 @@ enum TaxonomyCategoryField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyCategory extends JsonObject {
-  TaxonomyCategory(
+  TaxonomyCategory({
     this.agribalyseFoodCode,
     this.agribalyseFoodName,
     this.agribalyseProxyFoodCode,
@@ -90,7 +92,7 @@ class TaxonomyCategory extends JsonObject {
     this.wikidata,
     this.wikidataCategory,
     this.wikidataWikipediaCategory,
-  );
+  });
 
   factory TaxonomyCategory.fromJson(Map<String, dynamic> json) {
     return _$TaxonomyCategoryFromJson(json);

--- a/lib/model/TaxonomyCategory.g.dart
+++ b/lib/model/TaxonomyCategory.g.dart
@@ -3,41 +3,488 @@
 part of 'TaxonomyCategory.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyCategoryCWProxy {
+  TaxonomyCategory agribalyseFoodCode(
+      Map<OpenFoodFactsLanguage, String>? agribalyseFoodCode);
+
+  TaxonomyCategory agribalyseFoodName(
+      Map<OpenFoodFactsLanguage, String>? agribalyseFoodName);
+
+  TaxonomyCategory agribalyseProxyFoodCode(
+      Map<OpenFoodFactsLanguage, String>? agribalyseProxyFoodCode);
+
+  TaxonomyCategory agribalyseProxyFoodName(
+      Map<OpenFoodFactsLanguage, String>? agribalyseProxyFoodName);
+
+  TaxonomyCategory agribalyseProxyName(
+      Map<OpenFoodFactsLanguage, String>? agribalyseProxyName);
+
+  TaxonomyCategory carbonFootprintFrFoodgesIngredient(
+      Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesIngredient);
+
+  TaxonomyCategory children(List<String>? children);
+
+  TaxonomyCategory ciqualFoodCode(
+      Map<OpenFoodFactsLanguage, String>? ciqualFoodCode);
+
+  TaxonomyCategory ciqualFoodName(
+      Map<OpenFoodFactsLanguage, String>? ciqualFoodName);
+
+  TaxonomyCategory ciqualProxyFoodCode(
+      Map<OpenFoodFactsLanguage, String>? ciqualProxyFoodCode);
+
+  TaxonomyCategory ciqualProxyFoodName(
+      Map<OpenFoodFactsLanguage, String>? ciqualProxyFoodName);
+
+  TaxonomyCategory country(Map<OpenFoodFactsLanguage, String>? country);
+
+  TaxonomyCategory grapevariety(
+      Map<OpenFoodFactsLanguage, String>? grapevariety);
+
+  TaxonomyCategory instanceof(Map<OpenFoodFactsLanguage, String>? instanceof);
+
+  TaxonomyCategory name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyCategory nova(Map<OpenFoodFactsLanguage, String>? nova);
+
+  TaxonomyCategory oqaliFamily(Map<OpenFoodFactsLanguage, String>? oqaliFamily);
+
+  TaxonomyCategory origins(Map<OpenFoodFactsLanguage, String>? origins);
+
+  TaxonomyCategory parents(List<String>? parents);
+
+  TaxonomyCategory pnnsGroup1(Map<OpenFoodFactsLanguage, String>? pnnsGroup1);
+
+  TaxonomyCategory pnnsGroup2(Map<OpenFoodFactsLanguage, String>? pnnsGroup2);
+
+  TaxonomyCategory protectedNameFileNumber(
+      Map<OpenFoodFactsLanguage, String>? protectedNameFileNumber);
+
+  TaxonomyCategory protectedNameType(
+      Map<OpenFoodFactsLanguage, String>? protectedNameType);
+
+  TaxonomyCategory region(Map<OpenFoodFactsLanguage, String>? region);
+
+  TaxonomyCategory seasonInCountryFr(
+      Map<OpenFoodFactsLanguage, String>? seasonInCountryFr);
+
+  TaxonomyCategory whoId(Map<OpenFoodFactsLanguage, String>? whoId);
+
+  TaxonomyCategory wikidata(Map<OpenFoodFactsLanguage, String>? wikidata);
+
+  TaxonomyCategory wikidataCategory(
+      Map<OpenFoodFactsLanguage, String>? wikidataCategory);
+
+  TaxonomyCategory wikidataWikipediaCategory(
+      Map<OpenFoodFactsLanguage, String>? wikidataWikipediaCategory);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyCategory(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyCategory(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyCategory call({
+    Map<OpenFoodFactsLanguage, String>? agribalyseFoodCode,
+    Map<OpenFoodFactsLanguage, String>? agribalyseFoodName,
+    Map<OpenFoodFactsLanguage, String>? agribalyseProxyFoodCode,
+    Map<OpenFoodFactsLanguage, String>? agribalyseProxyFoodName,
+    Map<OpenFoodFactsLanguage, String>? agribalyseProxyName,
+    Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesIngredient,
+    List<String>? children,
+    Map<OpenFoodFactsLanguage, String>? ciqualFoodCode,
+    Map<OpenFoodFactsLanguage, String>? ciqualFoodName,
+    Map<OpenFoodFactsLanguage, String>? ciqualProxyFoodCode,
+    Map<OpenFoodFactsLanguage, String>? ciqualProxyFoodName,
+    Map<OpenFoodFactsLanguage, String>? country,
+    Map<OpenFoodFactsLanguage, String>? grapevariety,
+    Map<OpenFoodFactsLanguage, String>? instanceof,
+    Map<OpenFoodFactsLanguage, String>? name,
+    Map<OpenFoodFactsLanguage, String>? nova,
+    Map<OpenFoodFactsLanguage, String>? oqaliFamily,
+    Map<OpenFoodFactsLanguage, String>? origins,
+    List<String>? parents,
+    Map<OpenFoodFactsLanguage, String>? pnnsGroup1,
+    Map<OpenFoodFactsLanguage, String>? pnnsGroup2,
+    Map<OpenFoodFactsLanguage, String>? protectedNameFileNumber,
+    Map<OpenFoodFactsLanguage, String>? protectedNameType,
+    Map<OpenFoodFactsLanguage, String>? region,
+    Map<OpenFoodFactsLanguage, String>? seasonInCountryFr,
+    Map<OpenFoodFactsLanguage, String>? whoId,
+    Map<OpenFoodFactsLanguage, String>? wikidata,
+    Map<OpenFoodFactsLanguage, String>? wikidataCategory,
+    Map<OpenFoodFactsLanguage, String>? wikidataWikipediaCategory,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyCategory.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyCategory.copyWith.fieldName(...)`
+class _$TaxonomyCategoryCWProxyImpl implements _$TaxonomyCategoryCWProxy {
+  final TaxonomyCategory _value;
+
+  const _$TaxonomyCategoryCWProxyImpl(this._value);
+
+  @override
+  TaxonomyCategory agribalyseFoodCode(
+          Map<OpenFoodFactsLanguage, String>? agribalyseFoodCode) =>
+      this(agribalyseFoodCode: agribalyseFoodCode);
+
+  @override
+  TaxonomyCategory agribalyseFoodName(
+          Map<OpenFoodFactsLanguage, String>? agribalyseFoodName) =>
+      this(agribalyseFoodName: agribalyseFoodName);
+
+  @override
+  TaxonomyCategory agribalyseProxyFoodCode(
+          Map<OpenFoodFactsLanguage, String>? agribalyseProxyFoodCode) =>
+      this(agribalyseProxyFoodCode: agribalyseProxyFoodCode);
+
+  @override
+  TaxonomyCategory agribalyseProxyFoodName(
+          Map<OpenFoodFactsLanguage, String>? agribalyseProxyFoodName) =>
+      this(agribalyseProxyFoodName: agribalyseProxyFoodName);
+
+  @override
+  TaxonomyCategory agribalyseProxyName(
+          Map<OpenFoodFactsLanguage, String>? agribalyseProxyName) =>
+      this(agribalyseProxyName: agribalyseProxyName);
+
+  @override
+  TaxonomyCategory carbonFootprintFrFoodgesIngredient(
+          Map<OpenFoodFactsLanguage, String>?
+              carbonFootprintFrFoodgesIngredient) =>
+      this(
+          carbonFootprintFrFoodgesIngredient:
+              carbonFootprintFrFoodgesIngredient);
+
+  @override
+  TaxonomyCategory children(List<String>? children) => this(children: children);
+
+  @override
+  TaxonomyCategory ciqualFoodCode(
+          Map<OpenFoodFactsLanguage, String>? ciqualFoodCode) =>
+      this(ciqualFoodCode: ciqualFoodCode);
+
+  @override
+  TaxonomyCategory ciqualFoodName(
+          Map<OpenFoodFactsLanguage, String>? ciqualFoodName) =>
+      this(ciqualFoodName: ciqualFoodName);
+
+  @override
+  TaxonomyCategory ciqualProxyFoodCode(
+          Map<OpenFoodFactsLanguage, String>? ciqualProxyFoodCode) =>
+      this(ciqualProxyFoodCode: ciqualProxyFoodCode);
+
+  @override
+  TaxonomyCategory ciqualProxyFoodName(
+          Map<OpenFoodFactsLanguage, String>? ciqualProxyFoodName) =>
+      this(ciqualProxyFoodName: ciqualProxyFoodName);
+
+  @override
+  TaxonomyCategory country(Map<OpenFoodFactsLanguage, String>? country) =>
+      this(country: country);
+
+  @override
+  TaxonomyCategory grapevariety(
+          Map<OpenFoodFactsLanguage, String>? grapevariety) =>
+      this(grapevariety: grapevariety);
+
+  @override
+  TaxonomyCategory instanceof(Map<OpenFoodFactsLanguage, String>? instanceof) =>
+      this(instanceof: instanceof);
+
+  @override
+  TaxonomyCategory name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyCategory nova(Map<OpenFoodFactsLanguage, String>? nova) =>
+      this(nova: nova);
+
+  @override
+  TaxonomyCategory oqaliFamily(
+          Map<OpenFoodFactsLanguage, String>? oqaliFamily) =>
+      this(oqaliFamily: oqaliFamily);
+
+  @override
+  TaxonomyCategory origins(Map<OpenFoodFactsLanguage, String>? origins) =>
+      this(origins: origins);
+
+  @override
+  TaxonomyCategory parents(List<String>? parents) => this(parents: parents);
+
+  @override
+  TaxonomyCategory pnnsGroup1(Map<OpenFoodFactsLanguage, String>? pnnsGroup1) =>
+      this(pnnsGroup1: pnnsGroup1);
+
+  @override
+  TaxonomyCategory pnnsGroup2(Map<OpenFoodFactsLanguage, String>? pnnsGroup2) =>
+      this(pnnsGroup2: pnnsGroup2);
+
+  @override
+  TaxonomyCategory protectedNameFileNumber(
+          Map<OpenFoodFactsLanguage, String>? protectedNameFileNumber) =>
+      this(protectedNameFileNumber: protectedNameFileNumber);
+
+  @override
+  TaxonomyCategory protectedNameType(
+          Map<OpenFoodFactsLanguage, String>? protectedNameType) =>
+      this(protectedNameType: protectedNameType);
+
+  @override
+  TaxonomyCategory region(Map<OpenFoodFactsLanguage, String>? region) =>
+      this(region: region);
+
+  @override
+  TaxonomyCategory seasonInCountryFr(
+          Map<OpenFoodFactsLanguage, String>? seasonInCountryFr) =>
+      this(seasonInCountryFr: seasonInCountryFr);
+
+  @override
+  TaxonomyCategory whoId(Map<OpenFoodFactsLanguage, String>? whoId) =>
+      this(whoId: whoId);
+
+  @override
+  TaxonomyCategory wikidata(Map<OpenFoodFactsLanguage, String>? wikidata) =>
+      this(wikidata: wikidata);
+
+  @override
+  TaxonomyCategory wikidataCategory(
+          Map<OpenFoodFactsLanguage, String>? wikidataCategory) =>
+      this(wikidataCategory: wikidataCategory);
+
+  @override
+  TaxonomyCategory wikidataWikipediaCategory(
+          Map<OpenFoodFactsLanguage, String>? wikidataWikipediaCategory) =>
+      this(wikidataWikipediaCategory: wikidataWikipediaCategory);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyCategory(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyCategory(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyCategory call({
+    Object? agribalyseFoodCode = const $CopyWithPlaceholder(),
+    Object? agribalyseFoodName = const $CopyWithPlaceholder(),
+    Object? agribalyseProxyFoodCode = const $CopyWithPlaceholder(),
+    Object? agribalyseProxyFoodName = const $CopyWithPlaceholder(),
+    Object? agribalyseProxyName = const $CopyWithPlaceholder(),
+    Object? carbonFootprintFrFoodgesIngredient = const $CopyWithPlaceholder(),
+    Object? children = const $CopyWithPlaceholder(),
+    Object? ciqualFoodCode = const $CopyWithPlaceholder(),
+    Object? ciqualFoodName = const $CopyWithPlaceholder(),
+    Object? ciqualProxyFoodCode = const $CopyWithPlaceholder(),
+    Object? ciqualProxyFoodName = const $CopyWithPlaceholder(),
+    Object? country = const $CopyWithPlaceholder(),
+    Object? grapevariety = const $CopyWithPlaceholder(),
+    Object? instanceof = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? nova = const $CopyWithPlaceholder(),
+    Object? oqaliFamily = const $CopyWithPlaceholder(),
+    Object? origins = const $CopyWithPlaceholder(),
+    Object? parents = const $CopyWithPlaceholder(),
+    Object? pnnsGroup1 = const $CopyWithPlaceholder(),
+    Object? pnnsGroup2 = const $CopyWithPlaceholder(),
+    Object? protectedNameFileNumber = const $CopyWithPlaceholder(),
+    Object? protectedNameType = const $CopyWithPlaceholder(),
+    Object? region = const $CopyWithPlaceholder(),
+    Object? seasonInCountryFr = const $CopyWithPlaceholder(),
+    Object? whoId = const $CopyWithPlaceholder(),
+    Object? wikidata = const $CopyWithPlaceholder(),
+    Object? wikidataCategory = const $CopyWithPlaceholder(),
+    Object? wikidataWikipediaCategory = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyCategory(
+      agribalyseFoodCode: agribalyseFoodCode == const $CopyWithPlaceholder()
+          ? _value.agribalyseFoodCode
+          // ignore: cast_nullable_to_non_nullable
+          : agribalyseFoodCode as Map<OpenFoodFactsLanguage, String>?,
+      agribalyseFoodName: agribalyseFoodName == const $CopyWithPlaceholder()
+          ? _value.agribalyseFoodName
+          // ignore: cast_nullable_to_non_nullable
+          : agribalyseFoodName as Map<OpenFoodFactsLanguage, String>?,
+      agribalyseProxyFoodCode:
+          agribalyseProxyFoodCode == const $CopyWithPlaceholder()
+              ? _value.agribalyseProxyFoodCode
+              // ignore: cast_nullable_to_non_nullable
+              : agribalyseProxyFoodCode as Map<OpenFoodFactsLanguage, String>?,
+      agribalyseProxyFoodName:
+          agribalyseProxyFoodName == const $CopyWithPlaceholder()
+              ? _value.agribalyseProxyFoodName
+              // ignore: cast_nullable_to_non_nullable
+              : agribalyseProxyFoodName as Map<OpenFoodFactsLanguage, String>?,
+      agribalyseProxyName: agribalyseProxyName == const $CopyWithPlaceholder()
+          ? _value.agribalyseProxyName
+          // ignore: cast_nullable_to_non_nullable
+          : agribalyseProxyName as Map<OpenFoodFactsLanguage, String>?,
+      carbonFootprintFrFoodgesIngredient:
+          carbonFootprintFrFoodgesIngredient == const $CopyWithPlaceholder()
+              ? _value.carbonFootprintFrFoodgesIngredient
+              // ignore: cast_nullable_to_non_nullable
+              : carbonFootprintFrFoodgesIngredient
+                  as Map<OpenFoodFactsLanguage, String>?,
+      children: children == const $CopyWithPlaceholder()
+          ? _value.children
+          // ignore: cast_nullable_to_non_nullable
+          : children as List<String>?,
+      ciqualFoodCode: ciqualFoodCode == const $CopyWithPlaceholder()
+          ? _value.ciqualFoodCode
+          // ignore: cast_nullable_to_non_nullable
+          : ciqualFoodCode as Map<OpenFoodFactsLanguage, String>?,
+      ciqualFoodName: ciqualFoodName == const $CopyWithPlaceholder()
+          ? _value.ciqualFoodName
+          // ignore: cast_nullable_to_non_nullable
+          : ciqualFoodName as Map<OpenFoodFactsLanguage, String>?,
+      ciqualProxyFoodCode: ciqualProxyFoodCode == const $CopyWithPlaceholder()
+          ? _value.ciqualProxyFoodCode
+          // ignore: cast_nullable_to_non_nullable
+          : ciqualProxyFoodCode as Map<OpenFoodFactsLanguage, String>?,
+      ciqualProxyFoodName: ciqualProxyFoodName == const $CopyWithPlaceholder()
+          ? _value.ciqualProxyFoodName
+          // ignore: cast_nullable_to_non_nullable
+          : ciqualProxyFoodName as Map<OpenFoodFactsLanguage, String>?,
+      country: country == const $CopyWithPlaceholder()
+          ? _value.country
+          // ignore: cast_nullable_to_non_nullable
+          : country as Map<OpenFoodFactsLanguage, String>?,
+      grapevariety: grapevariety == const $CopyWithPlaceholder()
+          ? _value.grapevariety
+          // ignore: cast_nullable_to_non_nullable
+          : grapevariety as Map<OpenFoodFactsLanguage, String>?,
+      instanceof: instanceof == const $CopyWithPlaceholder()
+          ? _value.instanceof
+          // ignore: cast_nullable_to_non_nullable
+          : instanceof as Map<OpenFoodFactsLanguage, String>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      nova: nova == const $CopyWithPlaceholder()
+          ? _value.nova
+          // ignore: cast_nullable_to_non_nullable
+          : nova as Map<OpenFoodFactsLanguage, String>?,
+      oqaliFamily: oqaliFamily == const $CopyWithPlaceholder()
+          ? _value.oqaliFamily
+          // ignore: cast_nullable_to_non_nullable
+          : oqaliFamily as Map<OpenFoodFactsLanguage, String>?,
+      origins: origins == const $CopyWithPlaceholder()
+          ? _value.origins
+          // ignore: cast_nullable_to_non_nullable
+          : origins as Map<OpenFoodFactsLanguage, String>?,
+      parents: parents == const $CopyWithPlaceholder()
+          ? _value.parents
+          // ignore: cast_nullable_to_non_nullable
+          : parents as List<String>?,
+      pnnsGroup1: pnnsGroup1 == const $CopyWithPlaceholder()
+          ? _value.pnnsGroup1
+          // ignore: cast_nullable_to_non_nullable
+          : pnnsGroup1 as Map<OpenFoodFactsLanguage, String>?,
+      pnnsGroup2: pnnsGroup2 == const $CopyWithPlaceholder()
+          ? _value.pnnsGroup2
+          // ignore: cast_nullable_to_non_nullable
+          : pnnsGroup2 as Map<OpenFoodFactsLanguage, String>?,
+      protectedNameFileNumber:
+          protectedNameFileNumber == const $CopyWithPlaceholder()
+              ? _value.protectedNameFileNumber
+              // ignore: cast_nullable_to_non_nullable
+              : protectedNameFileNumber as Map<OpenFoodFactsLanguage, String>?,
+      protectedNameType: protectedNameType == const $CopyWithPlaceholder()
+          ? _value.protectedNameType
+          // ignore: cast_nullable_to_non_nullable
+          : protectedNameType as Map<OpenFoodFactsLanguage, String>?,
+      region: region == const $CopyWithPlaceholder()
+          ? _value.region
+          // ignore: cast_nullable_to_non_nullable
+          : region as Map<OpenFoodFactsLanguage, String>?,
+      seasonInCountryFr: seasonInCountryFr == const $CopyWithPlaceholder()
+          ? _value.seasonInCountryFr
+          // ignore: cast_nullable_to_non_nullable
+          : seasonInCountryFr as Map<OpenFoodFactsLanguage, String>?,
+      whoId: whoId == const $CopyWithPlaceholder()
+          ? _value.whoId
+          // ignore: cast_nullable_to_non_nullable
+          : whoId as Map<OpenFoodFactsLanguage, String>?,
+      wikidata: wikidata == const $CopyWithPlaceholder()
+          ? _value.wikidata
+          // ignore: cast_nullable_to_non_nullable
+          : wikidata as Map<OpenFoodFactsLanguage, String>?,
+      wikidataCategory: wikidataCategory == const $CopyWithPlaceholder()
+          ? _value.wikidataCategory
+          // ignore: cast_nullable_to_non_nullable
+          : wikidataCategory as Map<OpenFoodFactsLanguage, String>?,
+      wikidataWikipediaCategory: wikidataWikipediaCategory ==
+              const $CopyWithPlaceholder()
+          ? _value.wikidataWikipediaCategory
+          // ignore: cast_nullable_to_non_nullable
+          : wikidataWikipediaCategory as Map<OpenFoodFactsLanguage, String>?,
+    );
+  }
+}
+
+extension $TaxonomyCategoryCopyWith on TaxonomyCategory {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyCategory.copyWith(...)` or like so:`instanceOfTaxonomyCategory.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyCategoryCWProxy get copyWith => _$TaxonomyCategoryCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyCategory _$TaxonomyCategoryFromJson(Map<String, dynamic> json) =>
     TaxonomyCategory(
-      LanguageHelper.fromJsonStringMap(json['agribalyse_food_code']),
-      LanguageHelper.fromJsonStringMap(json['agribalyse_food_name']),
-      LanguageHelper.fromJsonStringMap(json['agribalyse_proxy_food_code']),
-      LanguageHelper.fromJsonStringMap(json['agribalyse_proxy_food_name']),
-      LanguageHelper.fromJsonStringMap(json['agribalyse_proxy_name']),
-      LanguageHelper.fromJsonStringMap(
+      agribalyseFoodCode:
+          LanguageHelper.fromJsonStringMap(json['agribalyse_food_code']),
+      agribalyseFoodName:
+          LanguageHelper.fromJsonStringMap(json['agribalyse_food_name']),
+      agribalyseProxyFoodCode:
+          LanguageHelper.fromJsonStringMap(json['agribalyse_proxy_food_code']),
+      agribalyseProxyFoodName:
+          LanguageHelper.fromJsonStringMap(json['agribalyse_proxy_food_name']),
+      agribalyseProxyName:
+          LanguageHelper.fromJsonStringMap(json['agribalyse_proxy_name']),
+      carbonFootprintFrFoodgesIngredient: LanguageHelper.fromJsonStringMap(
           json['carbon_footprint_fr_foodges_ingredient']),
-      (json['children'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      LanguageHelper.fromJsonStringMap(json['ciqual_food_code']),
-      LanguageHelper.fromJsonStringMap(json['ciqual_food_name']),
-      LanguageHelper.fromJsonStringMap(json['ciqual_proxy_food_code']),
-      LanguageHelper.fromJsonStringMap(json['ciqual_proxy_food_name']),
-      LanguageHelper.fromJsonStringMap(json['country']),
-      LanguageHelper.fromJsonStringMap(json['grapevariety']),
-      LanguageHelper.fromJsonStringMap(json['instanceof']),
-      LanguageHelper.fromJsonStringMap(json['name']),
-      LanguageHelper.fromJsonStringMap(json['nova']),
-      LanguageHelper.fromJsonStringMap(json['oqali_family']),
-      LanguageHelper.fromJsonStringMap(json['origins']),
-      (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      LanguageHelper.fromJsonStringMap(json['pnns_group_1']),
-      LanguageHelper.fromJsonStringMap(json['pnns_group_2']),
-      LanguageHelper.fromJsonStringMap(json['protected_name_file_number']),
-      LanguageHelper.fromJsonStringMap(json['protected_name_type']),
-      LanguageHelper.fromJsonStringMap(json['region']),
-      LanguageHelper.fromJsonStringMap(json['season_in_country_fr']),
-      LanguageHelper.fromJsonStringMap(json['who_id']),
-      LanguageHelper.fromJsonStringMap(json['wikidata']),
-      LanguageHelper.fromJsonStringMap(json['wikidata_category']),
-      LanguageHelper.fromJsonStringMap(json['wikidata_wikipedia_category']),
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      ciqualFoodCode:
+          LanguageHelper.fromJsonStringMap(json['ciqual_food_code']),
+      ciqualFoodName:
+          LanguageHelper.fromJsonStringMap(json['ciqual_food_name']),
+      ciqualProxyFoodCode:
+          LanguageHelper.fromJsonStringMap(json['ciqual_proxy_food_code']),
+      ciqualProxyFoodName:
+          LanguageHelper.fromJsonStringMap(json['ciqual_proxy_food_name']),
+      country: LanguageHelper.fromJsonStringMap(json['country']),
+      grapevariety: LanguageHelper.fromJsonStringMap(json['grapevariety']),
+      instanceof: LanguageHelper.fromJsonStringMap(json['instanceof']),
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      nova: LanguageHelper.fromJsonStringMap(json['nova']),
+      oqaliFamily: LanguageHelper.fromJsonStringMap(json['oqali_family']),
+      origins: LanguageHelper.fromJsonStringMap(json['origins']),
+      parents:
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      pnnsGroup1: LanguageHelper.fromJsonStringMap(json['pnns_group_1']),
+      pnnsGroup2: LanguageHelper.fromJsonStringMap(json['pnns_group_2']),
+      protectedNameFileNumber:
+          LanguageHelper.fromJsonStringMap(json['protected_name_file_number']),
+      protectedNameType:
+          LanguageHelper.fromJsonStringMap(json['protected_name_type']),
+      region: LanguageHelper.fromJsonStringMap(json['region']),
+      seasonInCountryFr:
+          LanguageHelper.fromJsonStringMap(json['season_in_country_fr']),
+      whoId: LanguageHelper.fromJsonStringMap(json['who_id']),
+      wikidata: LanguageHelper.fromJsonStringMap(json['wikidata']),
+      wikidataCategory:
+          LanguageHelper.fromJsonStringMap(json['wikidata_category']),
+      wikidataWikipediaCategory:
+          LanguageHelper.fromJsonStringMap(json['wikidata_wikipedia_category']),
     );
 
 Map<String, dynamic> _$TaxonomyCategoryToJson(TaxonomyCategory instance) {

--- a/lib/model/TaxonomyCountry.dart
+++ b/lib/model/TaxonomyCountry.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyCountry.g.dart';
 
@@ -33,9 +34,18 @@ enum TaxonomyCountryField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyCountry extends JsonObject {
-  TaxonomyCountry();
+  TaxonomyCountry({
+    this.countryCode2,
+    this.countryCode3,
+    this.languages,
+    this.name,
+    this.synonyms,
+    this.wikidata,
+    this.officialCountryCode2,
+  });
 
   factory TaxonomyCountry.fromJson(Map<String, dynamic> json) {
     return _$TaxonomyCountryFromJson(json);

--- a/lib/model/TaxonomyCountry.g.dart
+++ b/lib/model/TaxonomyCountry.g.dart
@@ -3,22 +3,149 @@
 part of 'TaxonomyCountry.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyCountryCWProxy {
+  TaxonomyCountry countryCode2(String? countryCode2);
+
+  TaxonomyCountry countryCode3(String? countryCode3);
+
+  TaxonomyCountry languages(List<OpenFoodFactsLanguage>? languages);
+
+  TaxonomyCountry name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyCountry officialCountryCode2(String? officialCountryCode2);
+
+  TaxonomyCountry synonyms(Map<OpenFoodFactsLanguage, List<String>>? synonyms);
+
+  TaxonomyCountry wikidata(String? wikidata);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyCountry(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyCountry(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyCountry call({
+    String? countryCode2,
+    String? countryCode3,
+    List<OpenFoodFactsLanguage>? languages,
+    Map<OpenFoodFactsLanguage, String>? name,
+    String? officialCountryCode2,
+    Map<OpenFoodFactsLanguage, List<String>>? synonyms,
+    String? wikidata,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyCountry.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyCountry.copyWith.fieldName(...)`
+class _$TaxonomyCountryCWProxyImpl implements _$TaxonomyCountryCWProxy {
+  final TaxonomyCountry _value;
+
+  const _$TaxonomyCountryCWProxyImpl(this._value);
+
+  @override
+  TaxonomyCountry countryCode2(String? countryCode2) =>
+      this(countryCode2: countryCode2);
+
+  @override
+  TaxonomyCountry countryCode3(String? countryCode3) =>
+      this(countryCode3: countryCode3);
+
+  @override
+  TaxonomyCountry languages(List<OpenFoodFactsLanguage>? languages) =>
+      this(languages: languages);
+
+  @override
+  TaxonomyCountry name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyCountry officialCountryCode2(String? officialCountryCode2) =>
+      this(officialCountryCode2: officialCountryCode2);
+
+  @override
+  TaxonomyCountry synonyms(
+          Map<OpenFoodFactsLanguage, List<String>>? synonyms) =>
+      this(synonyms: synonyms);
+
+  @override
+  TaxonomyCountry wikidata(String? wikidata) => this(wikidata: wikidata);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyCountry(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyCountry(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyCountry call({
+    Object? countryCode2 = const $CopyWithPlaceholder(),
+    Object? countryCode3 = const $CopyWithPlaceholder(),
+    Object? languages = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? officialCountryCode2 = const $CopyWithPlaceholder(),
+    Object? synonyms = const $CopyWithPlaceholder(),
+    Object? wikidata = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyCountry(
+      countryCode2: countryCode2 == const $CopyWithPlaceholder()
+          ? _value.countryCode2
+          // ignore: cast_nullable_to_non_nullable
+          : countryCode2 as String?,
+      countryCode3: countryCode3 == const $CopyWithPlaceholder()
+          ? _value.countryCode3
+          // ignore: cast_nullable_to_non_nullable
+          : countryCode3 as String?,
+      languages: languages == const $CopyWithPlaceholder()
+          ? _value.languages
+          // ignore: cast_nullable_to_non_nullable
+          : languages as List<OpenFoodFactsLanguage>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      officialCountryCode2: officialCountryCode2 == const $CopyWithPlaceholder()
+          ? _value.officialCountryCode2
+          // ignore: cast_nullable_to_non_nullable
+          : officialCountryCode2 as String?,
+      synonyms: synonyms == const $CopyWithPlaceholder()
+          ? _value.synonyms
+          // ignore: cast_nullable_to_non_nullable
+          : synonyms as Map<OpenFoodFactsLanguage, List<String>>?,
+      wikidata: wikidata == const $CopyWithPlaceholder()
+          ? _value.wikidata
+          // ignore: cast_nullable_to_non_nullable
+          : wikidata as String?,
+    );
+  }
+}
+
+extension $TaxonomyCountryCopyWith on TaxonomyCountry {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyCountry.copyWith(...)` or like so:`instanceOfTaxonomyCountry.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyCountryCWProxy get copyWith => _$TaxonomyCountryCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyCountry _$TaxonomyCountryFromJson(Map<String, dynamic> json) =>
-    TaxonomyCountry()
-      ..countryCode2 =
-          LanguageHelper.fromJsonStringMapIsoUnique(json['country_code_2'])
-      ..countryCode3 =
-          LanguageHelper.fromJsonStringMapIsoUnique(json['country_code_3'])
-      ..languages =
-          LanguageHelper.fromJsonStringMapIsoList(json['language_codes'])
-      ..name = LanguageHelper.fromJsonStringMap(json['name'])
-      ..synonyms = LanguageHelper.fromJsonStringMapList(json['synonyms'])
-      ..wikidata = LanguageHelper.fromJsonStringMapIsoUnique(json['wikidata'])
-      ..officialCountryCode2 = LanguageHelper.fromJsonStringMapIsoUnique(
-          json['official_country_code_2']);
+    TaxonomyCountry(
+      countryCode2:
+          LanguageHelper.fromJsonStringMapIsoUnique(json['country_code_2']),
+      countryCode3:
+          LanguageHelper.fromJsonStringMapIsoUnique(json['country_code_3']),
+      languages:
+          LanguageHelper.fromJsonStringMapIsoList(json['language_codes']),
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      synonyms: LanguageHelper.fromJsonStringMapList(json['synonyms']),
+      wikidata: LanguageHelper.fromJsonStringMapIsoUnique(json['wikidata']),
+      officialCountryCode2: LanguageHelper.fromJsonStringMapIsoUnique(
+          json['official_country_code_2']),
+    );
 
 Map<String, dynamic> _$TaxonomyCountryToJson(TaxonomyCountry instance) {
   final val = <String, dynamic>{};

--- a/lib/model/TaxonomyIngredient.dart
+++ b/lib/model/TaxonomyIngredient.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyIngredient.g.dart';
 
@@ -78,9 +79,10 @@ enum TaxonomyIngredientField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyIngredient extends JsonObject {
-  TaxonomyIngredient(
+  TaxonomyIngredient({
     this.additivesClasses,
     this.allergens,
     this.brioche,
@@ -123,7 +125,7 @@ class TaxonomyIngredient extends JsonObject {
     this.vegetarian,
     this.wikidata,
     this.wiktionary,
-  );
+  });
 
   factory TaxonomyIngredient.fromJson(Map<String, dynamic> json) {
     return _$TaxonomyIngredientFromJson(json);

--- a/lib/model/TaxonomyIngredient.g.dart
+++ b/lib/model/TaxonomyIngredient.g.dart
@@ -3,61 +3,729 @@
 part of 'TaxonomyIngredient.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyIngredientCWProxy {
+  TaxonomyIngredient additivesClasses(
+      Map<OpenFoodFactsLanguage, String>? additivesClasses);
+
+  TaxonomyIngredient allergens(Map<OpenFoodFactsLanguage, String>? allergens);
+
+  TaxonomyIngredient brioche(Map<OpenFoodFactsLanguage, String>? brioche);
+
+  TaxonomyIngredient carbonFootprintFrFoodgesIngredient(
+      Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesIngredient);
+
+  TaxonomyIngredient carbonFootprintFrFoodgesValue(
+      Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesValue);
+
+  TaxonomyIngredient children(List<String>? children);
+
+  TaxonomyIngredient ciqualFoodCode(
+      Map<OpenFoodFactsLanguage, String>? ciqualFoodCode);
+
+  TaxonomyIngredient ciqualFoodName(
+      Map<OpenFoodFactsLanguage, String>? ciqualFoodName);
+
+  TaxonomyIngredient colourIndex(
+      Map<OpenFoodFactsLanguage, String>? colourIndex);
+
+  TaxonomyIngredient comment(Map<OpenFoodFactsLanguage, String>? comment);
+
+  TaxonomyIngredient defaultAdditiveClass(
+      Map<OpenFoodFactsLanguage, String>? defaultAdditiveClass);
+
+  TaxonomyIngredient description(
+      Map<OpenFoodFactsLanguage, String>? description);
+
+  TaxonomyIngredient eNumber(Map<OpenFoodFactsLanguage, String>? eNumber);
+
+  TaxonomyIngredient efsa(Map<OpenFoodFactsLanguage, String>? efsa);
+
+  TaxonomyIngredient efsaEvaluation(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluation);
+
+  TaxonomyIngredient efsaEvaluationAdi(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdi);
+
+  TaxonomyIngredient efsaEvaluationAdiEstablished(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdiEstablished);
+
+  TaxonomyIngredient efsaEvaluationDate(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationDate);
+
+  TaxonomyIngredient efsaEvaluationExposure95ThGreaterThanAdi(
+      Map<OpenFoodFactsLanguage, String>?
+          efsaEvaluationExposure95ThGreaterThanAdi);
+
+  TaxonomyIngredient efsaEvaluationExposure95ThGreaterThanNoael(
+      Map<OpenFoodFactsLanguage, String>?
+          efsaEvaluationExposure95ThGreaterThanNoael);
+
+  TaxonomyIngredient efsaEvaluationExposureMeanGreaterThanAdi(
+      Map<OpenFoodFactsLanguage, String>?
+          efsaEvaluationExposureMeanGreaterThanAdi);
+
+  TaxonomyIngredient efsaEvaluationExposureMeanGreaterThanNoael(
+      Map<OpenFoodFactsLanguage, String>?
+          efsaEvaluationExposureMeanGreaterThanNoael);
+
+  TaxonomyIngredient efsaEvaluationOverexposureRisk(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationOverexposureRisk);
+
+  TaxonomyIngredient efsaEvaluationSafetyAssessed(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationSafetyAssessed);
+
+  TaxonomyIngredient efsaEvaluationUrl(
+      Map<OpenFoodFactsLanguage, String>? efsaEvaluationUrl);
+
+  TaxonomyIngredient fromPalmOil(
+      Map<OpenFoodFactsLanguage, String>? fromPalmOil);
+
+  TaxonomyIngredient likelyAllergens(
+      Map<OpenFoodFactsLanguage, String>? likelyAllergens);
+
+  TaxonomyIngredient mandatoryAdditiveClass(
+      Map<OpenFoodFactsLanguage, String>? mandatoryAdditiveClass);
+
+  TaxonomyIngredient name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyIngredient nova(Map<OpenFoodFactsLanguage, String>? nova);
+
+  TaxonomyIngredient nutriscoreFruitsVegetablesNuts(
+      Map<OpenFoodFactsLanguage, String>? nutriscoreFruitsVegetablesNuts);
+
+  TaxonomyIngredient organicEu(Map<OpenFoodFactsLanguage, String>? organicEu);
+
+  TaxonomyIngredient origins(Map<OpenFoodFactsLanguage, String>? origins);
+
+  TaxonomyIngredient parents(List<String>? parents);
+
+  TaxonomyIngredient pnnsGroup2(Map<OpenFoodFactsLanguage, String>? pnnsGroup2);
+
+  TaxonomyIngredient protectedNameType(
+      Map<OpenFoodFactsLanguage, String>? protectedNameType);
+
+  TaxonomyIngredient reblochon(Map<OpenFoodFactsLanguage, String>? reblochon);
+
+  TaxonomyIngredient synonyms(
+      Map<OpenFoodFactsLanguage, List<String>>? synonyms);
+
+  TaxonomyIngredient vegan(Map<OpenFoodFactsLanguage, String>? vegan);
+
+  TaxonomyIngredient vegetarian(Map<OpenFoodFactsLanguage, String>? vegetarian);
+
+  TaxonomyIngredient wikidata(Map<OpenFoodFactsLanguage, String>? wikidata);
+
+  TaxonomyIngredient wiktionary(Map<OpenFoodFactsLanguage, String>? wiktionary);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyIngredient(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyIngredient(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyIngredient call({
+    Map<OpenFoodFactsLanguage, String>? additivesClasses,
+    Map<OpenFoodFactsLanguage, String>? allergens,
+    Map<OpenFoodFactsLanguage, String>? brioche,
+    Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesIngredient,
+    Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesValue,
+    List<String>? children,
+    Map<OpenFoodFactsLanguage, String>? ciqualFoodCode,
+    Map<OpenFoodFactsLanguage, String>? ciqualFoodName,
+    Map<OpenFoodFactsLanguage, String>? colourIndex,
+    Map<OpenFoodFactsLanguage, String>? comment,
+    Map<OpenFoodFactsLanguage, String>? defaultAdditiveClass,
+    Map<OpenFoodFactsLanguage, String>? description,
+    Map<OpenFoodFactsLanguage, String>? eNumber,
+    Map<OpenFoodFactsLanguage, String>? efsa,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluation,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdi,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdiEstablished,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationDate,
+    Map<OpenFoodFactsLanguage, String>?
+        efsaEvaluationExposure95ThGreaterThanAdi,
+    Map<OpenFoodFactsLanguage, String>?
+        efsaEvaluationExposure95ThGreaterThanNoael,
+    Map<OpenFoodFactsLanguage, String>?
+        efsaEvaluationExposureMeanGreaterThanAdi,
+    Map<OpenFoodFactsLanguage, String>?
+        efsaEvaluationExposureMeanGreaterThanNoael,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationOverexposureRisk,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationSafetyAssessed,
+    Map<OpenFoodFactsLanguage, String>? efsaEvaluationUrl,
+    Map<OpenFoodFactsLanguage, String>? fromPalmOil,
+    Map<OpenFoodFactsLanguage, String>? likelyAllergens,
+    Map<OpenFoodFactsLanguage, String>? mandatoryAdditiveClass,
+    Map<OpenFoodFactsLanguage, String>? name,
+    Map<OpenFoodFactsLanguage, String>? nova,
+    Map<OpenFoodFactsLanguage, String>? nutriscoreFruitsVegetablesNuts,
+    Map<OpenFoodFactsLanguage, String>? organicEu,
+    Map<OpenFoodFactsLanguage, String>? origins,
+    List<String>? parents,
+    Map<OpenFoodFactsLanguage, String>? pnnsGroup2,
+    Map<OpenFoodFactsLanguage, String>? protectedNameType,
+    Map<OpenFoodFactsLanguage, String>? reblochon,
+    Map<OpenFoodFactsLanguage, List<String>>? synonyms,
+    Map<OpenFoodFactsLanguage, String>? vegan,
+    Map<OpenFoodFactsLanguage, String>? vegetarian,
+    Map<OpenFoodFactsLanguage, String>? wikidata,
+    Map<OpenFoodFactsLanguage, String>? wiktionary,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyIngredient.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyIngredient.copyWith.fieldName(...)`
+class _$TaxonomyIngredientCWProxyImpl implements _$TaxonomyIngredientCWProxy {
+  final TaxonomyIngredient _value;
+
+  const _$TaxonomyIngredientCWProxyImpl(this._value);
+
+  @override
+  TaxonomyIngredient additivesClasses(
+          Map<OpenFoodFactsLanguage, String>? additivesClasses) =>
+      this(additivesClasses: additivesClasses);
+
+  @override
+  TaxonomyIngredient allergens(Map<OpenFoodFactsLanguage, String>? allergens) =>
+      this(allergens: allergens);
+
+  @override
+  TaxonomyIngredient brioche(Map<OpenFoodFactsLanguage, String>? brioche) =>
+      this(brioche: brioche);
+
+  @override
+  TaxonomyIngredient carbonFootprintFrFoodgesIngredient(
+          Map<OpenFoodFactsLanguage, String>?
+              carbonFootprintFrFoodgesIngredient) =>
+      this(
+          carbonFootprintFrFoodgesIngredient:
+              carbonFootprintFrFoodgesIngredient);
+
+  @override
+  TaxonomyIngredient carbonFootprintFrFoodgesValue(
+          Map<OpenFoodFactsLanguage, String>? carbonFootprintFrFoodgesValue) =>
+      this(carbonFootprintFrFoodgesValue: carbonFootprintFrFoodgesValue);
+
+  @override
+  TaxonomyIngredient children(List<String>? children) =>
+      this(children: children);
+
+  @override
+  TaxonomyIngredient ciqualFoodCode(
+          Map<OpenFoodFactsLanguage, String>? ciqualFoodCode) =>
+      this(ciqualFoodCode: ciqualFoodCode);
+
+  @override
+  TaxonomyIngredient ciqualFoodName(
+          Map<OpenFoodFactsLanguage, String>? ciqualFoodName) =>
+      this(ciqualFoodName: ciqualFoodName);
+
+  @override
+  TaxonomyIngredient colourIndex(
+          Map<OpenFoodFactsLanguage, String>? colourIndex) =>
+      this(colourIndex: colourIndex);
+
+  @override
+  TaxonomyIngredient comment(Map<OpenFoodFactsLanguage, String>? comment) =>
+      this(comment: comment);
+
+  @override
+  TaxonomyIngredient defaultAdditiveClass(
+          Map<OpenFoodFactsLanguage, String>? defaultAdditiveClass) =>
+      this(defaultAdditiveClass: defaultAdditiveClass);
+
+  @override
+  TaxonomyIngredient description(
+          Map<OpenFoodFactsLanguage, String>? description) =>
+      this(description: description);
+
+  @override
+  TaxonomyIngredient eNumber(Map<OpenFoodFactsLanguage, String>? eNumber) =>
+      this(eNumber: eNumber);
+
+  @override
+  TaxonomyIngredient efsa(Map<OpenFoodFactsLanguage, String>? efsa) =>
+      this(efsa: efsa);
+
+  @override
+  TaxonomyIngredient efsaEvaluation(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluation) =>
+      this(efsaEvaluation: efsaEvaluation);
+
+  @override
+  TaxonomyIngredient efsaEvaluationAdi(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdi) =>
+      this(efsaEvaluationAdi: efsaEvaluationAdi);
+
+  @override
+  TaxonomyIngredient efsaEvaluationAdiEstablished(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationAdiEstablished) =>
+      this(efsaEvaluationAdiEstablished: efsaEvaluationAdiEstablished);
+
+  @override
+  TaxonomyIngredient efsaEvaluationDate(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationDate) =>
+      this(efsaEvaluationDate: efsaEvaluationDate);
+
+  @override
+  TaxonomyIngredient efsaEvaluationExposure95ThGreaterThanAdi(
+          Map<OpenFoodFactsLanguage, String>?
+              efsaEvaluationExposure95ThGreaterThanAdi) =>
+      this(
+          efsaEvaluationExposure95ThGreaterThanAdi:
+              efsaEvaluationExposure95ThGreaterThanAdi);
+
+  @override
+  TaxonomyIngredient efsaEvaluationExposure95ThGreaterThanNoael(
+          Map<OpenFoodFactsLanguage, String>?
+              efsaEvaluationExposure95ThGreaterThanNoael) =>
+      this(
+          efsaEvaluationExposure95ThGreaterThanNoael:
+              efsaEvaluationExposure95ThGreaterThanNoael);
+
+  @override
+  TaxonomyIngredient efsaEvaluationExposureMeanGreaterThanAdi(
+          Map<OpenFoodFactsLanguage, String>?
+              efsaEvaluationExposureMeanGreaterThanAdi) =>
+      this(
+          efsaEvaluationExposureMeanGreaterThanAdi:
+              efsaEvaluationExposureMeanGreaterThanAdi);
+
+  @override
+  TaxonomyIngredient efsaEvaluationExposureMeanGreaterThanNoael(
+          Map<OpenFoodFactsLanguage, String>?
+              efsaEvaluationExposureMeanGreaterThanNoael) =>
+      this(
+          efsaEvaluationExposureMeanGreaterThanNoael:
+              efsaEvaluationExposureMeanGreaterThanNoael);
+
+  @override
+  TaxonomyIngredient efsaEvaluationOverexposureRisk(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationOverexposureRisk) =>
+      this(efsaEvaluationOverexposureRisk: efsaEvaluationOverexposureRisk);
+
+  @override
+  TaxonomyIngredient efsaEvaluationSafetyAssessed(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationSafetyAssessed) =>
+      this(efsaEvaluationSafetyAssessed: efsaEvaluationSafetyAssessed);
+
+  @override
+  TaxonomyIngredient efsaEvaluationUrl(
+          Map<OpenFoodFactsLanguage, String>? efsaEvaluationUrl) =>
+      this(efsaEvaluationUrl: efsaEvaluationUrl);
+
+  @override
+  TaxonomyIngredient fromPalmOil(
+          Map<OpenFoodFactsLanguage, String>? fromPalmOil) =>
+      this(fromPalmOil: fromPalmOil);
+
+  @override
+  TaxonomyIngredient likelyAllergens(
+          Map<OpenFoodFactsLanguage, String>? likelyAllergens) =>
+      this(likelyAllergens: likelyAllergens);
+
+  @override
+  TaxonomyIngredient mandatoryAdditiveClass(
+          Map<OpenFoodFactsLanguage, String>? mandatoryAdditiveClass) =>
+      this(mandatoryAdditiveClass: mandatoryAdditiveClass);
+
+  @override
+  TaxonomyIngredient name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyIngredient nova(Map<OpenFoodFactsLanguage, String>? nova) =>
+      this(nova: nova);
+
+  @override
+  TaxonomyIngredient nutriscoreFruitsVegetablesNuts(
+          Map<OpenFoodFactsLanguage, String>? nutriscoreFruitsVegetablesNuts) =>
+      this(nutriscoreFruitsVegetablesNuts: nutriscoreFruitsVegetablesNuts);
+
+  @override
+  TaxonomyIngredient organicEu(Map<OpenFoodFactsLanguage, String>? organicEu) =>
+      this(organicEu: organicEu);
+
+  @override
+  TaxonomyIngredient origins(Map<OpenFoodFactsLanguage, String>? origins) =>
+      this(origins: origins);
+
+  @override
+  TaxonomyIngredient parents(List<String>? parents) => this(parents: parents);
+
+  @override
+  TaxonomyIngredient pnnsGroup2(
+          Map<OpenFoodFactsLanguage, String>? pnnsGroup2) =>
+      this(pnnsGroup2: pnnsGroup2);
+
+  @override
+  TaxonomyIngredient protectedNameType(
+          Map<OpenFoodFactsLanguage, String>? protectedNameType) =>
+      this(protectedNameType: protectedNameType);
+
+  @override
+  TaxonomyIngredient reblochon(Map<OpenFoodFactsLanguage, String>? reblochon) =>
+      this(reblochon: reblochon);
+
+  @override
+  TaxonomyIngredient synonyms(
+          Map<OpenFoodFactsLanguage, List<String>>? synonyms) =>
+      this(synonyms: synonyms);
+
+  @override
+  TaxonomyIngredient vegan(Map<OpenFoodFactsLanguage, String>? vegan) =>
+      this(vegan: vegan);
+
+  @override
+  TaxonomyIngredient vegetarian(
+          Map<OpenFoodFactsLanguage, String>? vegetarian) =>
+      this(vegetarian: vegetarian);
+
+  @override
+  TaxonomyIngredient wikidata(Map<OpenFoodFactsLanguage, String>? wikidata) =>
+      this(wikidata: wikidata);
+
+  @override
+  TaxonomyIngredient wiktionary(
+          Map<OpenFoodFactsLanguage, String>? wiktionary) =>
+      this(wiktionary: wiktionary);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyIngredient(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyIngredient(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyIngredient call({
+    Object? additivesClasses = const $CopyWithPlaceholder(),
+    Object? allergens = const $CopyWithPlaceholder(),
+    Object? brioche = const $CopyWithPlaceholder(),
+    Object? carbonFootprintFrFoodgesIngredient = const $CopyWithPlaceholder(),
+    Object? carbonFootprintFrFoodgesValue = const $CopyWithPlaceholder(),
+    Object? children = const $CopyWithPlaceholder(),
+    Object? ciqualFoodCode = const $CopyWithPlaceholder(),
+    Object? ciqualFoodName = const $CopyWithPlaceholder(),
+    Object? colourIndex = const $CopyWithPlaceholder(),
+    Object? comment = const $CopyWithPlaceholder(),
+    Object? defaultAdditiveClass = const $CopyWithPlaceholder(),
+    Object? description = const $CopyWithPlaceholder(),
+    Object? eNumber = const $CopyWithPlaceholder(),
+    Object? efsa = const $CopyWithPlaceholder(),
+    Object? efsaEvaluation = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationAdi = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationAdiEstablished = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationDate = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationExposure95ThGreaterThanAdi =
+        const $CopyWithPlaceholder(),
+    Object? efsaEvaluationExposure95ThGreaterThanNoael =
+        const $CopyWithPlaceholder(),
+    Object? efsaEvaluationExposureMeanGreaterThanAdi =
+        const $CopyWithPlaceholder(),
+    Object? efsaEvaluationExposureMeanGreaterThanNoael =
+        const $CopyWithPlaceholder(),
+    Object? efsaEvaluationOverexposureRisk = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationSafetyAssessed = const $CopyWithPlaceholder(),
+    Object? efsaEvaluationUrl = const $CopyWithPlaceholder(),
+    Object? fromPalmOil = const $CopyWithPlaceholder(),
+    Object? likelyAllergens = const $CopyWithPlaceholder(),
+    Object? mandatoryAdditiveClass = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? nova = const $CopyWithPlaceholder(),
+    Object? nutriscoreFruitsVegetablesNuts = const $CopyWithPlaceholder(),
+    Object? organicEu = const $CopyWithPlaceholder(),
+    Object? origins = const $CopyWithPlaceholder(),
+    Object? parents = const $CopyWithPlaceholder(),
+    Object? pnnsGroup2 = const $CopyWithPlaceholder(),
+    Object? protectedNameType = const $CopyWithPlaceholder(),
+    Object? reblochon = const $CopyWithPlaceholder(),
+    Object? synonyms = const $CopyWithPlaceholder(),
+    Object? vegan = const $CopyWithPlaceholder(),
+    Object? vegetarian = const $CopyWithPlaceholder(),
+    Object? wikidata = const $CopyWithPlaceholder(),
+    Object? wiktionary = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyIngredient(
+      additivesClasses: additivesClasses == const $CopyWithPlaceholder()
+          ? _value.additivesClasses
+          // ignore: cast_nullable_to_non_nullable
+          : additivesClasses as Map<OpenFoodFactsLanguage, String>?,
+      allergens: allergens == const $CopyWithPlaceholder()
+          ? _value.allergens
+          // ignore: cast_nullable_to_non_nullable
+          : allergens as Map<OpenFoodFactsLanguage, String>?,
+      brioche: brioche == const $CopyWithPlaceholder()
+          ? _value.brioche
+          // ignore: cast_nullable_to_non_nullable
+          : brioche as Map<OpenFoodFactsLanguage, String>?,
+      carbonFootprintFrFoodgesIngredient:
+          carbonFootprintFrFoodgesIngredient == const $CopyWithPlaceholder()
+              ? _value.carbonFootprintFrFoodgesIngredient
+              // ignore: cast_nullable_to_non_nullable
+              : carbonFootprintFrFoodgesIngredient
+                  as Map<OpenFoodFactsLanguage, String>?,
+      carbonFootprintFrFoodgesValue:
+          carbonFootprintFrFoodgesValue == const $CopyWithPlaceholder()
+              ? _value.carbonFootprintFrFoodgesValue
+              // ignore: cast_nullable_to_non_nullable
+              : carbonFootprintFrFoodgesValue
+                  as Map<OpenFoodFactsLanguage, String>?,
+      children: children == const $CopyWithPlaceholder()
+          ? _value.children
+          // ignore: cast_nullable_to_non_nullable
+          : children as List<String>?,
+      ciqualFoodCode: ciqualFoodCode == const $CopyWithPlaceholder()
+          ? _value.ciqualFoodCode
+          // ignore: cast_nullable_to_non_nullable
+          : ciqualFoodCode as Map<OpenFoodFactsLanguage, String>?,
+      ciqualFoodName: ciqualFoodName == const $CopyWithPlaceholder()
+          ? _value.ciqualFoodName
+          // ignore: cast_nullable_to_non_nullable
+          : ciqualFoodName as Map<OpenFoodFactsLanguage, String>?,
+      colourIndex: colourIndex == const $CopyWithPlaceholder()
+          ? _value.colourIndex
+          // ignore: cast_nullable_to_non_nullable
+          : colourIndex as Map<OpenFoodFactsLanguage, String>?,
+      comment: comment == const $CopyWithPlaceholder()
+          ? _value.comment
+          // ignore: cast_nullable_to_non_nullable
+          : comment as Map<OpenFoodFactsLanguage, String>?,
+      defaultAdditiveClass: defaultAdditiveClass == const $CopyWithPlaceholder()
+          ? _value.defaultAdditiveClass
+          // ignore: cast_nullable_to_non_nullable
+          : defaultAdditiveClass as Map<OpenFoodFactsLanguage, String>?,
+      description: description == const $CopyWithPlaceholder()
+          ? _value.description
+          // ignore: cast_nullable_to_non_nullable
+          : description as Map<OpenFoodFactsLanguage, String>?,
+      eNumber: eNumber == const $CopyWithPlaceholder()
+          ? _value.eNumber
+          // ignore: cast_nullable_to_non_nullable
+          : eNumber as Map<OpenFoodFactsLanguage, String>?,
+      efsa: efsa == const $CopyWithPlaceholder()
+          ? _value.efsa
+          // ignore: cast_nullable_to_non_nullable
+          : efsa as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluation: efsaEvaluation == const $CopyWithPlaceholder()
+          ? _value.efsaEvaluation
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluation as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationAdi: efsaEvaluationAdi == const $CopyWithPlaceholder()
+          ? _value.efsaEvaluationAdi
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluationAdi as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationAdiEstablished: efsaEvaluationAdiEstablished ==
+              const $CopyWithPlaceholder()
+          ? _value.efsaEvaluationAdiEstablished
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluationAdiEstablished as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationDate: efsaEvaluationDate == const $CopyWithPlaceholder()
+          ? _value.efsaEvaluationDate
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluationDate as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationExposure95ThGreaterThanAdi:
+          efsaEvaluationExposure95ThGreaterThanAdi ==
+                  const $CopyWithPlaceholder()
+              ? _value.efsaEvaluationExposure95ThGreaterThanAdi
+              // ignore: cast_nullable_to_non_nullable
+              : efsaEvaluationExposure95ThGreaterThanAdi
+                  as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationExposure95ThGreaterThanNoael:
+          efsaEvaluationExposure95ThGreaterThanNoael ==
+                  const $CopyWithPlaceholder()
+              ? _value.efsaEvaluationExposure95ThGreaterThanNoael
+              // ignore: cast_nullable_to_non_nullable
+              : efsaEvaluationExposure95ThGreaterThanNoael
+                  as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationExposureMeanGreaterThanAdi:
+          efsaEvaluationExposureMeanGreaterThanAdi ==
+                  const $CopyWithPlaceholder()
+              ? _value.efsaEvaluationExposureMeanGreaterThanAdi
+              // ignore: cast_nullable_to_non_nullable
+              : efsaEvaluationExposureMeanGreaterThanAdi
+                  as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationExposureMeanGreaterThanNoael:
+          efsaEvaluationExposureMeanGreaterThanNoael ==
+                  const $CopyWithPlaceholder()
+              ? _value.efsaEvaluationExposureMeanGreaterThanNoael
+              // ignore: cast_nullable_to_non_nullable
+              : efsaEvaluationExposureMeanGreaterThanNoael
+                  as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationOverexposureRisk:
+          efsaEvaluationOverexposureRisk == const $CopyWithPlaceholder()
+              ? _value.efsaEvaluationOverexposureRisk
+              // ignore: cast_nullable_to_non_nullable
+              : efsaEvaluationOverexposureRisk
+                  as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationSafetyAssessed: efsaEvaluationSafetyAssessed ==
+              const $CopyWithPlaceholder()
+          ? _value.efsaEvaluationSafetyAssessed
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluationSafetyAssessed as Map<OpenFoodFactsLanguage, String>?,
+      efsaEvaluationUrl: efsaEvaluationUrl == const $CopyWithPlaceholder()
+          ? _value.efsaEvaluationUrl
+          // ignore: cast_nullable_to_non_nullable
+          : efsaEvaluationUrl as Map<OpenFoodFactsLanguage, String>?,
+      fromPalmOil: fromPalmOil == const $CopyWithPlaceholder()
+          ? _value.fromPalmOil
+          // ignore: cast_nullable_to_non_nullable
+          : fromPalmOil as Map<OpenFoodFactsLanguage, String>?,
+      likelyAllergens: likelyAllergens == const $CopyWithPlaceholder()
+          ? _value.likelyAllergens
+          // ignore: cast_nullable_to_non_nullable
+          : likelyAllergens as Map<OpenFoodFactsLanguage, String>?,
+      mandatoryAdditiveClass:
+          mandatoryAdditiveClass == const $CopyWithPlaceholder()
+              ? _value.mandatoryAdditiveClass
+              // ignore: cast_nullable_to_non_nullable
+              : mandatoryAdditiveClass as Map<OpenFoodFactsLanguage, String>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      nova: nova == const $CopyWithPlaceholder()
+          ? _value.nova
+          // ignore: cast_nullable_to_non_nullable
+          : nova as Map<OpenFoodFactsLanguage, String>?,
+      nutriscoreFruitsVegetablesNuts:
+          nutriscoreFruitsVegetablesNuts == const $CopyWithPlaceholder()
+              ? _value.nutriscoreFruitsVegetablesNuts
+              // ignore: cast_nullable_to_non_nullable
+              : nutriscoreFruitsVegetablesNuts
+                  as Map<OpenFoodFactsLanguage, String>?,
+      organicEu: organicEu == const $CopyWithPlaceholder()
+          ? _value.organicEu
+          // ignore: cast_nullable_to_non_nullable
+          : organicEu as Map<OpenFoodFactsLanguage, String>?,
+      origins: origins == const $CopyWithPlaceholder()
+          ? _value.origins
+          // ignore: cast_nullable_to_non_nullable
+          : origins as Map<OpenFoodFactsLanguage, String>?,
+      parents: parents == const $CopyWithPlaceholder()
+          ? _value.parents
+          // ignore: cast_nullable_to_non_nullable
+          : parents as List<String>?,
+      pnnsGroup2: pnnsGroup2 == const $CopyWithPlaceholder()
+          ? _value.pnnsGroup2
+          // ignore: cast_nullable_to_non_nullable
+          : pnnsGroup2 as Map<OpenFoodFactsLanguage, String>?,
+      protectedNameType: protectedNameType == const $CopyWithPlaceholder()
+          ? _value.protectedNameType
+          // ignore: cast_nullable_to_non_nullable
+          : protectedNameType as Map<OpenFoodFactsLanguage, String>?,
+      reblochon: reblochon == const $CopyWithPlaceholder()
+          ? _value.reblochon
+          // ignore: cast_nullable_to_non_nullable
+          : reblochon as Map<OpenFoodFactsLanguage, String>?,
+      synonyms: synonyms == const $CopyWithPlaceholder()
+          ? _value.synonyms
+          // ignore: cast_nullable_to_non_nullable
+          : synonyms as Map<OpenFoodFactsLanguage, List<String>>?,
+      vegan: vegan == const $CopyWithPlaceholder()
+          ? _value.vegan
+          // ignore: cast_nullable_to_non_nullable
+          : vegan as Map<OpenFoodFactsLanguage, String>?,
+      vegetarian: vegetarian == const $CopyWithPlaceholder()
+          ? _value.vegetarian
+          // ignore: cast_nullable_to_non_nullable
+          : vegetarian as Map<OpenFoodFactsLanguage, String>?,
+      wikidata: wikidata == const $CopyWithPlaceholder()
+          ? _value.wikidata
+          // ignore: cast_nullable_to_non_nullable
+          : wikidata as Map<OpenFoodFactsLanguage, String>?,
+      wiktionary: wiktionary == const $CopyWithPlaceholder()
+          ? _value.wiktionary
+          // ignore: cast_nullable_to_non_nullable
+          : wiktionary as Map<OpenFoodFactsLanguage, String>?,
+    );
+  }
+}
+
+extension $TaxonomyIngredientCopyWith on TaxonomyIngredient {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyIngredient.copyWith(...)` or like so:`instanceOfTaxonomyIngredient.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyIngredientCWProxy get copyWith =>
+      _$TaxonomyIngredientCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyIngredient _$TaxonomyIngredientFromJson(Map<String, dynamic> json) =>
     TaxonomyIngredient(
-      LanguageHelper.fromJsonStringMap(json['additives_classes']),
-      LanguageHelper.fromJsonStringMap(json['allergens']),
-      LanguageHelper.fromJsonStringMap(json['brioche']),
-      LanguageHelper.fromJsonStringMap(
+      additivesClasses:
+          LanguageHelper.fromJsonStringMap(json['additives_classes']),
+      allergens: LanguageHelper.fromJsonStringMap(json['allergens']),
+      brioche: LanguageHelper.fromJsonStringMap(json['brioche']),
+      carbonFootprintFrFoodgesIngredient: LanguageHelper.fromJsonStringMap(
           json['carbon_footprint_fr_foodges_ingredient']),
-      LanguageHelper.fromJsonStringMap(
+      carbonFootprintFrFoodgesValue: LanguageHelper.fromJsonStringMap(
           json['carbon_footprint_fr_foodges_value']),
-      (json['children'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      LanguageHelper.fromJsonStringMap(json['ciqual_food_code']),
-      LanguageHelper.fromJsonStringMap(json['ciqual_food_name']),
-      LanguageHelper.fromJsonStringMap(json['colour_index']),
-      LanguageHelper.fromJsonStringMap(json['comment']),
-      LanguageHelper.fromJsonStringMap(json['default_additive_class']),
-      LanguageHelper.fromJsonStringMap(json['description']),
-      LanguageHelper.fromJsonStringMap(json['e_number']),
-      LanguageHelper.fromJsonStringMap(json['efsa']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation_adi']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation_adi_established']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation_date']),
-      LanguageHelper.fromJsonStringMap(
-          json['efsa_evaluation_exposure_95_th_greater_than_adi']),
-      LanguageHelper.fromJsonStringMap(
-          json['efsa_evaluation_exposure_95_th_greater_than_noael']),
-      LanguageHelper.fromJsonStringMap(
-          json['efsa_evaluation_exposure_mean_greater_than_adi']),
-      LanguageHelper.fromJsonStringMap(
-          json['efsa_evaluation_exposure_mean_greater_than_noael']),
-      LanguageHelper.fromJsonStringMap(
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      ciqualFoodCode:
+          LanguageHelper.fromJsonStringMap(json['ciqual_food_code']),
+      ciqualFoodName:
+          LanguageHelper.fromJsonStringMap(json['ciqual_food_name']),
+      colourIndex: LanguageHelper.fromJsonStringMap(json['colour_index']),
+      comment: LanguageHelper.fromJsonStringMap(json['comment']),
+      defaultAdditiveClass:
+          LanguageHelper.fromJsonStringMap(json['default_additive_class']),
+      description: LanguageHelper.fromJsonStringMap(json['description']),
+      eNumber: LanguageHelper.fromJsonStringMap(json['e_number']),
+      efsa: LanguageHelper.fromJsonStringMap(json['efsa']),
+      efsaEvaluation: LanguageHelper.fromJsonStringMap(json['efsa_evaluation']),
+      efsaEvaluationAdi:
+          LanguageHelper.fromJsonStringMap(json['efsa_evaluation_adi']),
+      efsaEvaluationAdiEstablished: LanguageHelper.fromJsonStringMap(
+          json['efsa_evaluation_adi_established']),
+      efsaEvaluationDate:
+          LanguageHelper.fromJsonStringMap(json['efsa_evaluation_date']),
+      efsaEvaluationExposure95ThGreaterThanAdi:
+          LanguageHelper.fromJsonStringMap(
+              json['efsa_evaluation_exposure_95_th_greater_than_adi']),
+      efsaEvaluationExposure95ThGreaterThanNoael:
+          LanguageHelper.fromJsonStringMap(
+              json['efsa_evaluation_exposure_95_th_greater_than_noael']),
+      efsaEvaluationExposureMeanGreaterThanAdi:
+          LanguageHelper.fromJsonStringMap(
+              json['efsa_evaluation_exposure_mean_greater_than_adi']),
+      efsaEvaluationExposureMeanGreaterThanNoael:
+          LanguageHelper.fromJsonStringMap(
+              json['efsa_evaluation_exposure_mean_greater_than_noael']),
+      efsaEvaluationOverexposureRisk: LanguageHelper.fromJsonStringMap(
           json['efsa_evaluation_overexposure_risk']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation_safety_assessed']),
-      LanguageHelper.fromJsonStringMap(json['efsa_evaluation_url']),
-      LanguageHelper.fromJsonStringMap(json['from_palm_oil']),
-      LanguageHelper.fromJsonStringMap(json['likely_allergens']),
-      LanguageHelper.fromJsonStringMap(json['mandatory_additive_class']),
-      LanguageHelper.fromJsonStringMap(json['name']),
-      LanguageHelper.fromJsonStringMap(json['nova']),
-      LanguageHelper.fromJsonStringMap(
+      efsaEvaluationSafetyAssessed: LanguageHelper.fromJsonStringMap(
+          json['efsa_evaluation_safety_assessed']),
+      efsaEvaluationUrl:
+          LanguageHelper.fromJsonStringMap(json['efsa_evaluation_url']),
+      fromPalmOil: LanguageHelper.fromJsonStringMap(json['from_palm_oil']),
+      likelyAllergens:
+          LanguageHelper.fromJsonStringMap(json['likely_allergens']),
+      mandatoryAdditiveClass:
+          LanguageHelper.fromJsonStringMap(json['mandatory_additive_class']),
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      nova: LanguageHelper.fromJsonStringMap(json['nova']),
+      nutriscoreFruitsVegetablesNuts: LanguageHelper.fromJsonStringMap(
           json['nutriscore_fruits_vegetables_nuts']),
-      LanguageHelper.fromJsonStringMap(json['organic_eu']),
-      LanguageHelper.fromJsonStringMap(json['origins']),
-      (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      LanguageHelper.fromJsonStringMap(json['pnns_group_2']),
-      LanguageHelper.fromJsonStringMap(json['protected_name_type']),
-      LanguageHelper.fromJsonStringMap(json['reblochon']),
-      LanguageHelper.fromJsonStringsListMap(json['synonyms']),
-      LanguageHelper.fromJsonStringMap(json['vegan']),
-      LanguageHelper.fromJsonStringMap(json['vegetarian']),
-      LanguageHelper.fromJsonStringMap(json['wikidata']),
-      LanguageHelper.fromJsonStringMap(json['wiktionary']),
+      organicEu: LanguageHelper.fromJsonStringMap(json['organic_eu']),
+      origins: LanguageHelper.fromJsonStringMap(json['origins']),
+      parents:
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      pnnsGroup2: LanguageHelper.fromJsonStringMap(json['pnns_group_2']),
+      protectedNameType:
+          LanguageHelper.fromJsonStringMap(json['protected_name_type']),
+      reblochon: LanguageHelper.fromJsonStringMap(json['reblochon']),
+      synonyms: LanguageHelper.fromJsonStringsListMap(json['synonyms']),
+      vegan: LanguageHelper.fromJsonStringMap(json['vegan']),
+      vegetarian: LanguageHelper.fromJsonStringMap(json['vegetarian']),
+      wikidata: LanguageHelper.fromJsonStringMap(json['wikidata']),
+      wiktionary: LanguageHelper.fromJsonStringMap(json['wiktionary']),
     );
 
 Map<String, dynamic> _$TaxonomyIngredientToJson(TaxonomyIngredient instance) {

--- a/lib/model/TaxonomyLabel.dart
+++ b/lib/model/TaxonomyLabel.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyLabel.g.dart';
 
@@ -52,9 +53,10 @@ enum TaxonomyLabelField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyLabel extends JsonObject {
-  TaxonomyLabel(
+  TaxonomyLabel({
     this.authAddress,
     this.authName,
     this.authUrl,
@@ -79,7 +81,7 @@ class TaxonomyLabel extends JsonObject {
     this.protectedNameType,
     this.stores,
     this.wikidata,
-  );
+  });
 
   factory TaxonomyLabel.fromJson(Map<String, dynamic> json) {
     return _$TaxonomyLabelFromJson(json);

--- a/lib/model/TaxonomyLabel.g.dart
+++ b/lib/model/TaxonomyLabel.g.dart
@@ -3,35 +3,381 @@
 part of 'TaxonomyLabel.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyLabelCWProxy {
+  TaxonomyLabel authAddress(Map<OpenFoodFactsLanguage, String>? authAddress);
+
+  TaxonomyLabel authName(Map<OpenFoodFactsLanguage, String>? authName);
+
+  TaxonomyLabel authUrl(Map<OpenFoodFactsLanguage, String>? authUrl);
+
+  TaxonomyLabel categories(Map<OpenFoodFactsLanguage, String>? categories);
+
+  TaxonomyLabel children(List<String>? children);
+
+  TaxonomyLabel countriesWhereSold(
+      Map<OpenFoodFactsLanguage, String>? countriesWhereSold);
+
+  TaxonomyLabel country(Map<OpenFoodFactsLanguage, String>? country);
+
+  TaxonomyLabel description(Map<OpenFoodFactsLanguage, String>? description);
+
+  TaxonomyLabel euGroups(Map<OpenFoodFactsLanguage, String>? euGroups);
+
+  TaxonomyLabel exceptions(Map<OpenFoodFactsLanguage, String>? exceptions);
+
+  TaxonomyLabel image(Map<OpenFoodFactsLanguage, String>? image);
+
+  TaxonomyLabel images(Map<OpenFoodFactsLanguage, String>? images);
+
+  TaxonomyLabel ingredients(Map<OpenFoodFactsLanguage, String>? ingredients);
+
+  TaxonomyLabel labelCategories(
+      Map<OpenFoodFactsLanguage, String>? labelCategories);
+
+  TaxonomyLabel manufacturingPlaces(
+      Map<OpenFoodFactsLanguage, String>? manufacturingPlaces);
+
+  TaxonomyLabel name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyLabel opposite(Map<OpenFoodFactsLanguage, String>? opposite);
+
+  TaxonomyLabel origins(Map<OpenFoodFactsLanguage, String>? origins);
+
+  TaxonomyLabel packaging(Map<OpenFoodFactsLanguage, String>? packaging);
+
+  TaxonomyLabel packagingPlaces(
+      Map<OpenFoodFactsLanguage, String>? packagingPlaces);
+
+  TaxonomyLabel parents(List<String>? parents);
+
+  TaxonomyLabel protectedNameType(
+      Map<OpenFoodFactsLanguage, String>? protectedNameType);
+
+  TaxonomyLabel stores(Map<OpenFoodFactsLanguage, String>? stores);
+
+  TaxonomyLabel wikidata(Map<OpenFoodFactsLanguage, String>? wikidata);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyLabel(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyLabel(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyLabel call({
+    Map<OpenFoodFactsLanguage, String>? authAddress,
+    Map<OpenFoodFactsLanguage, String>? authName,
+    Map<OpenFoodFactsLanguage, String>? authUrl,
+    Map<OpenFoodFactsLanguage, String>? categories,
+    List<String>? children,
+    Map<OpenFoodFactsLanguage, String>? countriesWhereSold,
+    Map<OpenFoodFactsLanguage, String>? country,
+    Map<OpenFoodFactsLanguage, String>? description,
+    Map<OpenFoodFactsLanguage, String>? euGroups,
+    Map<OpenFoodFactsLanguage, String>? exceptions,
+    Map<OpenFoodFactsLanguage, String>? image,
+    Map<OpenFoodFactsLanguage, String>? images,
+    Map<OpenFoodFactsLanguage, String>? ingredients,
+    Map<OpenFoodFactsLanguage, String>? labelCategories,
+    Map<OpenFoodFactsLanguage, String>? manufacturingPlaces,
+    Map<OpenFoodFactsLanguage, String>? name,
+    Map<OpenFoodFactsLanguage, String>? opposite,
+    Map<OpenFoodFactsLanguage, String>? origins,
+    Map<OpenFoodFactsLanguage, String>? packaging,
+    Map<OpenFoodFactsLanguage, String>? packagingPlaces,
+    List<String>? parents,
+    Map<OpenFoodFactsLanguage, String>? protectedNameType,
+    Map<OpenFoodFactsLanguage, String>? stores,
+    Map<OpenFoodFactsLanguage, String>? wikidata,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyLabel.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyLabel.copyWith.fieldName(...)`
+class _$TaxonomyLabelCWProxyImpl implements _$TaxonomyLabelCWProxy {
+  final TaxonomyLabel _value;
+
+  const _$TaxonomyLabelCWProxyImpl(this._value);
+
+  @override
+  TaxonomyLabel authAddress(Map<OpenFoodFactsLanguage, String>? authAddress) =>
+      this(authAddress: authAddress);
+
+  @override
+  TaxonomyLabel authName(Map<OpenFoodFactsLanguage, String>? authName) =>
+      this(authName: authName);
+
+  @override
+  TaxonomyLabel authUrl(Map<OpenFoodFactsLanguage, String>? authUrl) =>
+      this(authUrl: authUrl);
+
+  @override
+  TaxonomyLabel categories(Map<OpenFoodFactsLanguage, String>? categories) =>
+      this(categories: categories);
+
+  @override
+  TaxonomyLabel children(List<String>? children) => this(children: children);
+
+  @override
+  TaxonomyLabel countriesWhereSold(
+          Map<OpenFoodFactsLanguage, String>? countriesWhereSold) =>
+      this(countriesWhereSold: countriesWhereSold);
+
+  @override
+  TaxonomyLabel country(Map<OpenFoodFactsLanguage, String>? country) =>
+      this(country: country);
+
+  @override
+  TaxonomyLabel description(Map<OpenFoodFactsLanguage, String>? description) =>
+      this(description: description);
+
+  @override
+  TaxonomyLabel euGroups(Map<OpenFoodFactsLanguage, String>? euGroups) =>
+      this(euGroups: euGroups);
+
+  @override
+  TaxonomyLabel exceptions(Map<OpenFoodFactsLanguage, String>? exceptions) =>
+      this(exceptions: exceptions);
+
+  @override
+  TaxonomyLabel image(Map<OpenFoodFactsLanguage, String>? image) =>
+      this(image: image);
+
+  @override
+  TaxonomyLabel images(Map<OpenFoodFactsLanguage, String>? images) =>
+      this(images: images);
+
+  @override
+  TaxonomyLabel ingredients(Map<OpenFoodFactsLanguage, String>? ingredients) =>
+      this(ingredients: ingredients);
+
+  @override
+  TaxonomyLabel labelCategories(
+          Map<OpenFoodFactsLanguage, String>? labelCategories) =>
+      this(labelCategories: labelCategories);
+
+  @override
+  TaxonomyLabel manufacturingPlaces(
+          Map<OpenFoodFactsLanguage, String>? manufacturingPlaces) =>
+      this(manufacturingPlaces: manufacturingPlaces);
+
+  @override
+  TaxonomyLabel name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyLabel opposite(Map<OpenFoodFactsLanguage, String>? opposite) =>
+      this(opposite: opposite);
+
+  @override
+  TaxonomyLabel origins(Map<OpenFoodFactsLanguage, String>? origins) =>
+      this(origins: origins);
+
+  @override
+  TaxonomyLabel packaging(Map<OpenFoodFactsLanguage, String>? packaging) =>
+      this(packaging: packaging);
+
+  @override
+  TaxonomyLabel packagingPlaces(
+          Map<OpenFoodFactsLanguage, String>? packagingPlaces) =>
+      this(packagingPlaces: packagingPlaces);
+
+  @override
+  TaxonomyLabel parents(List<String>? parents) => this(parents: parents);
+
+  @override
+  TaxonomyLabel protectedNameType(
+          Map<OpenFoodFactsLanguage, String>? protectedNameType) =>
+      this(protectedNameType: protectedNameType);
+
+  @override
+  TaxonomyLabel stores(Map<OpenFoodFactsLanguage, String>? stores) =>
+      this(stores: stores);
+
+  @override
+  TaxonomyLabel wikidata(Map<OpenFoodFactsLanguage, String>? wikidata) =>
+      this(wikidata: wikidata);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyLabel(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyLabel(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyLabel call({
+    Object? authAddress = const $CopyWithPlaceholder(),
+    Object? authName = const $CopyWithPlaceholder(),
+    Object? authUrl = const $CopyWithPlaceholder(),
+    Object? categories = const $CopyWithPlaceholder(),
+    Object? children = const $CopyWithPlaceholder(),
+    Object? countriesWhereSold = const $CopyWithPlaceholder(),
+    Object? country = const $CopyWithPlaceholder(),
+    Object? description = const $CopyWithPlaceholder(),
+    Object? euGroups = const $CopyWithPlaceholder(),
+    Object? exceptions = const $CopyWithPlaceholder(),
+    Object? image = const $CopyWithPlaceholder(),
+    Object? images = const $CopyWithPlaceholder(),
+    Object? ingredients = const $CopyWithPlaceholder(),
+    Object? labelCategories = const $CopyWithPlaceholder(),
+    Object? manufacturingPlaces = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? opposite = const $CopyWithPlaceholder(),
+    Object? origins = const $CopyWithPlaceholder(),
+    Object? packaging = const $CopyWithPlaceholder(),
+    Object? packagingPlaces = const $CopyWithPlaceholder(),
+    Object? parents = const $CopyWithPlaceholder(),
+    Object? protectedNameType = const $CopyWithPlaceholder(),
+    Object? stores = const $CopyWithPlaceholder(),
+    Object? wikidata = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyLabel(
+      authAddress: authAddress == const $CopyWithPlaceholder()
+          ? _value.authAddress
+          // ignore: cast_nullable_to_non_nullable
+          : authAddress as Map<OpenFoodFactsLanguage, String>?,
+      authName: authName == const $CopyWithPlaceholder()
+          ? _value.authName
+          // ignore: cast_nullable_to_non_nullable
+          : authName as Map<OpenFoodFactsLanguage, String>?,
+      authUrl: authUrl == const $CopyWithPlaceholder()
+          ? _value.authUrl
+          // ignore: cast_nullable_to_non_nullable
+          : authUrl as Map<OpenFoodFactsLanguage, String>?,
+      categories: categories == const $CopyWithPlaceholder()
+          ? _value.categories
+          // ignore: cast_nullable_to_non_nullable
+          : categories as Map<OpenFoodFactsLanguage, String>?,
+      children: children == const $CopyWithPlaceholder()
+          ? _value.children
+          // ignore: cast_nullable_to_non_nullable
+          : children as List<String>?,
+      countriesWhereSold: countriesWhereSold == const $CopyWithPlaceholder()
+          ? _value.countriesWhereSold
+          // ignore: cast_nullable_to_non_nullable
+          : countriesWhereSold as Map<OpenFoodFactsLanguage, String>?,
+      country: country == const $CopyWithPlaceholder()
+          ? _value.country
+          // ignore: cast_nullable_to_non_nullable
+          : country as Map<OpenFoodFactsLanguage, String>?,
+      description: description == const $CopyWithPlaceholder()
+          ? _value.description
+          // ignore: cast_nullable_to_non_nullable
+          : description as Map<OpenFoodFactsLanguage, String>?,
+      euGroups: euGroups == const $CopyWithPlaceholder()
+          ? _value.euGroups
+          // ignore: cast_nullable_to_non_nullable
+          : euGroups as Map<OpenFoodFactsLanguage, String>?,
+      exceptions: exceptions == const $CopyWithPlaceholder()
+          ? _value.exceptions
+          // ignore: cast_nullable_to_non_nullable
+          : exceptions as Map<OpenFoodFactsLanguage, String>?,
+      image: image == const $CopyWithPlaceholder()
+          ? _value.image
+          // ignore: cast_nullable_to_non_nullable
+          : image as Map<OpenFoodFactsLanguage, String>?,
+      images: images == const $CopyWithPlaceholder()
+          ? _value.images
+          // ignore: cast_nullable_to_non_nullable
+          : images as Map<OpenFoodFactsLanguage, String>?,
+      ingredients: ingredients == const $CopyWithPlaceholder()
+          ? _value.ingredients
+          // ignore: cast_nullable_to_non_nullable
+          : ingredients as Map<OpenFoodFactsLanguage, String>?,
+      labelCategories: labelCategories == const $CopyWithPlaceholder()
+          ? _value.labelCategories
+          // ignore: cast_nullable_to_non_nullable
+          : labelCategories as Map<OpenFoodFactsLanguage, String>?,
+      manufacturingPlaces: manufacturingPlaces == const $CopyWithPlaceholder()
+          ? _value.manufacturingPlaces
+          // ignore: cast_nullable_to_non_nullable
+          : manufacturingPlaces as Map<OpenFoodFactsLanguage, String>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      opposite: opposite == const $CopyWithPlaceholder()
+          ? _value.opposite
+          // ignore: cast_nullable_to_non_nullable
+          : opposite as Map<OpenFoodFactsLanguage, String>?,
+      origins: origins == const $CopyWithPlaceholder()
+          ? _value.origins
+          // ignore: cast_nullable_to_non_nullable
+          : origins as Map<OpenFoodFactsLanguage, String>?,
+      packaging: packaging == const $CopyWithPlaceholder()
+          ? _value.packaging
+          // ignore: cast_nullable_to_non_nullable
+          : packaging as Map<OpenFoodFactsLanguage, String>?,
+      packagingPlaces: packagingPlaces == const $CopyWithPlaceholder()
+          ? _value.packagingPlaces
+          // ignore: cast_nullable_to_non_nullable
+          : packagingPlaces as Map<OpenFoodFactsLanguage, String>?,
+      parents: parents == const $CopyWithPlaceholder()
+          ? _value.parents
+          // ignore: cast_nullable_to_non_nullable
+          : parents as List<String>?,
+      protectedNameType: protectedNameType == const $CopyWithPlaceholder()
+          ? _value.protectedNameType
+          // ignore: cast_nullable_to_non_nullable
+          : protectedNameType as Map<OpenFoodFactsLanguage, String>?,
+      stores: stores == const $CopyWithPlaceholder()
+          ? _value.stores
+          // ignore: cast_nullable_to_non_nullable
+          : stores as Map<OpenFoodFactsLanguage, String>?,
+      wikidata: wikidata == const $CopyWithPlaceholder()
+          ? _value.wikidata
+          // ignore: cast_nullable_to_non_nullable
+          : wikidata as Map<OpenFoodFactsLanguage, String>?,
+    );
+  }
+}
+
+extension $TaxonomyLabelCopyWith on TaxonomyLabel {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyLabel.copyWith(...)` or like so:`instanceOfTaxonomyLabel.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyLabelCWProxy get copyWith => _$TaxonomyLabelCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyLabel _$TaxonomyLabelFromJson(Map<String, dynamic> json) =>
     TaxonomyLabel(
-      LanguageHelper.fromJsonStringMap(json['auth_address']),
-      LanguageHelper.fromJsonStringMap(json['auth_name']),
-      LanguageHelper.fromJsonStringMap(json['auth_url']),
-      LanguageHelper.fromJsonStringMap(json['categories']),
-      (json['children'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      LanguageHelper.fromJsonStringMap(json['countries_where_sold']),
-      LanguageHelper.fromJsonStringMap(json['country']),
-      LanguageHelper.fromJsonStringMap(json['description']),
-      LanguageHelper.fromJsonStringMap(json['eu_groups']),
-      LanguageHelper.fromJsonStringMap(json['exceptions']),
-      LanguageHelper.fromJsonStringMap(json['image']),
-      LanguageHelper.fromJsonStringMap(json['images']),
-      LanguageHelper.fromJsonStringMap(json['ingredients']),
-      LanguageHelper.fromJsonStringMap(json['label_categories']),
-      LanguageHelper.fromJsonStringMap(json['manufacturing_places']),
-      LanguageHelper.fromJsonStringMap(json['name']),
-      LanguageHelper.fromJsonStringMap(json['opposite']),
-      LanguageHelper.fromJsonStringMap(json['origins']),
-      LanguageHelper.fromJsonStringMap(json['packaging']),
-      LanguageHelper.fromJsonStringMap(json['packaging_places']),
-      (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      LanguageHelper.fromJsonStringMap(json['protected_name_type']),
-      LanguageHelper.fromJsonStringMap(json['stores']),
-      LanguageHelper.fromJsonStringMap(json['wikidata']),
+      authAddress: LanguageHelper.fromJsonStringMap(json['auth_address']),
+      authName: LanguageHelper.fromJsonStringMap(json['auth_name']),
+      authUrl: LanguageHelper.fromJsonStringMap(json['auth_url']),
+      categories: LanguageHelper.fromJsonStringMap(json['categories']),
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      countriesWhereSold:
+          LanguageHelper.fromJsonStringMap(json['countries_where_sold']),
+      country: LanguageHelper.fromJsonStringMap(json['country']),
+      description: LanguageHelper.fromJsonStringMap(json['description']),
+      euGroups: LanguageHelper.fromJsonStringMap(json['eu_groups']),
+      exceptions: LanguageHelper.fromJsonStringMap(json['exceptions']),
+      image: LanguageHelper.fromJsonStringMap(json['image']),
+      images: LanguageHelper.fromJsonStringMap(json['images']),
+      ingredients: LanguageHelper.fromJsonStringMap(json['ingredients']),
+      labelCategories:
+          LanguageHelper.fromJsonStringMap(json['label_categories']),
+      manufacturingPlaces:
+          LanguageHelper.fromJsonStringMap(json['manufacturing_places']),
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      opposite: LanguageHelper.fromJsonStringMap(json['opposite']),
+      origins: LanguageHelper.fromJsonStringMap(json['origins']),
+      packaging: LanguageHelper.fromJsonStringMap(json['packaging']),
+      packagingPlaces:
+          LanguageHelper.fromJsonStringMap(json['packaging_places']),
+      parents:
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      protectedNameType:
+          LanguageHelper.fromJsonStringMap(json['protected_name_type']),
+      stores: LanguageHelper.fromJsonStringMap(json['stores']),
+      wikidata: LanguageHelper.fromJsonStringMap(json['wikidata']),
     );
 
 Map<String, dynamic> _$TaxonomyLabelToJson(TaxonomyLabel instance) {

--- a/lib/model/TaxonomyLanguage.dart
+++ b/lib/model/TaxonomyLanguage.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyLanguage.g.dart';
 
@@ -32,14 +33,15 @@ enum TaxonomyLanguageField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyLanguage extends JsonObject {
-  TaxonomyLanguage(
+  TaxonomyLanguage({
     this.languageCode2,
     this.languageCode3,
     this.name,
     this.wikidata,
-  );
+  });
 
   factory TaxonomyLanguage.fromJson(Map<String, dynamic> json) {
     return _$TaxonomyLanguageFromJson(json);

--- a/lib/model/TaxonomyLanguage.g.dart
+++ b/lib/model/TaxonomyLanguage.g.dart
@@ -3,15 +3,109 @@
 part of 'TaxonomyLanguage.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyLanguageCWProxy {
+  TaxonomyLanguage languageCode2(
+      Map<OpenFoodFactsLanguage, String>? languageCode2);
+
+  TaxonomyLanguage languageCode3(
+      Map<OpenFoodFactsLanguage, String>? languageCode3);
+
+  TaxonomyLanguage name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyLanguage wikidata(Map<OpenFoodFactsLanguage, String>? wikidata);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyLanguage(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyLanguage(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyLanguage call({
+    Map<OpenFoodFactsLanguage, String>? languageCode2,
+    Map<OpenFoodFactsLanguage, String>? languageCode3,
+    Map<OpenFoodFactsLanguage, String>? name,
+    Map<OpenFoodFactsLanguage, String>? wikidata,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyLanguage.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyLanguage.copyWith.fieldName(...)`
+class _$TaxonomyLanguageCWProxyImpl implements _$TaxonomyLanguageCWProxy {
+  final TaxonomyLanguage _value;
+
+  const _$TaxonomyLanguageCWProxyImpl(this._value);
+
+  @override
+  TaxonomyLanguage languageCode2(
+          Map<OpenFoodFactsLanguage, String>? languageCode2) =>
+      this(languageCode2: languageCode2);
+
+  @override
+  TaxonomyLanguage languageCode3(
+          Map<OpenFoodFactsLanguage, String>? languageCode3) =>
+      this(languageCode3: languageCode3);
+
+  @override
+  TaxonomyLanguage name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyLanguage wikidata(Map<OpenFoodFactsLanguage, String>? wikidata) =>
+      this(wikidata: wikidata);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyLanguage(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyLanguage(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyLanguage call({
+    Object? languageCode2 = const $CopyWithPlaceholder(),
+    Object? languageCode3 = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? wikidata = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyLanguage(
+      languageCode2: languageCode2 == const $CopyWithPlaceholder()
+          ? _value.languageCode2
+          // ignore: cast_nullable_to_non_nullable
+          : languageCode2 as Map<OpenFoodFactsLanguage, String>?,
+      languageCode3: languageCode3 == const $CopyWithPlaceholder()
+          ? _value.languageCode3
+          // ignore: cast_nullable_to_non_nullable
+          : languageCode3 as Map<OpenFoodFactsLanguage, String>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      wikidata: wikidata == const $CopyWithPlaceholder()
+          ? _value.wikidata
+          // ignore: cast_nullable_to_non_nullable
+          : wikidata as Map<OpenFoodFactsLanguage, String>?,
+    );
+  }
+}
+
+extension $TaxonomyLanguageCopyWith on TaxonomyLanguage {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyLanguage.copyWith(...)` or like so:`instanceOfTaxonomyLanguage.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyLanguageCWProxy get copyWith => _$TaxonomyLanguageCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyLanguage _$TaxonomyLanguageFromJson(Map<String, dynamic> json) =>
     TaxonomyLanguage(
-      LanguageHelper.fromJsonStringMap(json['language_code_2']),
-      LanguageHelper.fromJsonStringMap(json['language_code_3']),
-      LanguageHelper.fromJsonStringMap(json['name']),
-      LanguageHelper.fromJsonStringMap(json['wikidata']),
+      languageCode2: LanguageHelper.fromJsonStringMap(json['language_code_2']),
+      languageCode3: LanguageHelper.fromJsonStringMap(json['language_code_3']),
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      wikidata: LanguageHelper.fromJsonStringMap(json['wikidata']),
     );
 
 Map<String, dynamic> _$TaxonomyLanguageToJson(TaxonomyLanguage instance) {

--- a/lib/model/TaxonomyOrigin.dart
+++ b/lib/model/TaxonomyOrigin.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyOrigin.g.dart';
 
@@ -26,9 +27,15 @@ enum TaxonomyOriginField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyOrigin extends JsonObject {
-  TaxonomyOrigin();
+  TaxonomyOrigin({
+    this.name,
+    this.synonyms,
+    this.children,
+    this.parents,
+  });
 
   factory TaxonomyOrigin.fromJson(Map<String, dynamic> json) =>
       _$TaxonomyOriginFromJson(json);

--- a/lib/model/TaxonomyOrigin.g.dart
+++ b/lib/model/TaxonomyOrigin.g.dart
@@ -3,17 +3,107 @@
 part of 'TaxonomyOrigin.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyOriginCWProxy {
+  TaxonomyOrigin children(List<String>? children);
+
+  TaxonomyOrigin name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyOrigin parents(List<String>? parents);
+
+  TaxonomyOrigin synonyms(Map<OpenFoodFactsLanguage, List<String>>? synonyms);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyOrigin(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyOrigin(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyOrigin call({
+    List<String>? children,
+    Map<OpenFoodFactsLanguage, String>? name,
+    List<String>? parents,
+    Map<OpenFoodFactsLanguage, List<String>>? synonyms,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyOrigin.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyOrigin.copyWith.fieldName(...)`
+class _$TaxonomyOriginCWProxyImpl implements _$TaxonomyOriginCWProxy {
+  final TaxonomyOrigin _value;
+
+  const _$TaxonomyOriginCWProxyImpl(this._value);
+
+  @override
+  TaxonomyOrigin children(List<String>? children) => this(children: children);
+
+  @override
+  TaxonomyOrigin name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyOrigin parents(List<String>? parents) => this(parents: parents);
+
+  @override
+  TaxonomyOrigin synonyms(Map<OpenFoodFactsLanguage, List<String>>? synonyms) =>
+      this(synonyms: synonyms);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyOrigin(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyOrigin(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyOrigin call({
+    Object? children = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? parents = const $CopyWithPlaceholder(),
+    Object? synonyms = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyOrigin(
+      children: children == const $CopyWithPlaceholder()
+          ? _value.children
+          // ignore: cast_nullable_to_non_nullable
+          : children as List<String>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      parents: parents == const $CopyWithPlaceholder()
+          ? _value.parents
+          // ignore: cast_nullable_to_non_nullable
+          : parents as List<String>?,
+      synonyms: synonyms == const $CopyWithPlaceholder()
+          ? _value.synonyms
+          // ignore: cast_nullable_to_non_nullable
+          : synonyms as Map<OpenFoodFactsLanguage, List<String>>?,
+    );
+  }
+}
+
+extension $TaxonomyOriginCopyWith on TaxonomyOrigin {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyOrigin.copyWith(...)` or like so:`instanceOfTaxonomyOrigin.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyOriginCWProxy get copyWith => _$TaxonomyOriginCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyOrigin _$TaxonomyOriginFromJson(Map<String, dynamic> json) =>
-    TaxonomyOrigin()
-      ..name = LanguageHelper.fromJsonStringMap(json['name'])
-      ..synonyms = LanguageHelper.fromJsonStringMapList(json['synonyms'])
-      ..children =
-          (json['children'] as List<dynamic>?)?.map((e) => e as String).toList()
-      ..parents =
-          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList();
+    TaxonomyOrigin(
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      synonyms: LanguageHelper.fromJsonStringMapList(json['synonyms']),
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      parents:
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
+    );
 
 Map<String, dynamic> _$TaxonomyOriginToJson(TaxonomyOrigin instance) {
   final val = <String, dynamic>{};

--- a/lib/model/TaxonomyPackaging.dart
+++ b/lib/model/TaxonomyPackaging.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyPackaging.g.dart';
 
@@ -41,9 +42,16 @@ enum TaxonomyPackagingField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyPackaging extends JsonObject {
-  TaxonomyPackaging();
+  TaxonomyPackaging({
+    this.name,
+    this.synonyms,
+    this.wikidata,
+    this.children,
+    this.parents,
+  });
 
   factory TaxonomyPackaging.fromJson(Map<String, dynamic> json) =>
       _$TaxonomyPackagingFromJson(json);

--- a/lib/model/TaxonomyPackaging.g.dart
+++ b/lib/model/TaxonomyPackaging.g.dart
@@ -3,18 +3,124 @@
 part of 'TaxonomyPackaging.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyPackagingCWProxy {
+  TaxonomyPackaging children(List<String>? children);
+
+  TaxonomyPackaging name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyPackaging parents(List<String>? parents);
+
+  TaxonomyPackaging synonyms(
+      Map<OpenFoodFactsLanguage, List<String>>? synonyms);
+
+  TaxonomyPackaging wikidata(Map<OpenFoodFactsLanguage, String>? wikidata);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyPackaging(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyPackaging(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyPackaging call({
+    List<String>? children,
+    Map<OpenFoodFactsLanguage, String>? name,
+    List<String>? parents,
+    Map<OpenFoodFactsLanguage, List<String>>? synonyms,
+    Map<OpenFoodFactsLanguage, String>? wikidata,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyPackaging.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyPackaging.copyWith.fieldName(...)`
+class _$TaxonomyPackagingCWProxyImpl implements _$TaxonomyPackagingCWProxy {
+  final TaxonomyPackaging _value;
+
+  const _$TaxonomyPackagingCWProxyImpl(this._value);
+
+  @override
+  TaxonomyPackaging children(List<String>? children) =>
+      this(children: children);
+
+  @override
+  TaxonomyPackaging name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyPackaging parents(List<String>? parents) => this(parents: parents);
+
+  @override
+  TaxonomyPackaging synonyms(
+          Map<OpenFoodFactsLanguage, List<String>>? synonyms) =>
+      this(synonyms: synonyms);
+
+  @override
+  TaxonomyPackaging wikidata(Map<OpenFoodFactsLanguage, String>? wikidata) =>
+      this(wikidata: wikidata);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyPackaging(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyPackaging(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyPackaging call({
+    Object? children = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? parents = const $CopyWithPlaceholder(),
+    Object? synonyms = const $CopyWithPlaceholder(),
+    Object? wikidata = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyPackaging(
+      children: children == const $CopyWithPlaceholder()
+          ? _value.children
+          // ignore: cast_nullable_to_non_nullable
+          : children as List<String>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      parents: parents == const $CopyWithPlaceholder()
+          ? _value.parents
+          // ignore: cast_nullable_to_non_nullable
+          : parents as List<String>?,
+      synonyms: synonyms == const $CopyWithPlaceholder()
+          ? _value.synonyms
+          // ignore: cast_nullable_to_non_nullable
+          : synonyms as Map<OpenFoodFactsLanguage, List<String>>?,
+      wikidata: wikidata == const $CopyWithPlaceholder()
+          ? _value.wikidata
+          // ignore: cast_nullable_to_non_nullable
+          : wikidata as Map<OpenFoodFactsLanguage, String>?,
+    );
+  }
+}
+
+extension $TaxonomyPackagingCopyWith on TaxonomyPackaging {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyPackaging.copyWith(...)` or like so:`instanceOfTaxonomyPackaging.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyPackagingCWProxy get copyWith =>
+      _$TaxonomyPackagingCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyPackaging _$TaxonomyPackagingFromJson(Map<String, dynamic> json) =>
-    TaxonomyPackaging()
-      ..name = LanguageHelper.fromJsonStringMap(json['name'])
-      ..synonyms = LanguageHelper.fromJsonStringsListMap(json['synonyms'])
-      ..wikidata = LanguageHelper.fromJsonStringMap(json['wikidata'])
-      ..children =
-          (json['children'] as List<dynamic>?)?.map((e) => e as String).toList()
-      ..parents =
-          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList();
+    TaxonomyPackaging(
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      synonyms: LanguageHelper.fromJsonStringsListMap(json['synonyms']),
+      wikidata: LanguageHelper.fromJsonStringMap(json['wikidata']),
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      parents:
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
+    );
 
 Map<String, dynamic> _$TaxonomyPackagingToJson(TaxonomyPackaging instance) {
   final val = <String, dynamic>{};

--- a/lib/model/TaxonomyPackagingMaterial.dart
+++ b/lib/model/TaxonomyPackagingMaterial.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyPackagingMaterial.g.dart';
 
@@ -26,9 +27,15 @@ enum TaxonomyPackagingMaterialField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyPackagingMaterial extends JsonObject {
-  TaxonomyPackagingMaterial();
+  TaxonomyPackagingMaterial({
+    this.name,
+    this.synonyms,
+    this.children,
+    this.parents,
+  });
 
   factory TaxonomyPackagingMaterial.fromJson(Map<String, dynamic> json) =>
       _$TaxonomyPackagingMaterialFromJson(json);

--- a/lib/model/TaxonomyPackagingMaterial.g.dart
+++ b/lib/model/TaxonomyPackagingMaterial.g.dart
@@ -3,18 +3,114 @@
 part of 'TaxonomyPackagingMaterial.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyPackagingMaterialCWProxy {
+  TaxonomyPackagingMaterial children(List<String>? children);
+
+  TaxonomyPackagingMaterial name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyPackagingMaterial parents(List<String>? parents);
+
+  TaxonomyPackagingMaterial synonyms(
+      Map<OpenFoodFactsLanguage, List<String>>? synonyms);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyPackagingMaterial(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyPackagingMaterial(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyPackagingMaterial call({
+    List<String>? children,
+    Map<OpenFoodFactsLanguage, String>? name,
+    List<String>? parents,
+    Map<OpenFoodFactsLanguage, List<String>>? synonyms,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyPackagingMaterial.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyPackagingMaterial.copyWith.fieldName(...)`
+class _$TaxonomyPackagingMaterialCWProxyImpl
+    implements _$TaxonomyPackagingMaterialCWProxy {
+  final TaxonomyPackagingMaterial _value;
+
+  const _$TaxonomyPackagingMaterialCWProxyImpl(this._value);
+
+  @override
+  TaxonomyPackagingMaterial children(List<String>? children) =>
+      this(children: children);
+
+  @override
+  TaxonomyPackagingMaterial name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyPackagingMaterial parents(List<String>? parents) =>
+      this(parents: parents);
+
+  @override
+  TaxonomyPackagingMaterial synonyms(
+          Map<OpenFoodFactsLanguage, List<String>>? synonyms) =>
+      this(synonyms: synonyms);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyPackagingMaterial(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyPackagingMaterial(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyPackagingMaterial call({
+    Object? children = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? parents = const $CopyWithPlaceholder(),
+    Object? synonyms = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyPackagingMaterial(
+      children: children == const $CopyWithPlaceholder()
+          ? _value.children
+          // ignore: cast_nullable_to_non_nullable
+          : children as List<String>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      parents: parents == const $CopyWithPlaceholder()
+          ? _value.parents
+          // ignore: cast_nullable_to_non_nullable
+          : parents as List<String>?,
+      synonyms: synonyms == const $CopyWithPlaceholder()
+          ? _value.synonyms
+          // ignore: cast_nullable_to_non_nullable
+          : synonyms as Map<OpenFoodFactsLanguage, List<String>>?,
+    );
+  }
+}
+
+extension $TaxonomyPackagingMaterialCopyWith on TaxonomyPackagingMaterial {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyPackagingMaterial.copyWith(...)` or like so:`instanceOfTaxonomyPackagingMaterial.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyPackagingMaterialCWProxy get copyWith =>
+      _$TaxonomyPackagingMaterialCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyPackagingMaterial _$TaxonomyPackagingMaterialFromJson(
         Map<String, dynamic> json) =>
-    TaxonomyPackagingMaterial()
-      ..name = LanguageHelper.fromJsonStringMap(json['name'])
-      ..synonyms = LanguageHelper.fromJsonStringMapList(json['synonyms'])
-      ..children =
-          (json['children'] as List<dynamic>?)?.map((e) => e as String).toList()
-      ..parents =
-          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList();
+    TaxonomyPackagingMaterial(
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      synonyms: LanguageHelper.fromJsonStringMapList(json['synonyms']),
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      parents:
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
+    );
 
 Map<String, dynamic> _$TaxonomyPackagingMaterialToJson(
     TaxonomyPackagingMaterial instance) {

--- a/lib/model/TaxonomyPackagingRecycling.dart
+++ b/lib/model/TaxonomyPackagingRecycling.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyPackagingRecycling.g.dart';
 
@@ -28,9 +29,17 @@ enum TaxonomyPackagingRecyclingField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyPackagingRecycling extends JsonObject {
-  TaxonomyPackagingRecycling();
+  TaxonomyPackagingRecycling({
+    this.name,
+    this.synonyms,
+    this.shape,
+    this.material,
+    this.children,
+    this.parents,
+  });
 
   factory TaxonomyPackagingRecycling.fromJson(Map<String, dynamic> json) =>
       _$TaxonomyPackagingRecyclingFromJson(json);

--- a/lib/model/TaxonomyPackagingRecycling.g.dart
+++ b/lib/model/TaxonomyPackagingRecycling.g.dart
@@ -3,20 +3,142 @@
 part of 'TaxonomyPackagingRecycling.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyPackagingRecyclingCWProxy {
+  TaxonomyPackagingRecycling children(List<String>? children);
+
+  TaxonomyPackagingRecycling material(
+      Map<OpenFoodFactsLanguage, String>? material);
+
+  TaxonomyPackagingRecycling name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyPackagingRecycling parents(List<String>? parents);
+
+  TaxonomyPackagingRecycling shape(Map<OpenFoodFactsLanguage, String>? shape);
+
+  TaxonomyPackagingRecycling synonyms(
+      Map<OpenFoodFactsLanguage, List<String>>? synonyms);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyPackagingRecycling(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyPackagingRecycling(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyPackagingRecycling call({
+    List<String>? children,
+    Map<OpenFoodFactsLanguage, String>? material,
+    Map<OpenFoodFactsLanguage, String>? name,
+    List<String>? parents,
+    Map<OpenFoodFactsLanguage, String>? shape,
+    Map<OpenFoodFactsLanguage, List<String>>? synonyms,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyPackagingRecycling.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyPackagingRecycling.copyWith.fieldName(...)`
+class _$TaxonomyPackagingRecyclingCWProxyImpl
+    implements _$TaxonomyPackagingRecyclingCWProxy {
+  final TaxonomyPackagingRecycling _value;
+
+  const _$TaxonomyPackagingRecyclingCWProxyImpl(this._value);
+
+  @override
+  TaxonomyPackagingRecycling children(List<String>? children) =>
+      this(children: children);
+
+  @override
+  TaxonomyPackagingRecycling material(
+          Map<OpenFoodFactsLanguage, String>? material) =>
+      this(material: material);
+
+  @override
+  TaxonomyPackagingRecycling name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyPackagingRecycling parents(List<String>? parents) =>
+      this(parents: parents);
+
+  @override
+  TaxonomyPackagingRecycling shape(Map<OpenFoodFactsLanguage, String>? shape) =>
+      this(shape: shape);
+
+  @override
+  TaxonomyPackagingRecycling synonyms(
+          Map<OpenFoodFactsLanguage, List<String>>? synonyms) =>
+      this(synonyms: synonyms);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyPackagingRecycling(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyPackagingRecycling(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyPackagingRecycling call({
+    Object? children = const $CopyWithPlaceholder(),
+    Object? material = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? parents = const $CopyWithPlaceholder(),
+    Object? shape = const $CopyWithPlaceholder(),
+    Object? synonyms = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyPackagingRecycling(
+      children: children == const $CopyWithPlaceholder()
+          ? _value.children
+          // ignore: cast_nullable_to_non_nullable
+          : children as List<String>?,
+      material: material == const $CopyWithPlaceholder()
+          ? _value.material
+          // ignore: cast_nullable_to_non_nullable
+          : material as Map<OpenFoodFactsLanguage, String>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      parents: parents == const $CopyWithPlaceholder()
+          ? _value.parents
+          // ignore: cast_nullable_to_non_nullable
+          : parents as List<String>?,
+      shape: shape == const $CopyWithPlaceholder()
+          ? _value.shape
+          // ignore: cast_nullable_to_non_nullable
+          : shape as Map<OpenFoodFactsLanguage, String>?,
+      synonyms: synonyms == const $CopyWithPlaceholder()
+          ? _value.synonyms
+          // ignore: cast_nullable_to_non_nullable
+          : synonyms as Map<OpenFoodFactsLanguage, List<String>>?,
+    );
+  }
+}
+
+extension $TaxonomyPackagingRecyclingCopyWith on TaxonomyPackagingRecycling {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyPackagingRecycling.copyWith(...)` or like so:`instanceOfTaxonomyPackagingRecycling.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyPackagingRecyclingCWProxy get copyWith =>
+      _$TaxonomyPackagingRecyclingCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyPackagingRecycling _$TaxonomyPackagingRecyclingFromJson(
         Map<String, dynamic> json) =>
-    TaxonomyPackagingRecycling()
-      ..name = LanguageHelper.fromJsonStringMap(json['name'])
-      ..synonyms = LanguageHelper.fromJsonStringMapList(json['synonyms'])
-      ..shape = LanguageHelper.fromJsonStringMap(json['shape'])
-      ..material = LanguageHelper.fromJsonStringMap(json['material'])
-      ..children =
-          (json['children'] as List<dynamic>?)?.map((e) => e as String).toList()
-      ..parents =
-          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList();
+    TaxonomyPackagingRecycling(
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      synonyms: LanguageHelper.fromJsonStringMapList(json['synonyms']),
+      shape: LanguageHelper.fromJsonStringMap(json['shape']),
+      material: LanguageHelper.fromJsonStringMap(json['material']),
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      parents:
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
+    );
 
 Map<String, dynamic> _$TaxonomyPackagingRecyclingToJson(
     TaxonomyPackagingRecycling instance) {

--- a/lib/model/TaxonomyPackagingShape.dart
+++ b/lib/model/TaxonomyPackagingShape.dart
@@ -1,10 +1,11 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:openfoodfacts/interface/JsonObject.dart';
 import 'package:openfoodfacts/model/OffTagged.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:openfoodfacts/utils/TaxonomyQueryConfiguration.dart';
 
 part 'TaxonomyPackagingShape.g.dart';
 
@@ -26,9 +27,15 @@ enum TaxonomyPackagingShapeField implements OffTagged {
 ///
 /// See [OpenFoodAPIClient.getTaxonomy] for more details on how to retrieve one
 /// of these.
+@CopyWith()
 @JsonSerializable()
 class TaxonomyPackagingShape extends JsonObject {
-  TaxonomyPackagingShape();
+  TaxonomyPackagingShape({
+    this.name,
+    this.synonyms,
+    this.children,
+    this.parents,
+  });
 
   factory TaxonomyPackagingShape.fromJson(Map<String, dynamic> json) =>
       _$TaxonomyPackagingShapeFromJson(json);

--- a/lib/model/TaxonomyPackagingShape.g.dart
+++ b/lib/model/TaxonomyPackagingShape.g.dart
@@ -3,18 +3,114 @@
 part of 'TaxonomyPackagingShape.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$TaxonomyPackagingShapeCWProxy {
+  TaxonomyPackagingShape children(List<String>? children);
+
+  TaxonomyPackagingShape name(Map<OpenFoodFactsLanguage, String>? name);
+
+  TaxonomyPackagingShape parents(List<String>? parents);
+
+  TaxonomyPackagingShape synonyms(
+      Map<OpenFoodFactsLanguage, List<String>>? synonyms);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyPackagingShape(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyPackagingShape(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyPackagingShape call({
+    List<String>? children,
+    Map<OpenFoodFactsLanguage, String>? name,
+    List<String>? parents,
+    Map<OpenFoodFactsLanguage, List<String>>? synonyms,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfTaxonomyPackagingShape.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfTaxonomyPackagingShape.copyWith.fieldName(...)`
+class _$TaxonomyPackagingShapeCWProxyImpl
+    implements _$TaxonomyPackagingShapeCWProxy {
+  final TaxonomyPackagingShape _value;
+
+  const _$TaxonomyPackagingShapeCWProxyImpl(this._value);
+
+  @override
+  TaxonomyPackagingShape children(List<String>? children) =>
+      this(children: children);
+
+  @override
+  TaxonomyPackagingShape name(Map<OpenFoodFactsLanguage, String>? name) =>
+      this(name: name);
+
+  @override
+  TaxonomyPackagingShape parents(List<String>? parents) =>
+      this(parents: parents);
+
+  @override
+  TaxonomyPackagingShape synonyms(
+          Map<OpenFoodFactsLanguage, List<String>>? synonyms) =>
+      this(synonyms: synonyms);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `TaxonomyPackagingShape(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// TaxonomyPackagingShape(...).copyWith(id: 12, name: "My name")
+  /// ````
+  TaxonomyPackagingShape call({
+    Object? children = const $CopyWithPlaceholder(),
+    Object? name = const $CopyWithPlaceholder(),
+    Object? parents = const $CopyWithPlaceholder(),
+    Object? synonyms = const $CopyWithPlaceholder(),
+  }) {
+    return TaxonomyPackagingShape(
+      children: children == const $CopyWithPlaceholder()
+          ? _value.children
+          // ignore: cast_nullable_to_non_nullable
+          : children as List<String>?,
+      name: name == const $CopyWithPlaceholder()
+          ? _value.name
+          // ignore: cast_nullable_to_non_nullable
+          : name as Map<OpenFoodFactsLanguage, String>?,
+      parents: parents == const $CopyWithPlaceholder()
+          ? _value.parents
+          // ignore: cast_nullable_to_non_nullable
+          : parents as List<String>?,
+      synonyms: synonyms == const $CopyWithPlaceholder()
+          ? _value.synonyms
+          // ignore: cast_nullable_to_non_nullable
+          : synonyms as Map<OpenFoodFactsLanguage, List<String>>?,
+    );
+  }
+}
+
+extension $TaxonomyPackagingShapeCopyWith on TaxonomyPackagingShape {
+  /// Returns a callable class that can be used as follows: `instanceOfTaxonomyPackagingShape.copyWith(...)` or like so:`instanceOfTaxonomyPackagingShape.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$TaxonomyPackagingShapeCWProxy get copyWith =>
+      _$TaxonomyPackagingShapeCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 TaxonomyPackagingShape _$TaxonomyPackagingShapeFromJson(
         Map<String, dynamic> json) =>
-    TaxonomyPackagingShape()
-      ..name = LanguageHelper.fromJsonStringMap(json['name'])
-      ..synonyms = LanguageHelper.fromJsonStringMapList(json['synonyms'])
-      ..children =
-          (json['children'] as List<dynamic>?)?.map((e) => e as String).toList()
-      ..parents =
-          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList();
+    TaxonomyPackagingShape(
+      name: LanguageHelper.fromJsonStringMap(json['name']),
+      synonyms: LanguageHelper.fromJsonStringMapList(json['synonyms']),
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      parents:
+          (json['parents'] as List<dynamic>?)?.map((e) => e as String).toList(),
+    );
 
 Map<String, dynamic> _$TaxonomyPackagingShapeToJson(
     TaxonomyPackagingShape instance) {

--- a/lib/model/User.dart
+++ b/lib/model/User.dart
@@ -1,8 +1,11 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
+
 import '../interface/JsonObject.dart';
 
 part 'User.g.dart';
 
+@CopyWith()
 @JsonSerializable()
 class User extends JsonObject {
   @JsonKey(includeIfNull: false)

--- a/lib/model/User.g.dart
+++ b/lib/model/User.g.dart
@@ -3,6 +3,81 @@
 part of 'User.dart';
 
 // **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$UserCWProxy {
+  User comment(String? comment);
+
+  User password(String password);
+
+  User userId(String userId);
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `User(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// User(...).copyWith(id: 12, name: "My name")
+  /// ````
+  User call({
+    String? comment,
+    String? password,
+    String? userId,
+  });
+}
+
+/// Proxy class for `copyWith` functionality. This is a callable class and can be used as follows: `instanceOfUser.copyWith(...)`. Additionally contains functions for specific fields e.g. `instanceOfUser.copyWith.fieldName(...)`
+class _$UserCWProxyImpl implements _$UserCWProxy {
+  final User _value;
+
+  const _$UserCWProxyImpl(this._value);
+
+  @override
+  User comment(String? comment) => this(comment: comment);
+
+  @override
+  User password(String password) => this(password: password);
+
+  @override
+  User userId(String userId) => this(userId: userId);
+
+  @override
+
+  /// This function **does support** nullification of nullable fields. All `null` values passed to `non-nullable` fields will be ignored. You can also use `User(...).copyWith.fieldName(...)` to override fields one at a time with nullification support.
+  ///
+  /// Usage
+  /// ```dart
+  /// User(...).copyWith(id: 12, name: "My name")
+  /// ````
+  User call({
+    Object? comment = const $CopyWithPlaceholder(),
+    Object? password = const $CopyWithPlaceholder(),
+    Object? userId = const $CopyWithPlaceholder(),
+  }) {
+    return User(
+      comment: comment == const $CopyWithPlaceholder()
+          ? _value.comment
+          // ignore: cast_nullable_to_non_nullable
+          : comment as String?,
+      password: password == const $CopyWithPlaceholder() || password == null
+          ? _value.password
+          // ignore: cast_nullable_to_non_nullable
+          : password as String,
+      userId: userId == const $CopyWithPlaceholder() || userId == null
+          ? _value.userId
+          // ignore: cast_nullable_to_non_nullable
+          : userId as String,
+    );
+  }
+}
+
+extension $UserCopyWith on User {
+  /// Returns a callable class that can be used as follows: `instanceOfUser.copyWith(...)` or like so:`instanceOfUser.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$UserCWProxy get copyWith => _$UserCWProxyImpl(this);
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   path: ^1.8.2
   image: ^3.2.0
   meta: ^1.8.0
+  copy_with_extension: ^4.0.4
 
 dev_dependencies:
   analyzer: ">=4.0.0 <5.0.0"
@@ -21,6 +22,7 @@ dev_dependencies:
   lints: ^2.0.0
   test: ^1.21.4
   coverage: ^1.3.2
+  copy_with_extension_gen: ^4.0.4
 
 funding:
   - "https://donate.openfoodfacts.org/"


### PR DESCRIPTION
### What
Adds copyWith methods to all JsonSerializable models we have

My first try was to use [freezed](https://pub.dev/packages/freezed) as this can add a copyWith method to JsonSerializable but because we have a lot of customization around languages and so on I decided to go for this simpler method.

For most classes it was just adding a `@CopyWith()` decorator others needed a change in the constructor to use named parameter.


I added it to all classes in a first run, if there are some were we don't need it I'am happy to remove them


### For
https://github.com/openfoodfacts/smooth-app/pull/3059
https://github.com/openfoodfacts/smooth-app/issues/3263
...
