### PR TITLE
fix: typo for mono and poly unsaturated fat tags

### DIFF
--- a/lib/src/model/nutrient.dart
+++ b/lib/src/model/nutrient.dart
@@ -136,10 +136,10 @@ enum Nutrient implements OffTagged {
   erucicAcid(typicalUnit: Unit.G, offTag: 'erucic-acid'),
 
   /// Monounsaturated Fats
-  monounsaturatedFat(typicalUnit: Unit.G, offTag: 'monounsaturated'),
+  monounsaturatedFat(typicalUnit: Unit.G, offTag: 'monounsaturated-fat'),
 
   /// Polyunsaturated Fats
-  polyunsaturatedFat(typicalUnit: Unit.G, offTag: 'polyunsaturated'),
+  polyunsaturatedFat(typicalUnit: Unit.G, offTag: 'polyunsaturated-fat'),
 
   /// Alcohol
   alcohol(typicalUnit: Unit.PERCENT, offTag: 'alcohol'),


### PR DESCRIPTION
### What
- There was a typo for mono and poly unsaturated fat tags: a trailing `-tag` was missing in both cases.
- This is fixed in this PR.

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/3980
