### PR TITLE
refactor!: 658 - api version is now required for barcode and search queries

### DIFF
--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -192,6 +192,7 @@ class OpenFoodAPIClient {
         language: language,
         country: null,
         fields: null,
+        version: ProductQueryVersion.v3,
       ),
       user: user,
       queryType: queryType,
@@ -349,6 +350,7 @@ class OpenFoodAPIClient {
   /// Returns the [ProductFreshness] for all the [barcodes].
   static Future<Map<String, ProductFreshness>> getProductFreshness({
     required final List<String> barcodes,
+    required final ProductQueryVersion version,
     final User? user,
     final OpenFoodFactsLanguage? language,
     final OpenFoodFactsCountry? country,
@@ -368,6 +370,7 @@ class OpenFoodAPIClient {
           ProductField.LAST_MODIFIED,
           ProductField.STATES_TAGS,
         ],
+        version: version,
       ),
       queryType: queryType,
     );

--- a/lib/src/utils/product_query_configurations.dart
+++ b/lib/src/utils/product_query_configurations.dart
@@ -14,8 +14,14 @@ class ProductQueryVersion {
 
   final int version;
 
+  // TODO: deprecated from 2022-12-29; remove when old enough
+  @Deprecated('Use v3 instead')
   static const ProductQueryVersion v0 = ProductQueryVersion(0);
+
+  // TODO: deprecated from 2022-12-29; remove when old enough
+  @Deprecated('Use v3 instead')
   static const ProductQueryVersion v2 = ProductQueryVersion(2);
+
   static const ProductQueryVersion v3 = ProductQueryVersion(3);
 
   String getPath(final String barcode) {
@@ -37,7 +43,7 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
   /// parameter's description.
   ProductQueryConfiguration(
     this.barcode, {
-    this.version = ProductQueryVersion.v0,
+    required this.version,
     final OpenFoodFactsLanguage? language,
     final List<OpenFoodFactsLanguage> languages = const [],
     final OpenFoodFactsCountry? country,

--- a/lib/src/utils/product_search_query_configuration.dart
+++ b/lib/src/utils/product_search_query_configuration.dart
@@ -15,7 +15,7 @@ class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
     final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
     required List<Parameter> parametersList,
-    this.version = ProductQueryVersion.v3,
+    required final this.version,
   }) : super(
           language: language,
           languages: languages,

--- a/test/api_get_to_be_completed_products_test.dart
+++ b/test/api_get_to_be_completed_products_test.dart
@@ -25,6 +25,7 @@ void main() {
         parametersList: [
           StatesTagsParameter(map: {ProductState.COMPLETED: false}),
         ],
+        version: ProductQueryVersion.v3,
       );
 
       final SearchResult result;

--- a/test/api_matched_product_v2_test.dart
+++ b/test/api_matched_product_v2_test.dart
@@ -120,6 +120,7 @@ void main() {
           parametersList: [BarcodeParameter.list(inputBarcodes)],
           language: language,
           fields: [ProductField.BARCODE, ProductField.ATTRIBUTE_GROUPS],
+          version: ProductQueryVersion.v3,
         ),
       );
       expect(result.count, expectedScores.keys.length);

--- a/test/api_search_products_test.dart
+++ b/test/api_search_products_test.dart
@@ -8,6 +8,7 @@ import 'test_constants.dart';
 void main() {
   OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
+  const ProductQueryVersion version = ProductQueryVersion.v3;
 
   group('$OpenFoodAPIClient search products', () {
     const String UNKNOWN_BARCODE = '1111111111111111111111111111111';
@@ -58,6 +59,7 @@ void main() {
             fields: [ProductField.BARCODE],
             language: OpenFoodFactsLanguage.FRENCH,
             country: OpenFoodFactsCountry.FRANCE,
+            version: version,
           ),
         );
 
@@ -125,9 +127,11 @@ void main() {
 
       final ProductSearchQueryConfiguration configuration =
           ProductSearchQueryConfiguration(
-              parametersList: parameters,
-              fields: [ProductField.ALL],
-              language: OpenFoodFactsLanguage.GERMAN);
+        parametersList: parameters,
+        fields: [ProductField.ALL],
+        language: OpenFoodFactsLanguage.GERMAN,
+        version: version,
+      );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         TestConstants.PROD_USER,
@@ -151,9 +155,11 @@ void main() {
 
       final ProductSearchQueryConfiguration configuration =
           ProductSearchQueryConfiguration(
-              parametersList: parameters,
-              fields: [ProductField.ALL],
-              language: OpenFoodFactsLanguage.ENGLISH);
+        parametersList: parameters,
+        fields: [ProductField.ALL],
+        language: OpenFoodFactsLanguage.ENGLISH,
+        version: version,
+      );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         TestConstants.PROD_USER,
@@ -199,6 +205,7 @@ void main() {
         ],
         language: OpenFoodFactsLanguage.FRENCH,
         country: OpenFoodFactsCountry.FRANCE,
+        version: version,
       );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -320,9 +327,11 @@ void main() {
 
       final ProductSearchQueryConfiguration configuration =
           ProductSearchQueryConfiguration(
-              parametersList: parameters,
-              fields: [ProductField.ALL],
-              language: OpenFoodFactsLanguage.GERMAN);
+        parametersList: parameters,
+        fields: [ProductField.ALL],
+        language: OpenFoodFactsLanguage.GERMAN,
+        version: version,
+      );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         TestConstants.PROD_USER,
@@ -346,9 +355,11 @@ void main() {
 
       final ProductSearchQueryConfiguration configuration =
           ProductSearchQueryConfiguration(
-              parametersList: parameters,
-              fields: [ProductField.BARCODE],
-              language: OpenFoodFactsLanguage.FRENCH);
+        parametersList: parameters,
+        fields: [ProductField.BARCODE],
+        language: OpenFoodFactsLanguage.FRENCH,
+        version: version,
+      );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         TestConstants.PROD_USER,
@@ -378,6 +389,7 @@ void main() {
         parametersList: parameters,
         language: OpenFoodFactsLanguage.GERMAN,
         fields: <ProductField>[ProductField.IMAGES],
+        version: version,
       );
 
       SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -407,6 +419,7 @@ void main() {
           parametersList: parameters,
           fields: [ProductField.BARCODE],
           language: OpenFoodFactsLanguage.FRENCH,
+          version: version,
         );
 
         final SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -439,9 +452,11 @@ void main() {
 
       final ProductSearchQueryConfiguration configuration =
           ProductSearchQueryConfiguration(
-              parametersList: parameters,
-              fields: [ProductField.ALL],
-              language: OpenFoodFactsLanguage.FRENCH);
+        parametersList: parameters,
+        fields: [ProductField.ALL],
+        language: OpenFoodFactsLanguage.FRENCH,
+        version: version,
+      );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         TestConstants.PROD_USER,
@@ -525,6 +540,7 @@ void main() {
         parametersList: parameters,
         fields: [ProductField.ALL],
         language: OpenFoodFactsLanguage.FRENCH,
+        version: version,
       );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -572,6 +588,7 @@ void main() {
         parametersList: parameters,
         fields: [ProductField.ALL],
         language: OpenFoodFactsLanguage.FRENCH,
+        version: version,
       );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -601,6 +618,7 @@ void main() {
         parametersList: parameters,
         fields: [ProductField.ALL],
         language: OpenFoodFactsLanguage.GERMAN,
+        version: version,
       );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -638,9 +656,11 @@ void main() {
 
       final ProductSearchQueryConfiguration configuration =
           ProductSearchQueryConfiguration(
-              parametersList: parameters,
-              fields: [ProductField.ALL],
-              language: OpenFoodFactsLanguage.GERMAN);
+        parametersList: parameters,
+        fields: [ProductField.ALL],
+        language: OpenFoodFactsLanguage.GERMAN,
+        version: version,
+      );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         TestConstants.TEST_USER,
@@ -663,6 +683,7 @@ void main() {
         parametersList: [BarcodeParameter.list(BARCODES)],
         fields: [ProductField.BARCODE, ProductField.NAME],
         language: OpenFoodFactsLanguage.FRENCH,
+        version: version,
       );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -688,6 +709,7 @@ void main() {
         user: TestConstants.PROD_USER,
         language: OpenFoodFactsLanguage.FRENCH,
         country: OpenFoodFactsCountry.FRANCE,
+        version: version,
       );
 
       int count = 0;
@@ -713,6 +735,7 @@ void main() {
           ],
           fields: [ProductField.BARCODE, ProductField.NAME],
           language: OpenFoodFactsLanguage.FRENCH,
+          version: version,
         );
 
         final result = await OpenFoodAPIClient.searchProducts(
@@ -741,6 +764,7 @@ void main() {
           PnnsGroup2Filter(pnnsGroup2: PnnsGroup2.POTATOES),
           PageNumber(page: 3),
         ],
+        version: version,
       );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -769,6 +793,7 @@ void main() {
         parametersList: [BarcodeParameter.list(manyBarcodes)],
         fields: [ProductField.BARCODE, ProductField.NAME],
         language: OpenFoodFactsLanguage.FRENCH,
+        version: version,
       );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -867,6 +892,7 @@ void main() {
         fields: [ProductField.BARCODE, ProductField.ALLERGENS],
         language: OpenFoodFactsLanguage.FRENCH,
         country: OpenFoodFactsCountry.FRANCE,
+        version: version,
       );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -975,6 +1001,7 @@ void main() {
         fields: [ProductField.BARCODE, ProductField.STATES_TAGS],
         language: OpenFoodFactsLanguage.FRENCH,
         country: OpenFoodFactsCountry.FRANCE,
+        version: version,
       );
 
       final SearchResult result = await OpenFoodAPIClient.searchProducts(


### PR DESCRIPTION
Impacted files:
* `api_get_to_be_completed_products_test.dart`: minor refactoring
* `api_matched_product_v2_test.dart`: minor refactoring
* `api_search_products_test.dart`: added version
* `open_food_api_client.dart`: api version is now required for `getProductFreshness`
* `product_query_configurations.dart`: api version is now required for `ProductQueryConfiguration`; deprecated version 0, (1) and 2
* `product_search_query_configuration.dart`: api version is now required for `ProductSearchQueryConfiguration`

### What
- It became embarrassing not to ask explictly for the api version and setting default versions instead: should we have different api versions for different methods? Should we upgrade the versions without notifying the user?
- A solution, implemented here, was to make the version a required field for barcode and search queries in off-dart.

### Fixes bug(s)
- Closes: #658