### PR TITLE
feat: 69 - method to get a server type from its off tag

### DIFF
--- a/lib/src/utils/server_type.dart
+++ b/lib/src/utils/server_type.dart
@@ -20,4 +20,8 @@ enum ServerType implements OffTagged {
 
   @override
   final String offTag;
+
+  /// Returns the [ServerType] that matches the [offTag].
+  static ServerType? fromOffTag(final String? offTag) =>
+      OffTagged.fromOffTag(offTag, ServerType.values) as ServerType?;
 }


### PR DESCRIPTION
### What
- We forgot to implement a method to get a server type from an off tag (e.g. `off`, `obf`, `opf` and `opff`).
- We need this method for Smoothie in order to store the server type into preferences.

### Part of 
- #69

### Impacted file
* `server_type.dart`: implemented the `fromOffTag` method