### PR TITLE
feat: method to get the Uri host (e.g. for ping)

### DIFF
--- a/lib/src/utils/uri_helper.dart
+++ b/lib/src/utils/uri_helper.dart
@@ -23,15 +23,18 @@ class UriHelper {
   }) =>
       Uri(
         scheme: OpenFoodAPIConfiguration.uriScheme,
-        host: OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
-            ? OpenFoodAPIConfiguration.uriProdHost
-            : OpenFoodAPIConfiguration.uriTestHost,
+        host: getUriHost(queryType),
         path: path,
         queryParameters: addUserAgentParameters
             ? HttpHelper.addUserAgentParameters(queryParameters)
             : queryParameters,
         userInfo: userInfo,
       );
+
+  static String getUriHost(final QueryType? queryType) =>
+      OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
+          ? OpenFoodAPIConfiguration.uriProdHost
+          : OpenFoodAPIConfiguration.uriTestHost;
 
   static Uri getPostUri({
     required final String path,


### PR DESCRIPTION
### What
- This is a method we had to implement in Smoothie.
- Typical use-case: trying to ping the server after a connection failed.
- Now we can get the uri host directly.

### Impacted file
* `uri_helper.dart`: new `getUriHost` method