### PR TITLE
feat: 659 - support of product field "packagingsComplete"

### DIFF
--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -320,6 +320,14 @@ class Product extends JsonObject {
   @JsonKey(name: 'packagings', includeIfNull: false)
   List<ProductPackaging>? packagings;
 
+  /// Is the "packagings" complete?
+  @JsonKey(
+    name: 'packagings_complete',
+    toJson: JsonHelper.boolToJSON,
+    fromJson: JsonHelper.boolFromJSON,
+  )
+  bool? packagingsComplete;
+
   @JsonKey(name: 'packaging_tags', includeIfNull: false)
   List<String>? packagingTags;
   @JsonKey(

--- a/lib/src/model/product.g.dart
+++ b/lib/src/model/product.g.dart
@@ -115,6 +115,8 @@ Product _$ProductFromJson(Map<String, dynamic> json) => Product(
       ..packagings = (json['packagings'] as List<dynamic>?)
           ?.map((e) => ProductPackaging.fromJson(e))
           .toList()
+      ..packagingsComplete =
+          JsonHelper.boolFromJSON(json['packagings_complete'])
       ..packagingTextInLanguages =
           LanguageHelper.fromJsonStringMap(json['packaging_text_in_languages'])
       ..lastModifiedBy = json['last_modified_by'] as String?
@@ -206,6 +208,8 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
       LanguageHelper.toJsonStringsListMap(instance.labelsTagsInLanguages));
   writeNotNull('packaging', instance.packaging);
   writeNotNull('packagings', instance.packagings);
+  val['packagings_complete'] =
+      JsonHelper.boolToJSON(instance.packagingsComplete);
   writeNotNull('packaging_tags', instance.packagingTags);
   writeNotNull('packaging_text_in_languages',
       LanguageHelper.toJsonStringMap(instance.packagingTextInLanguages));

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -110,18 +110,26 @@ class OpenFoodAPIClient {
     final User user,
     final String barcode, {
     final List<ProductPackaging>? packagings,
+    final bool? packagingsComplete,
     final QueryType? queryType,
     final OpenFoodFactsCountry? country,
     final OpenFoodFactsLanguage? language,
   }) async {
     final Map<String, dynamic> parameterMap = <String, dynamic>{};
     parameterMap.addAll(user.toData());
-    if (packagings == null) {
-      // For the moment it's the only purpose of this method: saving packagings.
-      throw Exception('packagings cannot be null');
+    if (packagings == null && packagingsComplete == null) {
+      // For the moment there are limited fields concerned.
+      throw Exception('At least one V3 field must be populated.');
     }
-    parameterMap['product'] = {};
-    parameterMap['product']['packagings'] = packagings;
+    const String productTag = 'product';
+    parameterMap[productTag] = {};
+    if (packagings != null) {
+      parameterMap[productTag][ProductField.PACKAGINGS.offTag] = packagings;
+    }
+    if (packagingsComplete != null) {
+      parameterMap[productTag][ProductField.PACKAGINGS_COMPLETE.offTag] =
+          packagingsComplete;
+    }
     if (language != null) {
       parameterMap['lc'] = language.offTag;
       parameterMap['tags_lc'] = language.offTag;

--- a/lib/src/utils/json_helper.dart
+++ b/lib/src/utils/json_helper.dart
@@ -217,6 +217,7 @@ class JsonHelper {
   static const String _checkboxOnValue = 'on';
   static const String _checkboxOffValue = '';
 
+  /// Returns a bool from ''/'on' conversion.
   static bool? checkboxFromJSON(dynamic jsonValue) {
     if (jsonValue == null) {
       return null;
@@ -225,6 +226,7 @@ class JsonHelper {
         jsonValue.trim().toLowerCase() == _checkboxOnValue;
   }
 
+  /// Returns a bool to ''/'on' conversion.
   static String? checkboxToJSON(dynamic value) {
     if (value == null) {
       return null;
@@ -234,5 +236,24 @@ class JsonHelper {
     } else {
       return _checkboxOffValue;
     }
+  }
+
+  /// Returns a bool from 0/1 conversion.
+  static bool? boolFromJSON(dynamic jsonValue) {
+    if (jsonValue == null) {
+      return null;
+    }
+    return jsonValue == 1;
+  }
+
+  /// Returns a bool to 0/1 conversion.
+  static int? boolToJSON(dynamic value) {
+    if (value == null) {
+      return null;
+    }
+    if (value == true || value == 1) {
+      return 1;
+    }
+    return 0;
   }
 }

--- a/lib/src/utils/product_fields.dart
+++ b/lib/src/utils/product_fields.dart
@@ -55,6 +55,7 @@ enum ProductField implements OffTagged {
   @Deprecated('Use packagingS field instead')
   PACKAGING(offTag: 'packaging'),
   PACKAGINGS(offTag: 'packagings'),
+  PACKAGINGS_COMPLETE(offTag: 'packagings_complete'),
   PACKAGING_TAGS(offTag: 'packaging_tags'),
   PACKAGING_TEXT_IN_LANGUAGES(offTag: 'packaging_text_'),
   PACKAGING_TEXT_ALL_LANGUAGES(offTag: 'packaging_text_languages'),


### PR DESCRIPTION
Impacted files:
* `api_save_product_v3_test.dart`: added a save/read test about new product field `packagingsComplete`
* `json_helper.dart`: added helper methods about bool to/from 0/1 conversion.
* `open_food_api_client.dart`: added a way to save new product field `packagingsComplete`
* `product.dart`: added field `packagingsComplete`
* `product.g.dart`: generated
* `product_fields.dart`: added field `PACKAGINGS_COMPLETE`

### What
- Support of new product field "packagingsComplete" through api V3.
- It's a `bool?`, coded as int 0 and 1.

### Fixes bug(s)
- Closes: #659