### PR TITLE
fix: 617 - user related queries now support api v3

### DIFF
--- a/lib/src/model/parameter/tag_filter.dart
+++ b/lib/src/model/parameter/tag_filter.dart
@@ -21,8 +21,16 @@ enum TagFilterType implements OffTagged {
   INGREDIENTS(offTag: 'ingredients'),
   NOVA_GROUPS(offTag: 'nova_groups'),
   LANGUAGES(offTag: 'languages'),
+
+  /// User who created this product
   CREATOR(offTag: 'creator'),
   EDITORS(offTag: 'editors'),
+
+  /// User who photographed for this product
+  PHOTOGRAPHERS(offTag: 'photographers'),
+
+  /// Users who contributed to this product
+  INFORMERS(offTag: 'informers'),
   LANG(offTag: 'lang');
 
   const TagFilterType({

--- a/lib/src/utils/user_product_search_query_configuration.dart
+++ b/lib/src/utils/user_product_search_query_configuration.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import '../interface/parameter.dart';
 import '../model/parameter/page_number.dart';
 import '../model/parameter/page_size.dart';
@@ -5,7 +7,9 @@ import 'abstract_query_configuration.dart';
 import 'language_helper.dart';
 import 'product_fields.dart';
 
+// TODO: deprecated from 2022-12-29; remove when old enough
 /// Query Configuration for user-related searches.
+@Deprecated('Use standard queries instead')
 class UserProductSearchQueryConfiguration extends AbstractQueryConfiguration {
   UserProductSearchQueryConfiguration({
     required this.type,
@@ -58,21 +62,29 @@ class UserProductSearchQueryConfiguration extends AbstractQueryConfiguration {
   }
 }
 
+// TODO: deprecated from 2022-12-29; remove when old enough
 /// Types of user-related searches.
+@Deprecated('Use standard queries instead')
 enum UserProductSearchType {
   /// Where the user created the product.
+  @Deprecated('Use a standard query with TagFilterType.CREATOR instead')
   CONTRIBUTOR,
 
   /// Where the user edited the product.
+  @Deprecated('Use a standard query with TagFilterType.INFORMERS instead')
   INFORMER,
 
   /// Where the user photographed the product.
+  @Deprecated('Use a standard query with TagFilterType.PHOTOGRAPHERS instead')
   PHOTOGRAPHER,
 
   /// Where the user edited a product that still needs to be completed.
+  @Deprecated(
+      'Use a standard query with TagFilterType.INFORMERS and TagFilterType.STATES=ProductState.COMPLETED.toBeCompletedTag instead')
   TO_BE_COMPLETED,
 }
 
+// TODO: deprecated from 2022-12-29; remove when old enough
 extension UserProductSearchTypeExtension on UserProductSearchType {
   /// Returns the URI path for the search.
   String getPath(final String userId) {


### PR DESCRIPTION
Impacted files:
* `api_get_user_products_test.dart`: now supporting api v3
* `tag_filter.dart`: added filters `PHOTOGRAPHERS` and `INFORMERS`
* `user_product_search_query_configuration.dart`: deprecated

### What
- User related product queries used a specific syntax, that made them incompatible with api v3.
- Now we use the standard syntax with new parameters.
- Therefore user related product queries now support api v3.

### Fixes bug(s)
- Closes: #617