### PR TITLE
fix: rollback to dart 2.17 / flutter 3.0.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,18 +8,18 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  json_annotation: ^4.8.0
+  json_annotation: ^4.7.0
   http: ^0.13.5
   path: ^1.8.3
   meta: ^1.8.0
 
 dev_dependencies:
-  analyzer: ^5.4.0
-  build_runner: ^2.3.3
-  json_serializable: ^6.6.0
+  analyzer: ^4.7.0
+  build_runner: ^2.3.0
+  json_serializable: ^6.5.4
   lints: ^2.0.1
-  test: ^1.23.1
-  coverage: ^1.6.3
+  test: ^1.21.4
+  coverage: ^1.6.2
 
 funding:
   - "https://donate.openfoodfacts.org/"


### PR DESCRIPTION
Impacted file:
* `pubspec.yaml`

### What
- If we don't rollback here too, we cannot use off-dart in Smoothie...