### PR TITLE
feat: 662 - new packaging fields "quantityPerUnit" and weightMeasured"

### DIFF
--- a/lib/src/model/product_packaging.dart
+++ b/lib/src/model/product_packaging.dart
@@ -7,21 +7,45 @@ part 'product_packaging.g.dart';
 /// Packaging component for a product, e.g. recyclable bottle made of glass.
 @JsonSerializable()
 class ProductPackaging extends JsonObject {
+  /// Shape, canonicalized using [TaxonomyPackagingShape].
   @JsonKey(includeIfNull: false)
   LocalizedTag? shape;
 
+  /// Material, canonicalized using [TaxonomyPackagingMaterial].
   @JsonKey(includeIfNull: false)
   LocalizedTag? material;
 
+  /// Recycling status, canonicalized using [TaxonomyPackagingRecycling].
   @JsonKey(includeIfNull: false)
   LocalizedTag? recycling;
 
+  /// Number of units of this component contained in the product.
+  ///
+  /// E.g. 6 for a pack of 6 bottles.
   @JsonKey(
     name: 'number_of_units',
     includeIfNull: false,
     fromJson: JsonObject.parseInt,
   )
   int? numberOfUnits;
+
+  /// Quantity (weight or volume) of food product contained.
+  ///
+  /// Ee.g. 75cl for a wine bottle.
+  @JsonKey(name: 'quantity_per_unit', includeIfNull: false)
+  String? quantityPerUnit;
+
+  /// Weight in grams as measured by a user of one unit of the empty component.
+  ///
+  /// E.g. for a 6 pack of 1.5l water bottles, it might be 30, the weight in
+  /// grams of 1 empty water bottle without its cap which is a different
+  /// component.
+  @JsonKey(
+    name: 'weight_measured',
+    includeIfNull: false,
+    fromJson: JsonObject.parseDouble,
+  )
+  double? weightMeasured;
 
   ProductPackaging();
 

--- a/lib/src/model/product_packaging.g.dart
+++ b/lib/src/model/product_packaging.g.dart
@@ -17,7 +17,9 @@ ProductPackaging _$ProductPackagingFromJson(Map<String, dynamic> json) =>
       ..recycling = json['recycling'] == null
           ? null
           : LocalizedTag.fromJson(json['recycling'] as Map<String, dynamic>)
-      ..numberOfUnits = JsonObject.parseInt(json['number_of_units']);
+      ..numberOfUnits = JsonObject.parseInt(json['number_of_units'])
+      ..quantityPerUnit = json['quantity_per_unit'] as String?
+      ..weightMeasured = JsonObject.parseDouble(json['weight_measured']);
 
 Map<String, dynamic> _$ProductPackagingToJson(ProductPackaging instance) {
   final val = <String, dynamic>{};
@@ -32,5 +34,7 @@ Map<String, dynamic> _$ProductPackagingToJson(ProductPackaging instance) {
   writeNotNull('material', instance.material);
   writeNotNull('recycling', instance.recycling);
   writeNotNull('number_of_units', instance.numberOfUnits);
+  writeNotNull('quantity_per_unit', instance.quantityPerUnit);
+  writeNotNull('weight_measured', instance.weightMeasured);
   return val;
 }

--- a/test/api_save_product_v3_test.dart
+++ b/test/api_save_product_v3_test.dart
@@ -14,12 +14,17 @@ void main() {
       // Here we put an unknown recycling label, and we expect related warnings.
       const String unknownRecycling = 'recyKKlage';
       const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
+      const int numberOfUnits = 12;
+      const String quantityPerUnit = '50cl';
+      const double weightMeasured = 250;
       final List<ProductPackaging> inputPackagings = [
         ProductPackaging()
           ..shape = (LocalizedTag()..lcName = 'bouteille')
           ..material = (LocalizedTag()..lcName = 'verre')
           ..recycling = (LocalizedTag()..lcName = unknownRecycling)
-          ..numberOfUnits = 12,
+          ..numberOfUnits = numberOfUnits
+          ..quantityPerUnit = quantityPerUnit
+          ..weightMeasured = weightMeasured,
       ];
       final ProductResultV3 status =
           await OpenFoodAPIClient.temporarySaveProductV3(
@@ -36,6 +41,17 @@ void main() {
       expect(status.result, isNull); // result is null for UPDATE queries
       expect(status.barcode, barcode);
       expect(status.product, isNotNull);
+
+      expect(status.product!.packagings, isNotNull);
+      final List<ProductPackaging> packagings = status.product!.packagings!;
+      expect(packagings, hasLength(1));
+      final ProductPackaging packaging = packagings.first;
+      expect(packaging.shape, isNotNull);
+      expect(packaging.material, isNotNull);
+      expect(packaging.recycling, isNotNull);
+      expect(packaging.numberOfUnits, numberOfUnits);
+      expect(packaging.quantityPerUnit, quantityPerUnit);
+      expect(packaging.weightMeasured, weightMeasured);
 
       expect(status.warnings, isNotEmpty);
       expect(status.warnings, hasLength(1));


### PR DESCRIPTION
Impacted files:
* `api_save_product_v3_test.dart`: added test for new packaging fields `quantityPerUnit` and `weightMeasured`
* `product_packaging.dart`: added fields `quantityPerUnit` and `weightMeasured`
* `product_packaging.g.dart`: generated

### What
- New packaging fields `quantityPerUnit` and `weightMeasured`

### Fixes bug(s)
- Closes: #662