### PR TITLE
fix: correct spelling of User-Agent

### DIFF
--- a/lib/src/utils/http_helper.dart
+++ b/lib/src/utils/http_helper.dart
@@ -203,7 +203,7 @@ class HttpHelper {
 
     headers.addAll({
       'Accept': 'application/json',
-      'UserAgent':
+      'User-Agent':
           OpenFoodAPIConfiguration.userAgent?.toValueString() ?? USER_AGENT,
       'From': OpenFoodAPIConfiguration.getUser(user)?.userId ?? FROM,
     });


### PR DESCRIPTION
Impacted file:
* `http_helper.dart`

### What
- We experience problems in Smoothie regarding the value of user agent for some queries.
- We recently switched those queries from POST to GET.
- And anyway the spelling of `User-Agent` was wrong.
- cf. https://github.com/openfoodfacts/smooth-app/pull/3546#issuecomment-1376043349

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/3534