### PR TITLE
fix!: fix for the uk/gb country code case

### DIFF
--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -1084,14 +1084,14 @@ class OpenFoodAPIClient {
   ///   print(orderedNutrients.nutrients[10].name); // Vitamin A
   /// ```
   static Future<OrderedNutrients> getOrderedNutrients({
-    required final String? cc,
+    required final OpenFoodFactsCountry country,
     required final OpenFoodFactsLanguage language,
     final QueryType? queryType,
   }) async =>
       OrderedNutrients.fromJson(
         HttpHelper().jsonDecode(
           await getOrderedNutrientsJsonString(
-            country: CountryHelper.fromJson(cc)!,
+            country: country,
             language: language,
           ),
         ),

--- a/lib/src/utils/country_helper.dart
+++ b/lib/src/utils/country_helper.dart
@@ -760,8 +760,12 @@ enum OpenFoodFactsCountry implements OffTagged {
   @override
   final String offTag;
 
-  /// Returns the first [OpenFoodFactsCountry] that matches the [offTag].
-  static OpenFoodFactsCountry? fromOffTag(final String? offTag) {
+  /// Returns the [OpenFoodFactsCountry] that matches the [offTag].
+  ///
+  /// Case-insensitive.
+  /// Special case: "uk" and "gb" both mean United Kingdom.
+  static OpenFoodFactsCountry? fromOffTag(String? offTag) {
+    offTag = offTag?.toLowerCase();
     // special case as we use 'uk' in off-dart
     if (offTag == 'gb') {
       return OpenFoodFactsCountry.UNITED_KINGDOM;

--- a/lib/src/utils/country_helper.dart
+++ b/lib/src/utils/country_helper.dart
@@ -761,20 +761,12 @@ enum OpenFoodFactsCountry implements OffTagged {
   final String offTag;
 
   /// Returns the first [OpenFoodFactsCountry] that matches the [offTag].
-  static OpenFoodFactsCountry? fromOffTag(final String? offTag) =>
-      OffTagged.fromOffTag(offTag, OpenFoodFactsCountry.values)
-          as OpenFoodFactsCountry?;
-}
-
-/// Helper class around [OpenFoodFactsCountry]
-class CountryHelper {
-  /// Converts an ISO 2 code into an [OpenFoodFactsCountry] (case-insensitive).
-  ///
-  /// E.g. 'fr' and 'FR' will give the same result: OpenFoodFactsCountry.FRANCE.
-  static OpenFoodFactsCountry? fromJson(String? code) {
-    if (code == null) {
-      return null;
+  static OpenFoodFactsCountry? fromOffTag(final String? offTag) {
+    // special case as we use 'uk' in off-dart
+    if (offTag == 'gb') {
+      return OpenFoodFactsCountry.UNITED_KINGDOM;
     }
-    return OpenFoodFactsCountry.fromOffTag(code.toLowerCase());
+    return OffTagged.fromOffTag(offTag, OpenFoodFactsCountry.values)
+        as OpenFoodFactsCountry?;
   }
 }

--- a/test/api_off_tag_test.dart
+++ b/test/api_off_tag_test.dart
@@ -1,0 +1,25 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:test/test.dart';
+
+/// Tests about [OffTagged] `enum`s.
+void main() {
+  test('$OpenFoodAPIClient country', () async {
+    const Map<String?, OpenFoodFactsCountry?> expectedCountries =
+        <String?, OpenFoodFactsCountry?>{
+      'fr': OpenFoodFactsCountry.FRANCE,
+      'FR': OpenFoodFactsCountry.FRANCE,
+      'fR': OpenFoodFactsCountry.FRANCE,
+      'Fr': OpenFoodFactsCountry.FRANCE,
+      'uk': OpenFoodFactsCountry.UNITED_KINGDOM,
+      'UK': OpenFoodFactsCountry.UNITED_KINGDOM,
+      'gb': OpenFoodFactsCountry.UNITED_KINGDOM,
+      'GB': OpenFoodFactsCountry.UNITED_KINGDOM,
+      null: null,
+      'this is not a country code': null,
+    };
+    for (final MapEntry<String?, OpenFoodFactsCountry?> entry
+        in expectedCountries.entries) {
+      expect(OpenFoodFactsCountry.fromOffTag(entry.key), entry.value);
+    }
+  });
+}

--- a/test/ordered_nutrient_test.dart
+++ b/test/ordered_nutrient_test.dart
@@ -164,7 +164,7 @@ void main() {
       for (final OpenFoodFactsCountry country in countries) {
         checkNutrients(
           await OpenFoodAPIClient.getOrderedNutrients(
-            cc: country.offTag,
+            country: country,
             language: language,
           ),
           country,
@@ -191,12 +191,16 @@ void main() {
         OpenFoodFactsLanguage.ENGLISH: 'Energy',
         OpenFoodFactsLanguage.PORTUGUESE: 'Energia',
       };
-      const Set<String> countries = {'us', 'it', 'br'};
+      const Set<OpenFoodFactsCountry> countries = {
+        OpenFoodFactsCountry.USA,
+        OpenFoodFactsCountry.ITALY,
+        OpenFoodFactsCountry.BRAZIL,
+      };
       for (final OpenFoodFactsLanguage language in energies.keys) {
-        for (final String country in countries) {
+        for (final OpenFoodFactsCountry country in countries) {
           final OrderedNutrients orderedNutrients =
               await OpenFoodAPIClient.getOrderedNutrients(
-            cc: country,
+            country: country,
             language: language,
           );
           final OrderedNutrient? found =


### PR DESCRIPTION
### What
- In Smoothie we detected a possible bug regarding our usage of 'uk' as United Kingdom country code - while the official country code is 'gb'.
- It got fixed in Smoothie - the current PR is about fixing it in off-dart too.
- Meanwhile, country related minor issues were fixed. Those are minor breaking changes, that will be embedded in the already "breaking change" next release.

### Impacted files
* `country_helper.dart`: `fromOffTag` now includes a fix for the uk/gb case; breaking change - removed class `CountryHelper`
* `open_food_api_client.dart`: breaking change - `getOrderedNutrients` now uses parameter `OpenFoodFactsCountry country`
* `ordered_nutrient_test.dart`: minor refactoring