### PR TITLE
fix: more read-only tests on PROD env

### DIFF
--- a/test/api_get_robotoff_test.dart
+++ b/test/api_get_robotoff_test.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 import 'test_constants.dart';
 
 void main() {
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   group('$OpenFoodAPIClient get robotoff questions', () {
     test('get questions for Noix de Saint-Jacques EN', () async {
@@ -11,7 +11,7 @@ void main() {
           await OpenFoodAPIClient.getRobotoffQuestionsForProduct(
         '3274570800026',
         'en',
-        user: TestConstants.TEST_USER,
+        user: TestConstants.PROD_USER,
         count: 1,
       );
 
@@ -37,7 +37,7 @@ void main() {
           await OpenFoodAPIClient.getRobotoffQuestionsForProduct(
         '3274570800026',
         'fr',
-        user: TestConstants.TEST_USER,
+        user: TestConstants.PROD_USER,
       );
 
       if (result.status != 'no_questions') {
@@ -65,7 +65,6 @@ void main() {
         TestConstants.PROD_USER,
         types: [type],
         count: 2,
-        queryType: QueryType.PROD,
       );
 
       expect(result.status, isNotNull);
@@ -81,7 +80,6 @@ void main() {
         'fr',
         TestConstants.PROD_USER,
         count: 2,
-        queryType: QueryType.PROD,
       );
 
       expect(result.status, isNotNull);
@@ -95,7 +93,6 @@ void main() {
       final InsightsResult result = await OpenFoodAPIClient.getRandomInsight(
         TestConstants.PROD_USER,
         type: InsightType.CATEGORY,
-        queryType: QueryType.PROD,
       );
 
       expect(result.status, isNotNull);
@@ -109,7 +106,6 @@ void main() {
       final InsightsResult result1 = await OpenFoodAPIClient.getRandomInsight(
         TestConstants.PROD_USER,
         type: InsightType.CATEGORY,
-        queryType: QueryType.PROD,
       );
 
       final String barcode = result1.insights![0].barcode!;
@@ -117,7 +113,6 @@ void main() {
       final InsightsResult result = await OpenFoodAPIClient.getProductInsights(
         barcode,
         TestConstants.PROD_USER,
-        queryType: QueryType.PROD,
       );
 
       expect(result.status, isNotNull);
@@ -132,7 +127,6 @@ void main() {
       InsightsResult result = await OpenFoodAPIClient.getProductInsights(
         fakeBarcode,
         TestConstants.PROD_USER,
-        queryType: QueryType.PROD,
       );
 
       expect(result.status, isNotNull);

--- a/test/api_matched_product_v1_test.dart
+++ b/test/api_matched_product_v1_test.dart
@@ -7,7 +7,7 @@ import 'test_constants.dart';
 void main() {
   const int HTTP_OK = 200;
 
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   /// Tests around Matched Product v1.
   group('$OpenFoodAPIClient matched product v1', () {
@@ -55,7 +55,7 @@ void main() {
       );
       final ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         configurations,
-        user: TestConstants.TEST_USER,
+        user: TestConstants.PROD_USER,
       );
       expect(result.status, ProductResultV3.statusSuccess);
       expect(result.barcode, barcode);

--- a/test/api_search_products_test.dart
+++ b/test/api_search_products_test.dart
@@ -214,6 +214,9 @@ void main() {
       );
 
       expect(result.products, isNotNull);
+      if (result.count == null) {
+        expect(result.products!.length, 0);
+      }
       for (final Product product in result.products!) {
         if (veganStatus != null) {
           expect(
@@ -234,7 +237,7 @@ void main() {
           );
         }
       }
-      return result.count;
+      return result.count ?? 0;
     }
 
     test('check vegan search', () async {

--- a/test/ordered_nutrient_test.dart
+++ b/test/ordered_nutrient_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 /// Tests related to [OrderedNutrient] and [OrderedNutrients]
 void main() {
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   // Very long list, experimentally created from the 3 initial URLs.
   // Don't hesitate to edit this list if you have clear functional ideas


### PR DESCRIPTION
Impacted files:
* `api_get_robotoff_test.dart`: switched to PROD env
* `api_matched_product_v1_test.dart`: switched to PROD env
* `ordered_nutrient_test.dart`: switched to PROD env

### What
- [pub.dev](https://pub.dev/packages/openfoodfacts) says that [our tests are failing](https://github.com/openfoodfacts/openfoodfacts-dart/actions/workflows/test-sdk.yml).
- More precisely, it's a read-only test on TEST env.
- As TEST env is notoriously less stable than PROD, the goal of this PR is to switch to PROD env some read-only tests.

### Screenshot
![Capture d’écran 2023-01-09 à 12 13 05](https://user-images.githubusercontent.com/11576431/211295563-5a5c4035-154e-4f74-a6ff-091215419b0c.png)

![Capture d’écran 2023-01-09 à 12 12 33](https://user-images.githubusercontent.com/11576431/211295473-b39b46dc-df4d-42f1-8963-bf561a37fa2b.png)