### PR TITLE
fix: 650 - less server demanding nova integration test

### DIFF
--- a/test/api_search_products_test.dart
+++ b/test/api_search_products_test.dart
@@ -784,12 +784,14 @@ void main() {
     });
 
     test('nova filter', () async {
-      // approximated min counts
+      // Approximated min counts for POLAND
+      // There were too many results for FRANCE, and that made the server crash.
+      // There are far less results for POLAND, which is OK for these tests.
       const Map<int, int> novaMinCounts = <int, int>{
-        1: 25000, // was 28437 on 2022-12-19
-        2: 20000, // was 21124 on 2022-12-19
-        3: 50000, // was 52603 on 2022-12-19
-        4: 140000, // was 149003 on 2022-12-19
+        1: 400, // was 541 on 2022-12-31
+        2: 100, // was 126 on 2022-12-31
+        3: 750, // was 1015 on 2022-12-31
+        4: 2500, // was 3064 on 2022-12-31
       };
 
       // single filters
@@ -805,7 +807,7 @@ void main() {
             ],
             fields: [ProductField.BARCODE, ProductField.NOVA_GROUP],
             language: OpenFoodFactsLanguage.FRENCH,
-            country: OpenFoodFactsCountry.FRANCE,
+            country: OpenFoodFactsCountry.POLAND,
             version: ProductQueryVersion.v3,
           ),
         );


### PR DESCRIPTION
Impacted file:
* `api_search_products_test.dart`: slightly edited a test in order to be less intense for the server

### What
- Filter on NOVA looks very demanding on the server resources, and for NOVA 4 it may lead to Mongo DB crash.
- The fix here is about switching to a country with less data than France - in this case, Poland.

### Fixes bug(s)
- Fixes: #650