### PR TITLE
feat: Added enum for product result status instead of string

### DIFF
--- a/lib/src/model/product_result_v3.dart
+++ b/lib/src/model/product_result_v3.dart
@@ -27,8 +27,8 @@ class ProductResultV3 extends JsonObject {
   /// Status.
   ///
   /// Typical values: [statusFailure], [statusWarning] or [statusSuccess]
-  @JsonKey(includeIfNull: false)
-  String? status;
+  @JsonKey(includeIfNull: false, unknownEnumValue: ProductResultStatus.unKnown)
+  ProductResultStatus? status;
 
   /// Errors.
   ///
@@ -46,13 +46,16 @@ class ProductResultV3 extends JsonObject {
   Product? product;
 
   /// Possible value for [status]: the operation failed.
-  static const String statusFailure = 'failure';
+  static ProductResultStatus statusFailure =
+      ProductResultStatus.failure; //'failure';
 
   /// Possible value for [status]: the operation succeeded with warnings.
-  static const String statusWarning = 'success_with_warnings';
+  static ProductResultStatus statusWarning =
+      ProductResultStatus.successWarnings; //'success_with_warnings';
 
   /// Possible value for [status]: the operation succeeded.
-  static const String statusSuccess = 'success';
+  static ProductResultStatus statusSuccess =
+      ProductResultStatus.success; //'success';
 
   /// Possible value for [result.id]: product found
   static const String resultProductFound = 'product_found';
@@ -84,4 +87,19 @@ class ProductResultV3 extends JsonObject {
     }
     return result;
   }
+}
+
+enum ProductResultStatus {
+  @JsonValue('success')
+  success('success'),
+  @JsonValue('success_with_warnings')
+  successWarnings('success_with_warnings'),
+  @JsonValue('failure')
+  failure('failure'),
+  @JsonValue('unknown_status')
+  unKnown('unknown_status');
+
+  const ProductResultStatus(this.value);
+
+  final String value;
 }

--- a/lib/src/model/product_result_v3.g.dart
+++ b/lib/src/model/product_result_v3.g.dart
@@ -12,7 +12,9 @@ ProductResultV3 _$ProductResultV3FromJson(Map<String, dynamic> json) =>
       ..result = json['result'] == null
           ? null
           : LocalizedTag.fromJson(json['result'] as Map<String, dynamic>)
-      ..status = json['status'] as String?
+      ..status = $enumDecodeNullable(
+          _$ProductResultStatusEnumMap, json['status'],
+          unknownValue: ProductResultStatus.unKnown)
       ..errors = ProductResultV3._fromJsonListAnswerForField(json['errors'])
       ..warnings = ProductResultV3._fromJsonListAnswerForField(json['warnings'])
       ..product = json['product'] == null
@@ -30,9 +32,16 @@ Map<String, dynamic> _$ProductResultV3ToJson(ProductResultV3 instance) {
 
   writeNotNull('code', instance.barcode);
   writeNotNull('result', instance.result);
-  writeNotNull('status', instance.status);
+  writeNotNull('status', _$ProductResultStatusEnumMap[instance.status]);
   writeNotNull('errors', instance.errors);
   writeNotNull('warnings', instance.warnings);
   writeNotNull('product', instance.product);
   return val;
 }
+
+const _$ProductResultStatusEnumMap = {
+  ProductResultStatus.success: 'success',
+  ProductResultStatus.successWarnings: 'success_with_warnings',
+  ProductResultStatus.failure: 'failure',
+  ProductResultStatus.unKnown: 'unknown_status',
+};


### PR DESCRIPTION
### What

- Used enum instead of string as the status of a `ProductResultV3` to handle it easily
