### PR TITLE
feat: Allow to pass a country and/or a language to the `register` user method

### DIFF
--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -1134,6 +1134,8 @@ class OpenFoodAPIClient {
     required String email,
     String? orgName,
     bool newsletter = true,
+    final OpenFoodFactsLanguage? language,
+    final OpenFoodFactsCountry? country,
     QueryType? queryType,
   }) async {
     if (name.length > USER_NAME_MAX_LENGTH) {
@@ -1142,11 +1144,19 @@ class OpenFoodAPIClient {
       );
     }
 
-    var registerUri = UriHelper.getUri(
+    Uri registerUri = UriHelper.getUri(
       path: '/cgi/user.pl',
       queryType: queryType,
       addUserAgentParameters: false,
     );
+
+    if (language != null || country != null) {
+      registerUri = UriHelper.replaceSubdomain(
+        registerUri,
+        language: language,
+        country: country,
+      );
+    }
 
     Map<String, String> data = <String, String>{
       'name': name,

--- a/test/user_management_test_prod.dart
+++ b/test/user_management_test_prod.dart
@@ -92,8 +92,8 @@ void main() {
       );
       expect(response.status, 400);
       expect(
-        response.statusErrors!
-            .contains(SignUpStatusError.USERNAME_ALREADY_USED),
+        response.error!.contains(
+            'Ce nom d\'utilisateur existe déjà, choisissez en un autre.'),
         isTrue,
       );
     });
@@ -108,7 +108,8 @@ void main() {
       );
       expect(response.status, 400);
       expect(
-        response.statusErrors!.contains(SignUpStatusError.EMAIL_ALREADY_USED),
+        response.error!.contains(
+            'Ce nom d\'utilisateur existe déjà, choisissez en un autre.'),
         isTrue,
       );
     });

--- a/test/user_management_test_prod.dart
+++ b/test/user_management_test_prod.dart
@@ -9,7 +9,8 @@ void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
   OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
-  group('Create existing user', () {
+  group('Create existing user (without specifying a country, nor a language)',
+      () {
     final User user = TestConstants.PROD_USER;
     final String email = 'grumpf@gmx.de';
 
@@ -48,6 +49,62 @@ void main() {
         name: _generateRandomString(OpenFoodAPIClient.USER_NAME_MAX_LENGTH),
         user: user,
         email: 'test@test.com',
+      );
+      expect(response.status, 400);
+      expect(
+        response.statusErrors!.contains(SignUpStatusError.EMAIL_ALREADY_USED),
+        isTrue,
+      );
+    });
+  });
+
+  group('Create existing user by forcing a country + language', () {
+    final User user = TestConstants.PROD_USER;
+    final String email = 'grumpf@gmx.de';
+    final OpenFoodFactsCountry country = OpenFoodFactsCountry.FRANCE;
+    final OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
+
+    test('Create a FR-fr user with a long username', () async {
+      String randomUserName = List.filled(
+        OpenFoodAPIClient.USER_NAME_MAX_LENGTH + 1,
+        'A',
+      ).join();
+
+      expect(
+        OpenFoodAPIClient.register(
+          name: randomUserName,
+          user: user,
+          email: email,
+          country: country,
+          language: language,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('Create an existing FR-fr user', () async {
+      SignUpStatus response = await OpenFoodAPIClient.register(
+        name: 'Irrelevant',
+        user: user,
+        email: email,
+        country: country,
+        language: language,
+      );
+      expect(response.status, 400);
+      expect(
+        response.statusErrors!
+            .contains(SignUpStatusError.USERNAME_ALREADY_USED),
+        isTrue,
+      );
+    });
+
+    test('Create a FR-fr user with an existing email', () async {
+      SignUpStatus response = await OpenFoodAPIClient.register(
+        name: _generateRandomString(OpenFoodAPIClient.USER_NAME_MAX_LENGTH),
+        user: user,
+        email: 'test@test.com',
+        country: country,
+        language: language,
       );
       expect(response.status, 400);
       expect(


### PR DESCRIPTION
Hi everyone,

Today, all users are registered on the `world.openfoodfacts.org` subdomain.
If they choose to also subscribe to the newsletter, they will receive it in English, but we have translated issues.

That's why we can now pass a country and/or a language.

It will fix #753 