### PR TITLE
fix: 712 - optional User parameter for get random robotoff questions

### DIFF
--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -880,7 +880,7 @@ class OpenFoodAPIClient {
 
   static Future<RobotoffQuestionResult> getRandomRobotoffQuestion(
     String lang,
-    User user, {
+    User? user, {
     int? count,
     List<InsightType>? types,
     QueryType? queryType,


### PR DESCRIPTION
Impacted file:
* `open_food_api_client.dart`

### What
- The `User` parameter is optional for get random robotoff questions

### Fixes bug(s)
- #712

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/3600