### PR TITLE
refactor: lint - as close to pub.dev as possible in order to pass the checks

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,16 +1,5 @@
 include: package:lints/recommended.yaml
 
-analyzer:
-  exclude:
-    - "**/*.g.dart"
-  errors:
-    omit_local_variable_types: ignore
-    annotate_overrides: ignore
-    use_function_type_syntax_for_parameters: ignore
-    missing_required_param: warning
-    missing_return: warning
-    prefer_single_quotes: warning
-
 linter:
   rules:
     constant_identifier_names: false

--- a/lib/src/model/product.g.dart
+++ b/lib/src/model/product.g.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// That's a bit ugly, but we need the previous line in order to pass the pub.dev
+// tests, so put that line back after code generation.
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'product.dart';

--- a/lib/src/model/product_result.g.dart
+++ b/lib/src/model/product_result.g.dart
@@ -1,3 +1,6 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+// That's a bit ugly, but we need the previous line in order to pass the pub.dev
+// tests, so put that line back after code generation.
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'product_result.dart';

--- a/lib/src/model/robotoff_question.dart
+++ b/lib/src/model/robotoff_question.dart
@@ -44,5 +44,6 @@ class RobotoffQuestion extends JsonObject {
   factory RobotoffQuestion.fromJson(Map<String, dynamic> json) =>
       _$RobotoffQuestionFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$RobotoffQuestionToJson(this);
 }

--- a/lib/src/model/status.dart
+++ b/lib/src/model/status.dart
@@ -79,5 +79,6 @@ class Status extends JsonObject {
   bool isWrongUsernameOrPassword() =>
       statusVerbose == WRONG_USER_OR_PASSWORD_ERROR_MESSAGE;
 
+  @override
   Map<String, dynamic> toJson() => _$StatusToJson(this);
 }

--- a/lib/src/model/user.dart
+++ b/lib/src/model/user.dart
@@ -21,5 +21,6 @@ class User extends JsonObject {
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$UserToJson(this);
 }

--- a/lib/src/model/user_agent.dart
+++ b/lib/src/model/user_agent.dart
@@ -15,6 +15,7 @@ class UserAgent extends JsonObject {
     this.comment,
   });
 
+  @override
   Map<String, dynamic> toJson() => {
         'name': name,
         'version': version,

--- a/lib/src/utils/barcodes_validator.dart
+++ b/lib/src/utils/barcodes_validator.dart
@@ -80,6 +80,7 @@ class _EANValidator extends _AbstractBarcodeValidator {
     return true;
   }
 
+  @override
   int _weightedValue(int charValue, int leftPos, int rightPos) {
     int weight = _POSITION_WEIGHT[rightPos % 2];
     return charValue * weight;


### PR DESCRIPTION
Impacted files:
* `analysis_options.yaml`: as close as the recommendations as possible
* `barcodes_validator.dart`: minor refactoring
* `product.g.dart`: ugly minor refactoring
* `product_result.g.dart`: ugly minor refactoring
* `robotoff_question.dart`: minor refactoring
* `status.dart`: minor refactoring
* `user.dart`: minor refactoring
* `user_agent.dart`: minor refactoring

### What
- Unexpectedly with 2.0.0 we still haven't reached the max score of 140 on pub.dev.
- Part of the reason is that pub.dev does check the generated files, and we did not.
- Now our check parameters are as close to pub.dev as possible.
- Hopefully when this PR is merged into pub.dev we get the max score!