### PR TITLE
feat: insight - method to get an insight annotation from an int value

### DIFF
--- a/lib/src/model/insight.dart
+++ b/lib/src/model/insight.dart
@@ -12,6 +12,15 @@ enum InsightAnnotation {
   const InsightAnnotation(this.value);
 
   final int value;
+
+  static InsightAnnotation? fromInt(final int annotation) {
+    for (final InsightAnnotation insightAnnotation in values) {
+      if (insightAnnotation.value == annotation) {
+        return insightAnnotation;
+      }
+    }
+    return null;
+  }
 }
 
 enum InsightType implements OffTagged {


### PR DESCRIPTION
### What
- In Smoothie we had to implement that method.
- Now we implement that method directly in off-dart.

### Impacted file
* `insight.dart`: implemented the `fromInt` method for `InsightAnnotation`