### PR TITLE
ci: release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@
           id: release
           uses: GoogleCloudPlatform/release-please-action@v3
           with:
-            token: ${{ secrets.GITHUB_TOKEN }}
+            token: ${{ secrets.OPENFOODFACTS_BOT_PAT }}
             release-type: dart
 
 #        - name: Chekout code


### PR DESCRIPTION
The release was not triggered due to GitHub's recursive run protection. Now we releases using the Openfoodfacts-bot account

