### PR TITLE
refactor: new "KP action" enum

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -16,6 +16,7 @@ export 'src/model/ingredients_analysis_tags.dart';
 export 'src/model/insight.dart';
 export 'src/model/key_stats.dart';
 export 'src/model/knowledge_panel.dart';
+export 'src/model/knowledge_panel_action.dart';
 export 'src/model/knowledge_panel_element.dart';
 export 'src/model/knowledge_panels.dart';
 export 'src/model/leaderboard_entry.dart';

--- a/lib/src/model/knowledge_panel_action.dart
+++ b/lib/src/model/knowledge_panel_action.dart
@@ -1,0 +1,48 @@
+import '../model/off_tagged.dart';
+
+/// Possible needed contribute actions.
+///
+/// cf. [KnowledgePanelActionElement.actions].
+enum KnowledgePanelAction implements OffTagged {
+  /// Action: add categories.
+  addCategories(offTag: 'add_categories'),
+
+  /// Action: add ingredients text.
+  addIngredientsText(offTag: 'add_ingredients_text'),
+
+  /// Action: add ingredients image.
+  addIngredientsImage(offTag: 'add_ingredients_image'),
+
+  /// Action: add packaging image.
+  addPackagingImage(offTag: 'add_packaging_image'),
+
+  /// Action: add packaging text.
+  addPackagingText(offTag: 'add_packaging_text'),
+
+  /// Action: add nutrition facts.
+  addNutritionFacts(offTag: 'add_nutrition_facts'),
+
+  /// Action: add origins.
+  addOrigins(offTag: 'add_origins'),
+
+  /// Action: add stores.
+  addStores(offTag: 'add_stores'),
+
+  /// Action: add labels.
+  addLabels(offTag: 'add_labels'),
+
+  /// Action: add countries.
+  addCountries(offTag: 'add_countries');
+
+  const KnowledgePanelAction({
+    required this.offTag,
+  });
+
+  @override
+  final String offTag;
+
+  /// Returns the first [KnowledgePanelAction] that matches the [offTag].
+  static KnowledgePanelAction? fromOffTag(final String? offTag) =>
+      OffTagged.fromOffTag(offTag, KnowledgePanelAction.values)
+          as KnowledgePanelAction?;
+}

--- a/lib/src/model/knowledge_panel_element.dart
+++ b/lib/src/model/knowledge_panel_element.dart
@@ -299,18 +299,24 @@ class KnowledgePanelTableElement extends JsonObject {
 @JsonSerializable()
 class KnowledgePanelActionElement extends JsonObject {
   /// Possible needed contribute action: add categories.
+  // TODO: deprecated from 2023-05-13; remove when old enough
+  @Deprecated('Use KnowledgePanelAction instead')
   static const String ACTION_ADD_CATEGORIES = 'add_categories';
 
   /// Possible needed contribute action: add ingredients text.
+  // TODO: deprecated from 2023-05-13; remove when old enough
+  @Deprecated('Use KnowledgePanelAction instead')
   static const String ACTION_ADD_INGREDIENTS_TEXT = 'add_ingredients_text';
 
   /// Possible needed contribute action: add nutrition facts.
+  // TODO: deprecated from 2023-05-13; remove when old enough
+  @Deprecated('Use KnowledgePanelAction instead')
   static const String ACTION_ADD_NUTRITION_FACTS = 'add_nutrition_facts';
 
   /// HTML description.
   final String html;
 
-  /// Needed contribute actions, e.g. [ACTION_ADD_CATEGORIES].
+  /// Needed contribute actions, as [KnowledgePanelAction.addCategories.offTag].
   final List<String> actions;
 
   const KnowledgePanelActionElement({


### PR DESCRIPTION
New file:
* `knowledge_panel_action.dart`: Possible needed contribute actions.

Impacted files:
* `knowledge_panel_element.dart`: deprecated const String in favor of the new enum
* `openfoodfacts.dart`: exported the new file

### What
- Simple refactoring, using `OffTagged`

### Fixes bug(s)
- Fixes: #729