### PR TITLE
feat: Allow to pass `insight_types` to `api/v1/questions/$barcode`

### DIFF
--- a/lib/src/robot_off_api_client.dart
+++ b/lib/src/robot_off_api_client.dart
@@ -4,15 +4,15 @@ import 'package:http/http.dart';
 
 import 'model/insight.dart';
 import 'model/robotoff_question.dart';
+import 'model/robotoff_question_order.dart';
 import 'model/status.dart';
 import 'model/user.dart';
 import 'utils/country_helper.dart';
 import 'utils/http_helper.dart';
 import 'utils/language_helper.dart';
 import 'utils/query_type.dart';
-import 'model/robotoff_question_order.dart';
-import 'utils/uri_helper.dart';
 import 'utils/server_type.dart';
+import 'utils/uri_helper.dart';
 
 class RobotoffAPIClient {
   RobotoffAPIClient._();
@@ -84,11 +84,15 @@ class RobotoffAPIClient {
     int? count,
     ServerType? serverType,
     QueryType? queryType,
+    List<InsightType>? insightTypes,
   }) async {
     final Map<String, String> parameters = <String, String>{
       'lang': language.code,
       if (count != null) 'count': count.toString(),
       if (serverType != null) 'server_type': serverType.offTag,
+      if (insightTypes != null)
+        'insight_types':
+            insightTypes.map((InsightType type) => type.offTag).join(','),
     };
 
     var robotoffQuestionUri = UriHelper.getRobotoffUri(

--- a/test/api_get_robotoff_test.dart
+++ b/test/api_get_robotoff_test.dart
@@ -59,18 +59,40 @@ void main() {
       }
     });
 
-    test('get questions with a given insight type', () async {
-      RobotoffQuestionResult result =
-          await RobotoffAPIClient.getProductQuestions(
-        '3270160471966',
-        OpenFoodFactsLanguage.FRENCH,
-        user: TestConstants.PROD_USER,
-        insightTypes: [InsightType.CATEGORY],
+    test('Find questions by insight type', () async {
+      // Let's find 5 products with questions
+      final OpenFoodFactsLanguage language = OpenFoodFactsLanguage.ENGLISH;
+      final User user = TestConstants.PROD_USER;
+
+      final RobotoffQuestionResult productsWithQuestions =
+          await RobotoffAPIClient.getQuestions(
+        language,
+        user: user,
+        count: 5,
       );
 
-      if (result.status != 'no_questions') {
-        for (RobotoffQuestion question in result.questions!) {
-          expect(question.insightType, InsightType.CATEGORY);
+      // For each question, check if we can get it with [getProductQuestions]
+      // with the given insight type
+      if (productsWithQuestions.questions?.isNotEmpty == true) {
+        for (RobotoffQuestion question in productsWithQuestions.questions!) {
+          if (question.insightType != null) {
+            final InsightType insightType = question.insightType!;
+
+            final RobotoffQuestionResult result =
+                await RobotoffAPIClient.getProductQuestions(
+              question.barcode!,
+              language,
+              user: user,
+              insightTypes: [insightType],
+            );
+
+            int count = result.questions!
+                .where((RobotoffQuestion productQuestion) =>
+                    productQuestion.insightType == insightType)
+                .length;
+
+            expect(count, greaterThan(0));
+          }
         }
       }
     });

--- a/test/api_get_robotoff_test.dart
+++ b/test/api_get_robotoff_test.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:test/test.dart';
+
 import 'test_constants.dart';
 
 void main() {
@@ -55,6 +56,22 @@ void main() {
         expect(result.questions![0].insightType, InsightType.CATEGORY);
         expect(result.questions![0].imageUrl,
             'https://static.openfoodfacts.org/images/products/327/457/080/0026/front_en.4.400.jpg');
+      }
+    });
+
+    test('get questions with a given insight type', () async {
+      RobotoffQuestionResult result =
+          await RobotoffAPIClient.getProductQuestions(
+        '3270160471966',
+        OpenFoodFactsLanguage.FRENCH,
+        user: TestConstants.PROD_USER,
+        insightTypes: [InsightType.CATEGORY],
+      );
+
+      if (result.status != 'no_questions') {
+        for (RobotoffQuestion question in result.questions!) {
+          expect(question.insightType, InsightType.CATEGORY);
+        }
       }
     });
 


### PR DESCRIPTION
Hi everyone 🖐️!

We can now filter questions by giving one or more insight types.
This is not yet deployed (waiting for https://github.com/openfoodfacts/robotoff/pull/1134), so please don't merge this PR yet.

But we'll be ready once it's OK.