### PR TITLE
fix: get user products tests

### DIFF
--- a/test/api_get_user_products_test.dart
+++ b/test/api_get_user_products_test.dart
@@ -10,7 +10,8 @@ void main() {
 
   group('$OpenFoodAPIClient get user products', () {
     const String userId = 'monsieurtanuki';
-    const int pageSize = 100; // should be big enough to get everything on page1
+    // should be big enough to get everything on page1
+    const int pageSize = 1000;
     final String toBeCompletedTag = ProductState.COMPLETED.toBeCompletedTag;
 
     Future<int> getCount(


### PR DESCRIPTION
### What
- While reviewing #748, I noticed an unrelated bug in the tests.
- The fix is only to set a higher number of downloaded items, so that the algorithm of the test does work.

### Impacted file
* `api_get_user_products_test.dart`: fixed a test bug (set a higher limit)
