### PR TITLE
fix: #223 - deprecated method getIngredientSpellingCorrection

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -720,6 +720,7 @@ class OpenFoodAPIClient {
     return Status.fromApiResponse(response.body);
   }
 
+  // TODO: deprecated from 2022-11-22; remove when old enough
   @Deprecated('Unstable version, do not use and wait for the next version')
   static Future<SpellingCorrection?> getIngredientSpellingCorrection({
     String? ingredientName,

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -720,6 +720,7 @@ class OpenFoodAPIClient {
     return Status.fromApiResponse(response.body);
   }
 
+  @Deprecated('Unstable version, do not use and wait for the next version')
   static Future<SpellingCorrection?> getIngredientSpellingCorrection({
     String? ingredientName,
     Product? product,

--- a/test/api_getRobotoff_test.dart
+++ b/test/api_getRobotoff_test.dart
@@ -147,20 +147,4 @@ void main() {
       expect(result.insights, isNull);
     });
   });
-
-  group('$OpenFoodAPIClient get robotoff ingredient spelling corrections', () {
-    test('get farine de blé spelling corrections', () async {
-      final SpellingCorrection? result =
-          await OpenFoodAPIClient.getIngredientSpellingCorrection(
-        user: TestConstants.TEST_USER,
-        ingredientName: 'fqrine de blé',
-      );
-
-      expect(result, isNotNull);
-      expect(result!.corrected, 'farine de blé');
-      expect(result.input, 'fqrine de blé');
-      expect(result.termCorrections!.length, 1);
-      expect(result.termCorrections![0].corrections, isNull);
-    });
-  }, skip: 'This Group of tests is unstable');
 }


### PR DESCRIPTION
Impacted files:
* `api_getRobotoff_test.dart`: removed test related to `getIngredientSpellingCorrection`
* `openfoodfacts.dart`: deprecated method `getIngredientSpellingCorrection` that does not work

Closes #223