### PR TITLE
fix: 715 - downgraded "path" in order to match "flutter_test"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   json_annotation: ^4.7.0
   http: ^0.13.5
-  path: ^1.8.3
+  path: ^1.8.2 # 1.8.2 for flutter_test as of 2023-04-06
   meta: ^1.8.0
 
 dev_dependencies:


### PR DESCRIPTION
Impacted file:
* `pubspec.yaml`: downgraded `path` to ^1.8.2 in order to match `flutter_test`'s `path`

### What
- We used `path: ^1.8.3`, but `flutter_test` uses `1.8.2`, which caused dependency issues for flutter projects.
- As `1.8.2` is good enough for us, in the current PR we downgrade the `path` version to `^1.8.2`

### Fixes bug(s)
- Closes: #715