### PR TITLE
feat: 785 - list of problematic attributes as score explanation

### DIFF
--- a/lib/src/personalized_search/available_attribute_groups.dart
+++ b/lib/src/personalized_search/available_attribute_groups.dart
@@ -1,5 +1,6 @@
 import '../model/attribute_group.dart';
 import '../utils/http_helper.dart';
+import '../utils/language_helper.dart';
 
 /// Referential of attribute groups, with loader.
 class AvailableAttributeGroups {
@@ -25,6 +26,12 @@ class AvailableAttributeGroups {
 
   /// Where a localized JSON file can be found.
   /// [languageCode] is a 2-letter language code.
+  // TODO: deprecated from 2023-08-12; remove when old enough
+  @Deprecated('Use getLocalizedUrl instead')
   static String getUrl(final String languageCode) =>
       'https://world.openfoodfacts.org/api/v2/attribute_groups?lc=$languageCode';
+
+  /// Where a localized JSON file can be found.
+  static String getLocalizedUrl(final OpenFoodFactsLanguage language) =>
+      'https://world.openfoodfacts.org/api/v2/attribute_groups?lc=${language.code}';
 }

--- a/lib/src/personalized_search/available_preference_importances.dart
+++ b/lib/src/personalized_search/available_preference_importances.dart
@@ -1,5 +1,6 @@
 import 'preference_importance.dart';
 import '../utils/http_helper.dart';
+import '../utils/language_helper.dart';
 
 /// Referential of preference importance, with loader.
 class AvailablePreferenceImportances {
@@ -43,8 +44,14 @@ class AvailablePreferenceImportances {
 
   /// Where a localized JSON file can be found.
   /// [languageCode] is a 2-letter language code.
+  // TODO: deprecated from 2023-08-12; remove when old enough
+  @Deprecated('Use getLocalizedUrl instead')
   static String getUrl(final String languageCode) =>
       'https://world.openfoodfacts.org/api/v2/preferences?lc=$languageCode';
+
+  /// Where a localized JSON file can be found.
+  static String getLocalizedUrl(final OpenFoodFactsLanguage language) =>
+      'https://world.openfoodfacts.org/api/v2/preferences?lc=${language.code}';
 
   /// Returns the index of an importance.
   ///

--- a/test/api_matched_product_v1_test.dart
+++ b/test/api_matched_product_v1_test.dart
@@ -27,11 +27,10 @@ void main() {
         ),
       );
       const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.ENGLISH;
-      final String languageCode = language.code;
       final String importanceUrl =
-          AvailablePreferenceImportances.getUrl(languageCode);
+          AvailablePreferenceImportances.getLocalizedUrl(language);
       final String attributeGroupUrl =
-          AvailableAttributeGroups.getUrl(languageCode);
+          AvailableAttributeGroups.getLocalizedUrl(language);
       http.Response response;
       response = await http.get(Uri.parse(importanceUrl));
       expect(response.statusCode, HTTP_OK);

--- a/test/api_product_preferences_test.dart
+++ b/test/api_product_preferences_test.dart
@@ -32,11 +32,10 @@ void main() {
           notify: () => refreshCounter++,
         ),
       );
-      final String languageCode = language.code;
       final String importanceUrl =
-          AvailablePreferenceImportances.getUrl(languageCode);
+          AvailablePreferenceImportances.getLocalizedUrl(language);
       final String attributeGroupUrl =
-          AvailableAttributeGroups.getUrl(languageCode);
+          AvailableAttributeGroups.getLocalizedUrl(language);
       http.Response response;
       response = await http.get(Uri.parse(importanceUrl));
       expect(response.statusCode, HTTP_OK);


### PR DESCRIPTION
### What
- The PR provides, as an option, lists of problematic attributes when the score is not explicit (unknown match, may not match, does not match).
- With this, we can be more verbose than "It's not OK", and provide localized explanations about the score, e.g. `'Caractère végétarien inconnu'` (FR) / `'Vegetarian status unknown'` (EN).

### Fixes bug(s)
- Closes: #785

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1118

### Impacted files
* `api_matched_product_v1_test.dart`: minor refactoring
* `api_matched_product_v2_test.dart`: added a test about score explanations
* `api_product_preferences_test.dart`: minor refactoring
* `available_attribute_groups.dart`: refactored with language instead of language code
* `available_preference_importances.dart`: refactored with language instead of language code
* `matched_product_v2.dart`: added an optional parameter that lists the problematic attributes when the status unknown, does not match and may not match