### PR TITLE
fix: fixed lint error

### DIFF
--- a/lib/src/utils/product_search_query_configuration.dart
+++ b/lib/src/utils/product_search_query_configuration.dart
@@ -15,7 +15,7 @@ class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
     final OpenFoodFactsCountry? country,
     final List<ProductField>? fields,
     required List<Parameter> parametersList,
-    required final this.version,
+    required this.version,
   }) : super(
           language: language,
           languages: languages,


### PR DESCRIPTION
Impacted file:
* `product_search_query_configuration.dart`: fixed lint error

### What
- Fix of a lint error found on pub.dev but that we didn't detect locally.