### PR TITLE
fix: The registration checks the username length on the wrong field

### DIFF
--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -1138,7 +1138,7 @@ class OpenFoodAPIClient {
     final OpenFoodFactsCountry? country,
     QueryType? queryType,
   }) async {
-    if (name.length > USER_NAME_MAX_LENGTH) {
+    if (user.userId.length > USER_NAME_MAX_LENGTH) {
       throw ArgumentError(
         'A username may not exceed $USER_NAME_MAX_LENGTH characters!',
       );


### PR DESCRIPTION
Hi everyone,

As part of https://github.com/openfoodfacts/smooth-app/issues/3740, I've noticed that the Dart package checks the length of the username.
But actually, the check is done on the name and not the username.