### PR TITLE
feat: Reset password: allow to receive "translated" email

### DIFF
--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -1128,6 +1128,9 @@ class OpenFoodAPIClient {
   ///  }
   /// ```
   ///
+  /// If the user wants to receive the [newsletter], by default it will be in
+  /// English. If you want to change this behavior, please provide a [language]
+  /// and/or a [country] for a localized content.
   static Future<SignUpStatus> register({
     required User user,
     required String name,
@@ -1185,15 +1188,28 @@ class OpenFoodAPIClient {
   /// Uses reset_password.pl to send a password reset Email
   /// needs only
   /// Returns [Status.status] 200 = complete; 400 = wrong inputs or other error + [Status.error]; 500 = server error;
+  ///
+  /// By default the email will be sent in English, please provide a [language]
+  /// and/or a [country] to have a localized content
   static Future<Status> resetPassword(
     String emailOrUserID, {
     QueryType? queryType,
+    final OpenFoodFactsLanguage? language,
+    final OpenFoodFactsCountry? country,
   }) async {
     var passwordResetUri = UriHelper.getUri(
       path: '/cgi/reset_password.pl',
       queryType: queryType,
       addUserAgentParameters: false,
     );
+
+    if (language != null || country != null) {
+      passwordResetUri = UriHelper.replaceSubdomain(
+        passwordResetUri,
+        language: language,
+        country: country,
+      );
+    }
 
     Map<String, String> data = <String, String>{
       'userid_or_email': emailOrUserID,

--- a/test/user_management_test_prod.dart
+++ b/test/user_management_test_prod.dart
@@ -130,6 +130,19 @@ void main() {
 
     expect(status.status, 200);
   });
+
+  test('Reset password in French', () async {
+    Status status = await OpenFoodAPIClient.resetPassword(
+      TestConstants.TEST_USER.userId,
+      language: OpenFoodFactsLanguage.FRENCH,
+    );
+
+    expect(
+      status.body!,
+      contains(
+          'Un e-mail avec un lien pour vous permettre de changer le mot de passe a été envoyé'),
+    );
+  });
 }
 
 String _generateRandomString(int length) {


### PR DESCRIPTION
Hi everyone,

When we want to reset the password of the user, we use the world instance of OFF.
By providing a country and/or language, the user will then receive the localized content