### PR TITLE
fix: 691 - implemented "imagesToJson"

### DIFF
--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -224,16 +224,18 @@ class Product extends JsonObject {
       toJson: IngredientsAnalysisTags.toJson)
   IngredientsAnalysisTags? ingredientsAnalysisTags;
 
-  /// When no nutrition data is true, nutriments are always null
+  /// When no nutrition data is true, nutriments are always null.
+  ///
   /// This logic is handled by the getters/setters of [noNutritionData] and
-  /// [nutriments]
-  @JsonKey(ignore: true)
+  /// [nutriments].
+  /// This field is therefore not populated directly by json.
   bool? _noNutritionData;
 
-  /// When nutriments are not null, no nutrition data can't be true
+  /// When nutriments are not null, no nutrition data can't be true.
+  ///
   /// This logic is handled by the getters/setters of [noNutritionData] and
   /// [nutriments]
-  @JsonKey(ignore: true)
+  /// This field is therefore not populated directly by json.
   Nutriments? _nutriments;
 
   @JsonKey(

--- a/lib/src/model/product_image.dart
+++ b/lib/src/model/product_image.dart
@@ -134,6 +134,8 @@ class ProductImage {
     this.y1,
     this.x2,
     this.y2,
+    this.width,
+    this.height,
   });
 
   final ImageField field;
@@ -165,6 +167,12 @@ class ProductImage {
   /// Crop coordinate y2, compared to the uploaded image
   int? y2;
 
+  /// Image width.
+  int? width;
+
+  /// Image height.
+  int? height;
+
   @override
   String toString() => 'ProductImage('
       '${field.offTag}'
@@ -179,5 +187,36 @@ class ProductImage {
       '${y1 == null ? '' : ',y1=$y1'}'
       '${x2 == null ? '' : ',x2=$x2'}'
       '${y2 == null ? '' : ',y2=$y2'}'
+      '${width == null ? '' : ',width=$width'}'
+      '${height == null ? '' : ',height=$height'}'
       ')';
+
+  @override
+  int get hashCode =>
+      '${field.offTag}_${language?.code}_${size?.offTag}'.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is ProductImage &&
+        other.field == field &&
+        other.size == size &&
+        other.language == language &&
+        other.url == url &&
+        other.rev == rev &&
+        other.imgid == imgid &&
+        other.angle == angle &&
+        other.coordinatesImageSize == coordinatesImageSize &&
+        other.x1 == x1 &&
+        other.y1 == y1 &&
+        other.x2 == x2 &&
+        other.y2 == y2 &&
+        other.width == width &&
+        other.height == height;
+  }
 }

--- a/test/api_json_to_from_test.dart
+++ b/test/api_json_to_from_test.dart
@@ -1,0 +1,43 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const BARCODE_DANISH_BUTTER_COOKIES = '5701184005007';
+
+  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
+
+  group('$OpenFoodAPIClient json to/from conversions', () {
+    test('images', () async {
+      final ProductResultV3 productResult =
+          await OpenFoodAPIClient.getProductV3(
+        ProductQueryConfiguration(
+          BARCODE_DANISH_BUTTER_COOKIES,
+          fields: [ProductField.IMAGES],
+          version: ProductQueryVersion.v3,
+        ),
+      );
+      expect(productResult.product, isNotNull);
+
+      final List<ProductImage>? images = productResult.product!.images;
+      expect(images, isNotNull);
+      expect(images, isNotEmpty);
+
+      final List<ProductImage>? imagesBackAndForth = JsonHelper.imagesFromJson(
+        JsonHelper.imagesToJson(images),
+      );
+      expect(imagesBackAndForth, isNotNull);
+      expect(imagesBackAndForth, isNotEmpty);
+
+      expect(imagesBackAndForth!.length, images!.length);
+      for (final ProductImage productImage1 in images) {
+        int count = 0;
+        for (final ProductImage productImage2 in imagesBackAndForth) {
+          if (productImage1 == productImage2) {
+            count++;
+          }
+        }
+        expect(count, 1);
+      }
+    });
+  });
+}

--- a/test/api_search_products_test.dart
+++ b/test/api_search_products_test.dart
@@ -1089,9 +1089,13 @@ void main() {
       final Random random = Random();
       final bool completed1 = random.nextBool();
       final bool completed2 = random.nextBool();
+      // TODO(monsieurtanuki): sometimes fails because of bad luck
+      // by the time the second count is retrieved, the first count changed too,
+      // if we are unlucky.
       await checkExpectations(state1, completed1, state2, completed2);
     });
   },
+      skip: 'Sometimes fails because of bad-luck',
       timeout: Timeout(
         // some tests can be slow here
         Duration(seconds: 300),


### PR DESCRIPTION
New file:
* `api_json_to_from_test.dart`: unit tests about to/from json conversions

Impacted files:
* `api_search_products_test.dart`: unrelated fix
* `json_helper.dart`: implemented method `imagesToJson`; refactored method `imagesFromJson`
* `product_images.dart`: added fields width and height; added `hashcode` and `==` operator

### What
- `imagesFromJson`was already implemented, but not `imagesToJson`.
- That was problematic if we wanted to store locally in a `String` a `Product` with field `images`.

### Fixes bug(s)
- Closes: #691
- Closes: #692