### PR TITLE
feat: 741 - new parameters for Robotoff

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -103,6 +103,8 @@ export 'src/utils/product_helper.dart';
 export 'src/utils/product_query_configurations.dart';
 export 'src/utils/product_search_query_configuration.dart';
 export 'src/utils/query_type.dart';
+export 'src/model/robotoff_question_order.dart';
+export 'src/utils/server_type.dart';
 export 'src/utils/suggestion_manager.dart';
 export 'src/utils/tag_type.dart';
 export 'src/utils/unit_helper.dart';

--- a/lib/src/model/insight.dart
+++ b/lib/src/model/insight.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'off_tagged.dart';
 import '../interface/json_object.dart';
 
 part 'insight.g.dart';
@@ -13,50 +14,52 @@ enum InsightAnnotation {
   final int value;
 }
 
-enum InsightType {
+enum InsightType implements OffTagged {
   @JsonValue('ingredient_spellcheck')
-  INGREDIENT_SPELLCHECK,
+  INGREDIENT_SPELLCHECK(offTag: 'ingredient_spellcheck'),
   @JsonValue('packager_code')
-  PACKAGER_CODE,
+  PACKAGER_CODE(offTag: 'packager_code'),
   @JsonValue('label')
-  LABEL,
+  LABEL(offTag: 'label'),
   @JsonValue('category')
-  CATEGORY,
+  CATEGORY(offTag: 'category'),
   @JsonValue('product_weight')
-  PRODUCT_WEIGHT,
+  PRODUCT_WEIGHT(offTag: 'product_weight'),
   @JsonValue('expiration_date')
-  EXPIRATION_DATE,
+  EXPIRATION_DATE(offTag: 'expiration_date'),
   @JsonValue('brand')
-  BRAND,
+  BRAND(offTag: 'brand'),
   @JsonValue('store')
-  STORE,
+  STORE(offTag: 'store'),
   @JsonValue('nutrient')
-  NUTRIENT,
+  NUTRIENT(offTag: 'nutrient'),
   @JsonValue('undefined')
-  UNDEFINED,
-  UNKNOWN
+  UNDEFINED(offTag: 'undefined'),
+  UNKNOWN(offTag: 'UNKNOWN');
+
+  const InsightType({
+    required this.offTag,
+  });
+
+  @override
+  final String offTag;
+
+  /// Returns the first [InsightType] that matches the [offTag].
+  static InsightType? fromOffTag(final String? offTag) =>
+      OffTagged.fromOffTag(offTag, InsightType.values) as InsightType?;
 }
 
+// TODO: deprecated from 2023-06-13; remove when old enough
+@Deprecated('Use directly InsightType instead')
 extension InsightTypesExtension on InsightType? {
-  static const Map<InsightType, String> _VALUES = {
-    InsightType.INGREDIENT_SPELLCHECK: 'ingredient_spellcheck',
-    InsightType.PACKAGER_CODE: 'packager_code',
-    InsightType.LABEL: 'label',
-    InsightType.CATEGORY: 'category',
-    InsightType.PRODUCT_WEIGHT: 'product_weight',
-    InsightType.EXPIRATION_DATE: 'expiration_date',
-    InsightType.BRAND: 'brand',
-    InsightType.STORE: 'store',
-    InsightType.NUTRIENT: 'nutrient',
-    InsightType.UNDEFINED: 'undefined',
-  };
+  // TODO: deprecated from 2023-06-13; remove when old enough
+  @Deprecated('Use offTag instead')
+  String? get value => this?.offTag;
 
-  String? get value => _VALUES[this];
-
-  static InsightType getType(String? s) => InsightType.values.firstWhere(
-        (final InsightType key) => _VALUES[key] == s,
-        orElse: () => InsightType.UNDEFINED,
-      );
+  // TODO: deprecated from 2023-06-13; remove when old enough
+  @Deprecated('Use InsightType.fromOffTag instead')
+  static InsightType getType(String? s) =>
+      InsightType.fromOffTag(s) ?? InsightType.UNDEFINED;
 }
 
 @JsonSerializable()
@@ -102,8 +105,8 @@ class Insight {
     }
     List<Insight> result = [];
     for (dynamic jsonInsight in json) {
-      InsightType insightType =
-          InsightTypesExtension.getType(jsonInsight['type']);
+      final InsightType insightType =
+          InsightType.fromOffTag(jsonInsight['type']) ?? InsightType.UNDEFINED;
 
       result.add(Insight(
           id: jsonInsight['id'],
@@ -126,7 +129,7 @@ class Insight {
       Map<String, dynamic> jsonInsight = {};
 
       jsonInsight['id'] = insight.id;
-      jsonInsight['type'] = insight.type.value;
+      jsonInsight['type'] = insight.type?.offTag;
       jsonInsight['barcode'] = insight.barcode;
       jsonInsight['countries'] = insight.countries;
       jsonInsight['lang'] = insight.lang;

--- a/lib/src/model/robotoff_question_order.dart
+++ b/lib/src/model/robotoff_question_order.dart
@@ -1,0 +1,20 @@
+import 'off_tagged.dart';
+
+/// Order for Robotoff questions.
+enum RobotoffQuestionOrder implements OffTagged {
+  /// order by (descending) model confidence, null confidence insights come last
+  confidence(offTag: 'confidence'),
+
+  /// random order
+  random(offTag: 'random'),
+
+  /// order by (descending) popularity (=scan count)
+  popularity(offTag: 'popularity');
+
+  const RobotoffQuestionOrder({
+    required this.offTag,
+  });
+
+  @override
+  final String offTag;
+}

--- a/lib/src/utils/server_type.dart
+++ b/lib/src/utils/server_type.dart
@@ -1,0 +1,23 @@
+import '../model/off_tagged.dart';
+
+/// Type of Server (e.g. "food facts", "beauty facts", ...).
+enum ServerType implements OffTagged {
+  /// Open Food Facts
+  openFoodFacts(offTag: 'off'),
+
+  /// Open Beauty Facts
+  openBeautyFacts(offTag: 'obf'),
+
+  /// Open Pet Food Facts
+  openPetFoodFacts(offTag: 'opff'),
+
+  /// Open Product Facts
+  openProductFacts(offTag: 'opf');
+
+  const ServerType({
+    required this.offTag,
+  });
+
+  @override
+  final String offTag;
+}

--- a/test/api_get_robotoff_test.dart
+++ b/test/api_get_robotoff_test.dart
@@ -58,29 +58,35 @@ void main() {
       }
     });
 
-    test('get 2 random questions with types', () async {
+    test('get popular questions with types', () async {
       const InsightType type = InsightType.CATEGORY;
+      const int numQuestions = 10;
       final RobotoffQuestionResult result =
-          await RobotoffAPIClient.getRandomQuestions(
-        OpenFoodFactsLanguage.FRENCH,
-        TestConstants.PROD_USER,
-        types: [type],
-        count: 2,
+          await RobotoffAPIClient.getQuestions(
+        OpenFoodFactsLanguage.GERMAN,
+        user: TestConstants.PROD_USER,
+        insightTypes: [type],
+        count: numQuestions,
+        country: OpenFoodFactsCountry.GERMANY,
+        questionOrder: RobotoffQuestionOrder.popularity,
       );
 
       expect(result.status, isNotNull);
       expect(result.status, 'found');
-      expect(result.questions!.length, 2);
-      expect(result.questions![0].insightType, type);
-      expect(result.questions![1].insightType, type);
+      expect(result.questions, isNotNull);
+      expect(result.questions!.length, numQuestions);
+      for (final RobotoffQuestion question in result.questions!) {
+        expect(question.insightType, type);
+      }
     });
 
     test('get 2 random questions with no specific type', () async {
       final RobotoffQuestionResult result =
-          await RobotoffAPIClient.getRandomQuestions(
+          await RobotoffAPIClient.getQuestions(
         OpenFoodFactsLanguage.FRENCH,
-        TestConstants.PROD_USER,
+        user: TestConstants.PROD_USER,
         count: 2,
+        questionOrder: RobotoffQuestionOrder.random,
       );
 
       expect(result.status, isNotNull);
@@ -93,6 +99,7 @@ void main() {
     test('get random insight', () async {
       final InsightsResult result = await RobotoffAPIClient.getRandomInsights(
         type: InsightType.CATEGORY,
+        country: OpenFoodFactsCountry.FRANCE,
       );
 
       expect(result.status, isNotNull);


### PR DESCRIPTION
### What
- New parameters for Robotoff
   - server type (which opens robotoff questions to OpenBeautyFacts, for instance)
   - "order by" for questions (so far we only used "random", and now we can use "confidence" and "popularity")
   - added and fixed the country parameter - now we can ask robotoff questions filtered by country and language

### Fixes bug(s)
- #741
- #742

### Files
New files:
* `robotoff_question_order.dart`: Order for Robotoff questions.
* `server_type.dart`: Type of Server (e.g. "food facts", "beauty facts", ...).

Impacted files:
* `api_get_robotoff_test.dart`: refactored
* `insight.dart`: refactored as `OffTagged`
* `openfoodfacts.dart`: exported the new 2 files.
* `robot_off_api_client.dart`: deprecated `getRandomQuestions` in favor of new method `getQuestions`; new parameters for `getRandomInsights`, `getProductInsights` and `getProductQuestions`