### PR TITLE
feat: specified minimum size for uploaded images (for pre-checks)

### DIFF
--- a/lib/src/utils/image_helper.dart
+++ b/lib/src/utils/image_helper.dart
@@ -5,6 +5,12 @@ import '../model/product_image.dart';
 
 /// Helper class related to product pictures
 class ImageHelper {
+  /// Minimum accepted width for an uploaded image.
+  static const int minimumWidth = 640;
+
+  /// Minimum accepted height· for an uploaded image.
+  static const int minimumHeight = 160;
+
   /// Returns the [image] full url - for a specific [imageSize] if needed.
   ///
   /// Returns null is [barcode] is null.

--- a/lib/src/utils/image_helper.dart
+++ b/lib/src/utils/image_helper.dart
@@ -8,7 +8,7 @@ class ImageHelper {
   /// Minimum accepted width for an uploaded image.
   static const int minimumWidth = 640;
 
-  /// Minimum accepted height· for an uploaded image.
+  /// Minimum accepted height for an uploaded image.
   static const int minimumHeight = 160;
 
   /// Returns the [image] full url - for a specific [imageSize] if needed.


### PR DESCRIPTION
### What
- Uploaded images have a minimum accepted size. Smaller images get rejected.
- In order to avoid this, developers can check the image size before trying to upload them.
- This is what we do in Smoothie. With this PR we can do that from values taken from off-dart.

### Impacted file
* `image_helper.dart`: specified minimum size for uploaded images