### PR TITLE
feat: Registration/Password lost: better catch 504 errors from the server

### DIFF
--- a/lib/src/model/sign_up_status.dart
+++ b/lib/src/model/sign_up_status.dart
@@ -101,6 +101,7 @@ class SignUpStatus extends Status {
         SignUpStatusError.INVALID_PASSWORD,
     'The user name must contain only unaccented letters, digits and dashes.':
         SignUpStatusError.INVALID_USERNAME,
+    '504 Gateway Time-out': SignUpStatusError.SERVER_BUSY,
   };
 }
 
@@ -121,6 +122,9 @@ enum SignUpStatusError {
 
   /// The password is incorrect (too short)
   INVALID_PASSWORD,
+
+  /// When the server is down (504 Gateway timeout)
+  SERVER_BUSY,
 
   /// Generic error
   UNKNOWN,

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -1224,7 +1224,7 @@ class OpenFoodAPIClient {
         body:
             'An email with a link to reset your password has been sent to the e-mail address associated with your account.',
       );
-    } else if (status.status is int && status.status != 500) {
+    } else if (status.status is int && status.status < 500) {
       return status.copyWith(status: 400);
     } else {
       /// Trigger real 5xx errors

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -1224,8 +1224,11 @@ class OpenFoodAPIClient {
         body:
             'An email with a link to reset your password has been sent to the e-mail address associated with your account.',
       );
-    } else {
+    } else if (status.status is int && status.status != 500) {
       return status.copyWith(status: 400);
+    } else {
+      /// Trigger real 5xx errors
+      return status;
     }
   }
 


### PR DESCRIPTION
Hi everyone,

Due to the current situation with the infrastructure, we often have 504 errors.
Here is a better catch of the errors for the registration and the password lost.
It's here limited to the user management, but it's more critical here.