### PR TITLE
feat!: 801 - more url flexibility with non static UriHelper

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -101,7 +101,6 @@ export 'src/utils/product_fields.dart';
 export 'src/utils/product_helper.dart';
 export 'src/utils/product_query_configurations.dart';
 export 'src/utils/product_search_query_configuration.dart';
-export 'src/utils/query_type.dart';
 export 'src/model/robotoff_question_order.dart';
 export 'src/utils/server_type.dart';
 export 'src/utils/suggestion_manager.dart';

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -6,7 +6,7 @@ import 'model/events_base.dart';
 import 'model/leaderboard_entry.dart';
 
 import 'utils/http_helper.dart';
-import 'utils/query_type.dart';
+import 'utils/open_food_api_configuration.dart';
 import 'utils/uri_helper.dart';
 
 /// Client calls of the Events API (Open Food Facts).
@@ -21,7 +21,7 @@ class EventsAPIClient {
     final String? deviceId,
     final int? skip,
     final int? limit,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperEventsProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     if (userId != null) {
@@ -37,12 +37,11 @@ class EventsAPIClient {
       parameters['limit'] = limit.toString();
     }
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getEventsUri(
+      uriHelper.getUri(
         path: '/events',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final List<EventsBase> result = <EventsBase>[];
@@ -58,7 +57,7 @@ class EventsAPIClient {
   static Future<Map<String, int>> getEventsCount({
     final String? userId,
     final String? deviceId,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperEventsProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     if (userId != null) {
@@ -68,12 +67,11 @@ class EventsAPIClient {
       parameters['device_id'] = deviceId;
     }
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getEventsUri(
+      uriHelper.getUri(
         path: '/events/count',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final Map<String, int> result = <String, int>{};
@@ -90,7 +88,7 @@ class EventsAPIClient {
     final String? userId,
     final String? deviceId,
     final String? eventType,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperEventsProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     if (userId != null) {
@@ -103,12 +101,11 @@ class EventsAPIClient {
       parameters['event_type'] = eventType;
     }
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getEventsUri(
+      uriHelper.getUri(
         path: '/scores',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final Map<String, dynamic> json =
@@ -120,7 +117,7 @@ class EventsAPIClient {
   static Future<List<BadgeBase>> getBadges({
     final String? userId,
     final String? deviceId,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperEventsProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     if (userId != null) {
@@ -130,12 +127,11 @@ class EventsAPIClient {
       parameters['device_id'] = deviceId;
     }
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getEventsUri(
+      uriHelper.getUri(
         path: '/badges',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final List<BadgeBase> result = <BadgeBase>[];
@@ -150,19 +146,18 @@ class EventsAPIClient {
   /// Returns all the [LeaderboardEntry], with optional filters.
   static Future<List<LeaderboardEntry>> getLeaderboard({
     final String? eventType,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperEventsProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     if (eventType != null) {
       parameters['event_type'] = eventType;
     }
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getEventsUri(
+      uriHelper.getUri(
         path: '/leaderboard',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final List<LeaderboardEntry> result = <LeaderboardEntry>[];

--- a/lib/src/folksonomy.dart
+++ b/lib/src/folksonomy.dart
@@ -7,7 +7,7 @@ import 'model/product_list.dart';
 import 'model/product_stats.dart';
 import 'model/product_tag.dart';
 import 'utils/http_helper.dart';
-import 'utils/query_type.dart';
+import 'utils/open_food_api_configuration.dart';
 import 'utils/uri_helper.dart';
 
 /// Client calls of the Folksonomy API (Open Food Facts)
@@ -18,14 +18,13 @@ class FolksonomyAPIClient {
 
   /// "hello world"
   static Future<void> hello({
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getFolksonomyUri(
+      uriHelper.getUri(
         path: '/',
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
   }
@@ -36,7 +35,7 @@ class FolksonomyAPIClient {
   static Future<List<ProductStats>> getProductStats({
     final String? key,
     final String? value,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     /* TODO
@@ -55,12 +54,11 @@ class FolksonomyAPIClient {
       parameters['v'] = value;
     }
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getFolksonomyUri(
+      uriHelper.getUri(
         path: 'products/stats',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final List<ProductStats> result = <ProductStats>[];
@@ -82,7 +80,7 @@ class FolksonomyAPIClient {
   static Future<Map<String, String>> getProducts({
     required final String key,
     final String? value,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     /* TODO
@@ -95,12 +93,11 @@ class FolksonomyAPIClient {
       parameters['v'] = value;
     }
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getFolksonomyUri(
+      uriHelper.getUri(
         path: 'products',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final Map<String, String> result = <String, String>{};
@@ -121,7 +118,7 @@ class FolksonomyAPIClient {
   /// The key of the returned map is the tag key.
   static Future<Map<String, ProductTag>> getProductTags({
     required final String barcode,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     /* TODO
@@ -130,12 +127,11 @@ class FolksonomyAPIClient {
     }
      */
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getFolksonomyUri(
+      uriHelper.getUri(
         path: 'product/$barcode',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final Map<String, ProductTag> result = <String, ProductTag>{};
@@ -158,7 +154,7 @@ class FolksonomyAPIClient {
   static Future<ProductTag?> getProductTag({
     required final String barcode,
     required final String key,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     /* TODO
@@ -167,12 +163,11 @@ class FolksonomyAPIClient {
     }
      */
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getFolksonomyUri(
+      uriHelper.getUri(
         path: 'product/$barcode/$key',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     if (response.body == 'null') {
@@ -190,7 +185,7 @@ class FolksonomyAPIClient {
   static Future<Map<String, ProductTag>> getProductTagWithSubKeys({
     required final String barcode,
     required final String key,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     /* TODO
@@ -199,12 +194,11 @@ class FolksonomyAPIClient {
     }
      */
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getFolksonomyUri(
+      uriHelper.getUri(
         path: 'product/$barcode/$key*', // look at the star!
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final Map<String, ProductTag> result = <String, ProductTag>{};
@@ -250,7 +244,7 @@ Future<void> deleteProductTag({
   static Future<List<ProductTag>> getProductTagVersions({
     required final String barcode,
     required final String key,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     /* TODO
@@ -259,12 +253,11 @@ Future<void> deleteProductTag({
     }
      */
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getFolksonomyUri(
+      uriHelper.getUri(
         path: 'product/$barcode/$key/versions',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final List<ProductTag> result = <ProductTag>[];
@@ -335,7 +328,7 @@ Future<void> deleteProductTag({
 
   /// Returns the list of tag keys with statistics.
   static Future<Map<String, KeyStats>> getKeys({
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Map<String, String> parameters = <String, String>{};
     /* TODO "The keys list can be restricted to private tags from some owner"
@@ -344,12 +337,11 @@ Future<void> deleteProductTag({
     }
      */
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getFolksonomyUri(
+      uriHelper.getUri(
         path: 'keys',
         queryParameters: parameters,
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
     final Map<String, KeyStats> result = <String, KeyStats>{};
@@ -363,14 +355,13 @@ Future<void> deleteProductTag({
   }
 
   static Future<void> ping({
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Response response = await HttpHelper().doGetRequest(
-      UriHelper.getFolksonomyUri(
+      uriHelper.getUri(
         path: 'ping',
-        queryType: queryType,
       ),
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     _checkResponse(response);
   }

--- a/lib/src/robot_off_api_client.dart
+++ b/lib/src/robot_off_api_client.dart
@@ -10,7 +10,7 @@ import 'model/user.dart';
 import 'utils/country_helper.dart';
 import 'utils/http_helper.dart';
 import 'utils/language_helper.dart';
-import 'utils/query_type.dart';
+import 'utils/open_food_api_configuration.dart';
 import 'utils/server_type.dart';
 import 'utils/uri_helper.dart';
 
@@ -23,7 +23,7 @@ class RobotoffAPIClient {
     String? valueTag,
     ServerType? serverType,
     int? count,
-    QueryType? queryType,
+    final UriHelper uriHelper = uriHelperRobotoffProd,
   }) async {
     final Map<String, String> parameters = {
       if (type != null) 'type': type.offTag,
@@ -34,15 +34,14 @@ class RobotoffAPIClient {
       if (serverType != null) 'server_type': serverType.offTag,
     };
 
-    var insightUri = UriHelper.getRobotoffUri(
+    var insightUri = uriHelper.getUri(
       path: 'api/v1/insights/random/',
-      queryType: queryType,
       queryParameters: parameters,
     );
 
     Response response = await HttpHelper().doGetRequest(
       insightUri,
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     var result = InsightsResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),
@@ -54,21 +53,20 @@ class RobotoffAPIClient {
   static Future<InsightsResult> getProductInsights(
     String barcode, {
     ServerType? serverType,
-    QueryType? queryType,
+    final UriHelper uriHelper = uriHelperRobotoffProd,
   }) async {
     final Map<String, String> parameters = <String, String>{
       if (serverType != null) 'server_type': serverType.offTag,
     };
 
-    var insightsUri = UriHelper.getRobotoffUri(
+    var insightsUri = uriHelper.getUri(
       path: 'api/v1/insights/$barcode',
-      queryType: queryType,
       queryParameters: parameters,
     );
 
     Response response = await HttpHelper().doGetRequest(
       insightsUri,
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
 
     return InsightsResult.fromJson(
@@ -82,7 +80,7 @@ class RobotoffAPIClient {
     User? user,
     int? count,
     ServerType? serverType,
-    QueryType? queryType,
+    final UriHelper uriHelper = uriHelperRobotoffProd,
     List<InsightType>? insightTypes,
   }) async {
     final Map<String, String> parameters = <String, String>{
@@ -94,16 +92,15 @@ class RobotoffAPIClient {
             insightTypes.map((InsightType type) => type.offTag).join(','),
     };
 
-    var robotoffQuestionUri = UriHelper.getRobotoffUri(
+    var robotoffQuestionUri = uriHelper.getUri(
       path: 'api/v1/questions/$barcode',
       queryParameters: parameters,
-      queryType: queryType,
     );
 
     Response response = await HttpHelper().doGetRequest(
       robotoffQuestionUri,
       user: user,
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     var result = RobotoffQuestionResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),
@@ -124,7 +121,7 @@ class RobotoffAPIClient {
     RobotoffQuestionOrder? questionOrder,
     ServerType? serverType,
     String? valueTag,
-    QueryType? queryType,
+    final UriHelper uriHelper = uriHelperRobotoffProd,
   }) async {
     final List<String> insightValues = [];
     if (insightTypes != null) {
@@ -146,16 +143,15 @@ class RobotoffAPIClient {
       if (valueTag != null) 'value_tag': valueTag,
     };
 
-    var robotoffQuestionUri = UriHelper.getRobotoffUri(
+    var robotoffQuestionUri = uriHelper.getUri(
       path: 'api/v1/questions',
       queryParameters: parameters,
-      queryType: queryType,
     );
 
     final Response response = await HttpHelper().doGetRequest(
       robotoffQuestionUri,
       user: user,
-      queryType: queryType,
+      uriHelper: uriHelper,
     );
     return RobotoffQuestionResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),
@@ -167,11 +163,10 @@ class RobotoffAPIClient {
     InsightAnnotation annotation, {
     String? deviceId,
     bool update = true,
-    final QueryType? queryType,
+    final UriHelper uriHelper = uriHelperRobotoffProd,
   }) async {
-    var insightUri = UriHelper.getRobotoffUri(
+    var insightUri = uriHelper.getUri(
       path: 'api/v1/insights/annotate',
-      queryType: queryType,
     );
 
     final Map<String, String> annotationData = {
@@ -190,7 +185,7 @@ class RobotoffAPIClient {
       insightUri,
       annotationData,
       null,
-      queryType: queryType,
+      uriHelper: uriHelper,
       addCredentialsToBody: false,
       addCredentialsToHeader: true,
     );

--- a/lib/src/utils/abstract_query_configuration.dart
+++ b/lib/src/utils/abstract_query_configuration.dart
@@ -4,13 +4,12 @@ import 'package:meta/meta.dart';
 import '../interface/parameter.dart';
 import '../model/parameter/tag_filter.dart';
 import '../model/user.dart';
-import '../utils/country_helper.dart';
-import '../utils/http_helper.dart';
-import '../utils/language_helper.dart';
-import '../utils/open_food_api_configuration.dart';
-import '../utils/product_fields.dart';
-import '../utils/query_type.dart';
-import '../utils/uri_helper.dart';
+import 'country_helper.dart';
+import 'http_helper.dart';
+import 'language_helper.dart';
+import 'open_food_api_configuration.dart';
+import 'product_fields.dart';
+import 'uri_helper.dart';
 
 /// Abstract Query Configuration, that helps build API URI
 abstract class AbstractQueryConfiguration {
@@ -149,16 +148,15 @@ abstract class AbstractQueryConfiguration {
   /// dedicates methods in [OpenFoodAPIClient]
   Future<Response> getResponse(
     final User? user,
-    final QueryType? queryType,
+    final UriProductHelper uriHelper,
   ) async =>
-      await HttpHelper().doPostRequest(
-        UriHelper.getPostUri(
+      HttpHelper().doPostRequest(
+        uriHelper.getPostUri(
           path: getUriPath(),
-          queryType: queryType,
         ),
         getParametersMap(),
         user,
-        queryType: queryType,
+        uriHelper: uriHelper,
         addCredentialsToBody: false,
       );
 }

--- a/lib/src/utils/image_helper.dart
+++ b/lib/src/utils/image_helper.dart
@@ -1,6 +1,6 @@
-import 'open_food_api_configuration.dart';
-import 'query_type.dart';
 import 'language_helper.dart';
+import 'open_food_api_configuration.dart';
+import 'uri_helper.dart';
 import '../model/product_image.dart';
 
 /// Helper class related to product pictures
@@ -19,14 +19,14 @@ class ImageHelper {
     final String? barcode,
     final ProductImage image, {
     final ImageSize? imageSize,
-    final QueryType? queryType,
+    final UriProductHelper uriHelper = uriHelperFoodProd,
     final String? root,
   }) =>
       barcode == null
           ? null
           : '${getProductImageRootUrl(
               barcode,
-              queryType: queryType,
+              uriHelper: uriHelper,
               root: root,
             )}'
               '/'
@@ -42,9 +42,9 @@ class ImageHelper {
     final String barcode,
     final int imageId,
     final ImageSize imageSize, {
-    final QueryType? queryType,
+    final UriProductHelper uriHelper = uriHelperFoodProd,
   }) =>
-      '${getProductImageRootUrl(barcode, queryType: queryType)}'
+      '${getProductImageRootUrl(barcode, uriHelper: uriHelper)}'
       '/'
       '${_getUploadedImageFilename(imageId, imageSize)}';
 
@@ -107,12 +107,10 @@ class ImageHelper {
   /// E.g. "https://static.openfoodfacts.org/images/products/359/671/046/2858"
   static String getProductImageRootUrl(
     final String barcode, {
-    final QueryType? queryType,
+    final UriProductHelper uriHelper = uriHelperFoodProd,
     String? root,
   }) {
-    root ??= OpenFoodAPIConfiguration.getQueryType(queryType) == QueryType.PROD
-        ? OpenFoodAPIConfiguration.imageProdUrlBase
-        : OpenFoodAPIConfiguration.imageTestUrlBase;
+    root ??= uriHelper.imageUrlBase;
     final String separator = root.endsWith('/') ? '' : '/';
     return '$root$separator${getBarcodeSubPath(barcode)}';
   }

--- a/lib/src/utils/open_food_api_configuration.dart
+++ b/lib/src/utils/open_food_api_configuration.dart
@@ -1,8 +1,9 @@
 import '../model/user.dart';
 import '../model/user_agent.dart';
 import 'country_helper.dart';
+import 'http_helper.dart';
 import 'language_helper.dart';
-import 'query_type.dart';
+import 'uri_helper.dart';
 
 /// Allows to configure the behavior of the package.
 ///
@@ -43,45 +44,6 @@ class OpenFoodAPIConfiguration {
   ///Defines a global user to avoid adding it to every request
   static User? globalUser;
 
-  ///change the uriScheme of the requests
-  static String uriScheme = 'https';
-
-  ///Uri host of the main requests to the backend, modify this to direct the request to a self-hosted instance.
-  static String uriProdHost = 'world.openfoodfacts.org';
-
-  ///Uri host of the test requests to the backend
-  static String uriTestHost = 'world.openfoodfacts.net';
-
-  ///Url base for images in prod: needs to match the domain of uriProdHost
-  static String imageProdUrlBase =
-      'https://static.openfoodfacts.org/images/products/';
-
-  ///Url base for images in test: needs to match the domain of uriTestHost
-  static String imageTestUrlBase =
-      'https://static.openfoodfacts.net/images/products/';
-
-  ///Uri host of the Robotoff requests to the backend, modify this to direct the request to a self-hosted instance.
-  static String uriProdHostRobotoff = 'robotoff.openfoodfacts.org';
-
-  ///Uri host of the test requests to Robotoff
-  static String uriTestHostRobotoff = 'robotoff.openfoodfacts.net';
-
-  ///Uri host of the Folksonomy requests to the backend, modify this to direct the request to a self-hosted instance.
-  static String uriProdHostFolksonomy = 'api.folksonomy.openfoodfacts.org';
-
-  ///Uri host of the test requests to Folksonomy
-  static String uriTestHostFolksonomy =
-      'api.folksonomy.openfoodfacts.net'; // TODO does not work
-
-  ///Uri host of the Events requests to the backend, modify this to direct the request to a self-hosted instance.
-  static String uriProdHostEvents = 'events.openfoodfacts.org';
-
-  ///Uri host of the test requests to Events
-  static String uriTestHostEvents = 'events.openfoodfacts.net';
-
-  ///Changes whether the requests sent by this package to the test or main server.
-  static QueryType globalQueryType = QueryType.PROD;
-
   ///A global way to specify the languages for queries, can be overwritten
   /// for each individual request by specifying the languages in the
   /// individual request configurations
@@ -91,10 +53,6 @@ class OpenFoodAPIConfiguration {
   /// for each individual request by specifying the country code in the
   /// individual request configurations
   static OpenFoodFactsCountry? globalCountry;
-
-  ///Returns the [QueryType] to use, using a default value
-  static QueryType getQueryType(final QueryType? queryType) =>
-      queryType ?? globalQueryType;
 
   ///Returns the [User] to use, using a default value
   static User? getUser(final User? user) => user ?? globalUser;
@@ -116,3 +74,50 @@ class OpenFoodAPIConfiguration {
     return null;
   }
 }
+
+/// Uri of the main requests to the backend (OFF).
+const UriProductHelper uriHelperFoodProd = UriProductHelper(
+  host: 'world.openfoodfacts.org',
+  imageUrlBase: 'https://static.openfoodfacts.org/images/products/',
+);
+
+/// Uri of the test requests to the backend (OFF).
+const UriProductHelper uriHelperFoodTest = UriProductHelper(
+  host: 'world.openfoodfacts.net',
+  userInfoForPatch: HttpHelper.userInfoForTest,
+  isTestMode: true,
+  imageUrlBase: 'https://static.openfoodfacts.net/images/products/',
+);
+
+/// Uri of the main requests to the backend (RobotOff).
+const UriHelper uriHelperRobotoffProd = UriHelper(
+  host: 'robotoff.openfoodfacts.org',
+);
+
+/// Uri of the test requests to the backend (RobotOff).
+const UriHelper uriHelperRobotoffTest = UriHelper(
+  host: 'robotoff.openfoodfacts.net',
+  isTestMode: true,
+);
+
+/// Uri of the main requests to the backend (Folksonomy).
+const UriHelper uriHelperFolksonomyProd = UriHelper(
+  host: 'api.folksonomy.openfoodfacts.org',
+);
+
+/// Uri of the test requests to the backend (Folksonomy) - does not work :-(
+const UriHelper uriHelperFolksonomyTest = UriHelper(
+  host: 'api.folksonomy.openfoodfacts.net',
+  isTestMode: true,
+);
+
+/// Uri of the main requests to the backend (Events).
+const UriHelper uriHelperEventsProd = UriHelper(
+  host: 'events.openfoodfacts.org',
+);
+
+/// Uri of the test requests to the backend (Events).
+const UriHelper uriHelperEventsTest = UriHelper(
+  host: 'events.openfoodfacts.net',
+  isTestMode: true,
+);

--- a/lib/src/utils/product_helper.dart
+++ b/lib/src/utils/product_helper.dart
@@ -1,6 +1,6 @@
 import 'image_helper.dart';
 import 'language_helper.dart';
-import 'query_type.dart';
+import 'uri_helper.dart';
 import '../model/product.dart';
 import '../model/product_image.dart';
 
@@ -24,7 +24,7 @@ class ProductHelper {
   /// Generates a image url for each product image entry
   static void createImageUrls(
     Product product, {
-    QueryType? queryType,
+    required UriProductHelper uriHelper,
   }) {
     if (product.images == null) {
       return;
@@ -34,7 +34,7 @@ class ProductHelper {
       image.url = ImageHelper.buildUrl(
         product.barcode,
         image,
-        queryType: queryType,
+        uriHelper: uriHelper,
       );
     }
   }

--- a/lib/src/utils/product_query_configurations.dart
+++ b/lib/src/utils/product_query_configurations.dart
@@ -4,7 +4,6 @@ import 'country_helper.dart';
 import 'http_helper.dart';
 import 'language_helper.dart';
 import 'product_fields.dart';
-import 'query_type.dart';
 import 'uri_helper.dart';
 import '../model/user.dart';
 
@@ -59,27 +58,25 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
   @override
   Future<Response> getResponse(
     final User? user,
-    final QueryType? queryType,
+    final UriProductHelper uriHelper,
   ) async {
     if (version == ProductQueryVersion.v3) {
       return await HttpHelper().doGetRequest(
-        UriHelper.getUri(
+        uriHelper.getUri(
           path: getUriPath(),
-          queryType: queryType,
           queryParameters: getParametersMap(),
         ),
         user: user,
-        queryType: queryType,
+        uriHelper: uriHelper,
       );
     }
     return await HttpHelper().doPostRequest(
-      UriHelper.getPostUri(
+      uriHelper.getPostUri(
         path: getUriPath(),
-        queryType: queryType,
       ),
       getParametersMap(),
       user,
-      queryType: queryType,
+      uriHelper: uriHelper,
       addCredentialsToBody: false,
     );
   }

--- a/lib/src/utils/query_type.dart
+++ b/lib/src/utils/query_type.dart
@@ -1,5 +1,0 @@
-/// Environment type for API query
-enum QueryType {
-  PROD,
-  TEST,
-}

--- a/lib/src/utils/suggestion_manager.dart
+++ b/lib/src/utils/suggestion_manager.dart
@@ -6,7 +6,8 @@ import '../model/user.dart';
 import '../open_food_api_client.dart';
 import 'country_helper.dart';
 import 'language_helper.dart';
-import 'query_type.dart';
+import 'open_food_api_configuration.dart';
+import 'uri_helper.dart';
 import 'tag_type.dart';
 
 /// Manager that returns the suggestions for the latest input.
@@ -25,7 +26,7 @@ class SuggestionManager {
     this.categories,
     this.shape,
     this.limit = 25,
-    this.queryType,
+    this.uriHelper = uriHelperFoodProd,
     this.user,
   });
 
@@ -35,7 +36,7 @@ class SuggestionManager {
   final String? categories;
   final String? shape;
   final int limit;
-  final QueryType? queryType;
+  final UriProductHelper uriHelper;
   final User? user;
 
   final List<String> _inputs = <String>[];
@@ -59,7 +60,7 @@ class SuggestionManager {
       categories: categories,
       shape: shape,
       limit: limit,
-      queryType: queryType,
+      uriHelper: uriHelper,
       user: user,
     );
     // meanwhile there might have been some calls to this method, adding inputs.

--- a/lib/src/utils/taxonomy_query_configuration.dart
+++ b/lib/src/utils/taxonomy_query_configuration.dart
@@ -2,7 +2,6 @@ import '../interface/json_object.dart';
 import '../interface/parameter.dart';
 import 'country_helper.dart';
 import 'language_helper.dart';
-import 'query_type.dart';
 import 'tag_type.dart';
 import 'open_food_api_configuration.dart';
 import 'uri_helper.dart';
@@ -117,20 +116,9 @@ abstract class TaxonomyQueryConfiguration<T extends JsonObject,
     return result;
   }
 
-  Uri getUri([QueryType? queryType]) {
-    return UriHelper.getUri(
-      path: 'api/v2/taxonomy',
-      queryParameters: getParametersMap(),
-      queryType: queryType,
-    );
-  }
-
-  Uri getPostUri([QueryType? queryType]) {
-    return UriHelper.getPostUri(
-      path: 'api/v2/taxonomy',
-      queryType: queryType,
-    );
-  }
+  Uri getPostUri(final UriProductHelper uriHelper) => uriHelper.getPostUri(
+        path: 'api/v2/taxonomy',
+      );
 
   /// Returns the set of fields to ignore if specified in the [fields] parameter.
   ///

--- a/test/api_add_product_image_test.dart
+++ b/test/api_add_product_image_test.dart
@@ -7,7 +7,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+  const UriProductHelper uriHelper = uriHelperFoodTest;
   const User user = TestConstants.TEST_USER;
 
   /// Common constants for several image operations
@@ -66,8 +66,10 @@ void main() {
       fields: <ProductField>[ProductField.IMAGES],
       version: ProductQueryVersion.v3,
     );
-    final ProductResultV3 result =
-        await OpenFoodAPIClient.getProductV3(configurations);
+    final ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
+      configurations,
+      uriHelper: uriHelper,
+    );
     expect(result.status, isNotNull);
     expect(result.product!.images, isNotEmpty);
 
@@ -92,6 +94,7 @@ void main() {
       final Status status = await OpenFoodAPIClient.addProductImage(
         user,
         image,
+        uriHelper: uriHelper,
       );
 
       expect(status.status, 'status ok');
@@ -107,6 +110,7 @@ void main() {
       Status status = await OpenFoodAPIClient.addProductImage(
         user,
         image,
+        uriHelper: uriHelper,
       );
 
       expect(status.status, 'status ok');
@@ -122,6 +126,7 @@ void main() {
       Status status = await OpenFoodAPIClient.addProductImage(
         user,
         image,
+        uriHelper: uriHelper,
       );
 
       expect(status.status, 'status not ok');
@@ -138,6 +143,7 @@ void main() {
       final ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         configurations,
         user: user,
+        uriHelper: uriHelper,
       );
       expect(result.status, isNotNull);
       expect(result.product!.images, isNotEmpty);
@@ -159,8 +165,10 @@ void main() {
       final String? imgid = await getImgid(barcode, imageField, language);
       expect(imgid, isNotNull);
 
-      final String productImageRootUrl =
-          ImageHelper.getProductImageRootUrl(barcode);
+      final String productImageRootUrl = ImageHelper.getProductImageRootUrl(
+        barcode,
+        root: uriHelper.imageUrlBase,
+      );
       final String uploadedImageUrl = '$productImageRootUrl/$imgid.jpg';
       final List<int> uploadedSize = await getJpegUrlSize(uploadedImageUrl);
       final int uploadedWidth = uploadedSize[0];
@@ -174,6 +182,7 @@ void main() {
           language: language,
           imgid: imgid!,
           angle: angle,
+          uriHelper: uriHelper,
         );
         expect(newUrl, isNotNull);
 
@@ -217,6 +226,7 @@ void main() {
           y1: y1,
           x2: x1 + width,
           y2: y1 + height,
+          uriHelper: uriHelper,
         );
         expect(newUrl, isNotNull);
 
@@ -239,6 +249,7 @@ void main() {
         user: user,
         imageField: unselectedImageField,
         language: language,
+        uriHelper: uriHelper,
       );
 
       final ProductResultV3 productResult =
@@ -248,6 +259,7 @@ void main() {
           fields: <ProductField>[ProductField.SELECTED_IMAGE],
           version: ProductQueryVersion.v3,
         ),
+        uriHelper: uriHelper,
       );
       expect(productResult.product, isNotNull);
       expect(productResult.product!.selectedImages, isNotNull);

--- a/test/api_events_test.dart
+++ b/test/api_events_test.dart
@@ -6,7 +6,7 @@ import 'test_constants.dart';
 /// Tests around Events API.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+  const UriHelper uriHelper = uriHelperEventsTest;
 
   const String knownUserId = 'ocervell';
   const String unknownUserId = "o' * cervell";
@@ -96,67 +96,95 @@ void main() {
 
   group('$OpenFoodAPIClient Events API', () {
     test('getEvents - all', () async {
-      final List<EventsBase> result = await EventsAPIClient.getEvents();
+      final List<EventsBase> result = await EventsAPIClient.getEvents(
+        uriHelper: uriHelper,
+      );
       checkEventsBase(result);
     });
 
     test('getEvents - known user', () async {
-      final List<EventsBase> result =
-          await EventsAPIClient.getEvents(userId: knownUserId);
+      final List<EventsBase> result = await EventsAPIClient.getEvents(
+        userId: knownUserId,
+        uriHelper: uriHelper,
+      );
       checkEventsBase(result);
     });
 
     test('getEvents - unknown user', () async {
-      final List<EventsBase> result =
-          await EventsAPIClient.getEvents(userId: unknownUserId);
+      final List<EventsBase> result = await EventsAPIClient.getEvents(
+        userId: unknownUserId,
+        uriHelper: uriHelper,
+      );
       expect(result, isEmpty);
     });
 
     test('getEventsCount - all', () async {
-      final Map<String, int> result = await EventsAPIClient.getEventsCount();
+      final Map<String, int> result = await EventsAPIClient.getEventsCount(
+        uriHelper: uriHelper,
+      );
       checkEventsCount(result, false);
     });
 
     test('getEventsCount - known user', () async {
-      final Map<String, int> result =
-          await EventsAPIClient.getEventsCount(userId: knownUserId);
+      final Map<String, int> result = await EventsAPIClient.getEventsCount(
+        userId: knownUserId,
+        uriHelper: uriHelper,
+      );
       checkEventsCount(result, false);
     });
 
     test('getEventsCount - unknown user', () async {
-      final Map<String, int> result =
-          await EventsAPIClient.getEventsCount(userId: unknownUserId);
+      final Map<String, int> result = await EventsAPIClient.getEventsCount(
+        userId: unknownUserId,
+        uriHelper: uriHelper,
+      );
       checkEventsCount(result, true);
     });
 
     test('getBadges - all', () async {
-      final List<BadgeBase> result = await EventsAPIClient.getBadges();
+      final List<BadgeBase> result = await EventsAPIClient.getBadges(
+        uriHelper: uriHelper,
+      );
       checkBadgeBase(result);
     });
 
     test('getBadges - known user', () async {
-      final List<BadgeBase> result =
-          await EventsAPIClient.getBadges(userId: knownUserId);
+      final List<BadgeBase> result = await EventsAPIClient.getBadges(
+        userId: knownUserId,
+        uriHelper: uriHelper,
+      );
       checkBadgeBase(result);
     });
 
     test('getBadges - unknown user', () async {
-      final List<BadgeBase> result =
-          await EventsAPIClient.getBadges(userId: unknownUserId);
+      final List<BadgeBase> result = await EventsAPIClient.getBadges(
+        userId: unknownUserId,
+        uriHelper: uriHelper,
+      );
       expect(result, isEmpty);
     });
 
     test('getScores', () async {
-      final int unknown =
-          await EventsAPIClient.getScores(userId: unknownUserId);
+      final int unknown = await EventsAPIClient.getScores(
+        userId: unknownUserId,
+        uriHelper: uriHelper,
+      );
       expect(unknown, 0);
 
-      final int all = await EventsAPIClient.getScores();
-      final int known = await EventsAPIClient.getScores(userId: knownUserId);
+      final int all = await EventsAPIClient.getScores(
+        uriHelper: uriHelper,
+      );
+      final int known = await EventsAPIClient.getScores(
+        userId: knownUserId,
+        uriHelper: uriHelper,
+      );
       expect(known, lessThanOrEqualTo(all));
       int sum = 0;
       for (final String eventType in typicalEventTypes) {
-        final int score = await EventsAPIClient.getScores(eventType: eventType);
+        final int score = await EventsAPIClient.getScores(
+          eventType: eventType,
+          uriHelper: uriHelper,
+        );
         sum += score;
       }
       expect(sum, all);
@@ -164,7 +192,9 @@ void main() {
 
     test('getLeaderboard', () async {
       final List<LeaderboardEntry> result =
-          await EventsAPIClient.getLeaderboard();
+          await EventsAPIClient.getLeaderboard(
+        uriHelper: uriHelper,
+      );
       final int knownTotal = getLeaderboardScore(knownUserId, result)!;
       final int nullTotal = getLeaderboardScore(null, result)!;
       expect(getLeaderboardScore(unknownUserId, result), isNull);
@@ -172,7 +202,10 @@ void main() {
       int nullSum = 0;
       for (final String eventType in typicalEventTypes) {
         final List<LeaderboardEntry> result =
-            await EventsAPIClient.getLeaderboard(eventType: eventType);
+            await EventsAPIClient.getLeaderboard(
+          eventType: eventType,
+          uriHelper: uriHelper,
+        );
         knownSum += getLeaderboardScore(knownUserId, result) ?? 0;
         nullSum += getLeaderboardScore(null, result) ?? 0;
         expect(getLeaderboardScore(unknownUserId, result), isNull);

--- a/test/api_folksonomy_test.dart
+++ b/test/api_folksonomy_test.dart
@@ -7,7 +7,6 @@ import 'test_constants.dart';
 void main() {
   // TODO have it working on TEST too
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   // of course we need to check that those 3 "known" guys combine well
   const String knownBarcode = '9310036071174';

--- a/test/api_get_product_image_ids_test.dart
+++ b/test/api_get_product_image_ids_test.dart
@@ -11,7 +11,6 @@ void main() {
     final List<int> result = await OpenFoodAPIClient.getProductImageIds(
       barcode,
       user: TestConstants.PROD_USER,
-      queryType: QueryType.PROD,
     );
     expect(result.length, greaterThanOrEqualTo(34)); // was 34 on 2023-01-25
   });

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -11,7 +11,6 @@ void main() {
   const BARCODE_DANISH_BUTTER_COOKIES = '5701184005007';
 
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
 
   void findExpectedIngredients(

--- a/test/api_get_robotoff_test.dart
+++ b/test/api_get_robotoff_test.dart
@@ -5,7 +5,6 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   group('$OpenFoodAPIClient get robotoff questions', () {
     test('get questions for Noix de Saint-Jacques EN', () async {

--- a/test/api_get_save_product_test.dart
+++ b/test/api_get_save_product_test.dart
@@ -7,7 +7,7 @@ import 'test_constants.dart';
 /// Therefore, in TEST env.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+  const UriProductHelper uriHelper = uriHelperFoodTest;
 
   // Returns a book barcode (978...), that cannot be confused with food.
   String getBookBarcode(final int index) => '${9780000000000 + index}';
@@ -47,6 +47,7 @@ void main() {
       await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         inputProduct,
+        uriHelper: uriHelper,
       );
 
       final SendImage fontImage = SendImage(
@@ -58,6 +59,7 @@ void main() {
       await OpenFoodAPIClient.addProductImage(
         TestConstants.TEST_USER,
         fontImage,
+        uriHelper: uriHelper,
       );
 
       final ProductQueryConfiguration configurations =
@@ -69,6 +71,7 @@ void main() {
       );
       final ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         configurations,
+        uriHelper: uriHelper,
       );
 
       expect(result.status, ProductResultV3.statusSuccess);
@@ -120,6 +123,7 @@ void main() {
       await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         englishInputProduct,
+        uriHelper: uriHelper,
       );
 
       final fields = [
@@ -152,6 +156,7 @@ void main() {
 
       ProductResultV3 englishResult = await OpenFoodAPIClient.getProductV3(
         englishConf,
+        uriHelper: uriHelper,
       );
       Product englishProduct = englishResult.product!;
 
@@ -188,6 +193,7 @@ void main() {
 
       ProductResultV3 russianResult = await OpenFoodAPIClient.getProductV3(
         russianConf,
+        uriHelper: uriHelper,
       );
       Product russianProduct = russianResult.product!;
 
@@ -245,10 +251,12 @@ void main() {
       await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         englishInputProduct,
+        uriHelper: uriHelper,
       );
       await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         russianInputProduct,
+        uriHelper: uriHelper,
       );
 
       final fields = [
@@ -281,6 +289,7 @@ void main() {
 
       ProductResultV3 englishResult = await OpenFoodAPIClient.getProductV3(
         englishConf,
+        uriHelper: uriHelper,
       );
       Product englishProduct = englishResult.product!;
 
@@ -317,6 +326,7 @@ void main() {
 
       ProductResultV3 russianResult = await OpenFoodAPIClient.getProductV3(
         russianConf,
+        uriHelper: uriHelper,
       );
       Product russianProduct = russianResult.product!;
 
@@ -373,6 +383,7 @@ void main() {
       await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         inputProduct,
+        uriHelper: uriHelper,
       );
 
       final fields = [
@@ -401,6 +412,7 @@ void main() {
 
       ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         conf,
+        uriHelper: uriHelper,
       );
       Product product = result.product!;
 
@@ -470,6 +482,7 @@ void main() {
       await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         inputProduct,
+        uriHelper: uriHelper,
       );
 
       final fields = [
@@ -490,6 +503,7 @@ void main() {
       );
       ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         conf,
+        uriHelper: uriHelper,
       );
       Product product = result.product!;
       // English was of highest priority so English texts are expected
@@ -509,6 +523,7 @@ void main() {
       );
       result = await OpenFoodAPIClient.getProductV3(
         conf,
+        uriHelper: uriHelper,
       );
       product = result.product!;
       // German was of highest priority so German texts are expected
@@ -528,6 +543,7 @@ void main() {
       );
       result = await OpenFoodAPIClient.getProductV3(
         conf,
+        uriHelper: uriHelper,
       );
       product = result.product!;
       // Russian was of highest priority so Russian _name_ is expected...
@@ -557,6 +573,7 @@ void main() {
       await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         inputProduct,
+        uriHelper: uriHelper,
       );
 
       // Request all available languages for the fields which allow it
@@ -571,6 +588,7 @@ void main() {
       );
       ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         conf,
+        uriHelper: uriHelper,
       );
       Product product = result.product!;
 
@@ -612,6 +630,7 @@ void main() {
       await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         inputProduct,
+        uriHelper: uriHelper,
       );
 
       // Request both 'all-langs' and 'in-langs' fields types
@@ -633,6 +652,7 @@ void main() {
       );
       ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         conf,
+        uriHelper: uriHelper,
       );
       Product product = result.product!;
 
@@ -666,6 +686,7 @@ void main() {
         await OpenFoodAPIClient.saveProduct(
           TestConstants.TEST_USER,
           product,
+          uriHelper: uriHelper,
         );
 
         ProductQueryConfiguration configurations = ProductQueryConfiguration(
@@ -676,6 +697,7 @@ void main() {
         );
         ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
           configurations,
+          uriHelper: uriHelper,
         );
 
         expect(result.product!.productName, equals('Quoted Coca "cola"'));
@@ -703,6 +725,7 @@ void main() {
     await OpenFoodAPIClient.saveProduct(
       TestConstants.TEST_USER,
       product,
+      uriHelper: uriHelper,
     );
 
     ProductQueryConfiguration configurations = ProductQueryConfiguration(
@@ -718,6 +741,7 @@ void main() {
 
     final ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
       configurations,
+      uriHelper: uriHelper,
     );
 
     expect(result.status, ProductResultV3.statusSuccess);
@@ -746,6 +770,7 @@ void main() {
                   ..setValue(Nutrient.salt, PerSize.oneHundredGrams, 10.0))
                 : null,
           ),
+          uriHelper: uriHelper,
         );
 
     test('Without nutriments', () async {
@@ -763,6 +788,7 @@ void main() {
 
       final ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         configurations,
+        uriHelper: uriHelper,
       );
 
       expect(result.product!.noNutritionData, isTrue);
@@ -784,6 +810,7 @@ void main() {
 
       final ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         configurations,
+        uriHelper: uriHelper,
       );
 
       expect(result.product!.noNutritionData, isFalse);

--- a/test/api_get_suggestions_test.dart
+++ b/test/api_get_suggestions_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration tests about the V3 suggestions.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   /// Checks if at least one item contains the [substring].
   void listContains(final List<String> list, final String substring) {

--- a/test/api_get_taxonomy_additives_server_test.dart
+++ b/test/api_get_taxonomy_additives_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about additives.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_allergens_server_test.dart
+++ b/test/api_get_taxonomy_allergens_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about allergens.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_categories_server_test.dart
+++ b/test/api_get_taxonomy_categories_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about categories.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_countries_server_test.dart
+++ b/test/api_get_taxonomy_countries_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about countries.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_ingredients_server_test.dart
+++ b/test/api_get_taxonomy_ingredients_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about ingredients.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_labels_server_test.dart
+++ b/test/api_get_taxonomy_labels_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about labels.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_languages_server_test.dart
+++ b/test/api_get_taxonomy_languages_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about languages.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_nova_server_test.dart
+++ b/test/api_get_taxonomy_nova_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about nova.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_origins_server_test.dart
+++ b/test/api_get_taxonomy_origins_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about origins.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_packaging_materials_server_test.dart
+++ b/test/api_get_taxonomy_packaging_materials_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about packaging materials.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_packaging_recycling_server_test.dart
+++ b/test/api_get_taxonomy_packaging_recycling_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about packaging recycling.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_packaging_shapes_server_test.dart
+++ b/test/api_get_taxonomy_packaging_shapes_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about packaging shapes.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_taxonomy_packagings_server_test.dart
+++ b/test/api_get_taxonomy_packagings_server_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Integration test about packagings.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalLanguages = [

--- a/test/api_get_to_be_completed_products_test.dart
+++ b/test/api_get_to_be_completed_products_test.dart
@@ -7,7 +7,6 @@ import 'test_constants.dart';
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   group('$OpenFoodAPIClient get all to-be-completed products', () {
     Future<int?> getCount(
@@ -39,7 +38,6 @@ void main() {
         result = await OpenFoodAPIClient.searchProducts(
           OpenFoodAPIConfiguration.globalUser,
           configuration,
-          queryType: OpenFoodAPIConfiguration.globalQueryType,
         );
       } catch (e) {
         fail('Could not retrieve data for $reason: $e');

--- a/test/api_get_user_products_test.dart
+++ b/test/api_get_user_products_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   group('$OpenFoodAPIClient get user products', () {
     const String userId = 'monsieurtanuki';
@@ -45,7 +44,6 @@ void main() {
         result = await OpenFoodAPIClient.searchProducts(
           OpenFoodAPIConfiguration.globalUser,
           configuration,
-          queryType: OpenFoodAPIConfiguration.globalQueryType,
         );
       } catch (e) {
         fail('Could not retrieve data for $reason: $e');

--- a/test/api_json_to_from_test.dart
+++ b/test/api_json_to_from_test.dart
@@ -7,7 +7,6 @@ void main() {
   const BARCODE_DANISH_BUTTER_COOKIES = '5701184005007';
 
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   group('$OpenFoodAPIClient json to/from conversions', () {
     test('images', () async {

--- a/test/api_matched_product_v1_test.dart
+++ b/test/api_matched_product_v1_test.dart
@@ -8,7 +8,6 @@ void main() {
   const int HTTP_OK = 200;
 
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   /// Tests around Matched Product v1.
   group('$OpenFoodAPIClient matched product v1', () {

--- a/test/api_matched_product_v2_test.dart
+++ b/test/api_matched_product_v2_test.dart
@@ -16,7 +16,6 @@ void main() {
 
   const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalLanguages = <OpenFoodFactsLanguage>[language];

--- a/test/api_ocr_ingredients_test.dart
+++ b/test/api_ocr_ingredients_test.dart
@@ -5,7 +5,6 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   Future<void> doTest(
     final String barcode,

--- a/test/api_post_robotoff_test.dart
+++ b/test/api_post_robotoff_test.dart
@@ -4,7 +4,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+  const UriHelper uriHelper = uriHelperRobotoffTest;
 
   group('$OpenFoodAPIClient answer robotoff question', () {
     test('get questions for Noix de Saint-Jacques EN and answer', () async {
@@ -14,12 +14,14 @@ void main() {
         OpenFoodFactsLanguage.ENGLISH,
         user: TestConstants.TEST_USER,
         count: 1,
+        uriHelper: uriHelper,
       );
 
       if (result.status == 'found') {
         Status postResult = await RobotoffAPIClient.postInsightAnnotation(
           result.questions![0].insightId,
           InsightAnnotation.YES,
+          uriHelper: uriHelper,
         );
         expect(postResult.status, 'saved');
       }

--- a/test/api_product_preferences_test.dart
+++ b/test/api_product_preferences_test.dart
@@ -11,7 +11,6 @@ void main() {
 
   const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalCountry = OpenFoodFactsCountry.FRANCE;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   OpenFoodAPIConfiguration.globalLanguages = <OpenFoodFactsLanguage>[language];

--- a/test/api_save_product_test.dart
+++ b/test/api_save_product_test.dart
@@ -7,7 +7,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+  const UriProductHelper uriHelper = uriHelperFoodTest;
 
   group('$OpenFoodAPIClient add new products', () {
     String barcode_1 = '0048151623426';
@@ -49,6 +49,7 @@ void main() {
       Status status = await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         product,
+        uriHelper: uriHelper,
       );
 
       expect(status.status, 1);
@@ -63,6 +64,7 @@ void main() {
       ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         configurations,
         user: TestConstants.TEST_USER,
+        uriHelper: uriHelper,
       );
 
       testProductResult1(result);
@@ -73,6 +75,7 @@ void main() {
       Status status2 = await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         product2,
+        uriHelper: uriHelper,
       );
       expect(status2.status, 1);
       expect(status2.statusVerbose, 'fields saved');
@@ -80,6 +83,7 @@ void main() {
       ProductResultV3 result2 = await OpenFoodAPIClient.getProductV3(
         configurations,
         user: TestConstants.TEST_USER,
+        uriHelper: uriHelper,
       );
 
       testProductResult1(result2);
@@ -114,6 +118,7 @@ void main() {
       final Status frenchStatus = await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         frenchProduct,
+        uriHelper: uriHelper,
       );
       expect(frenchStatus.status, 1);
       expect(frenchStatus.statusVerbose, 'fields saved');
@@ -132,6 +137,7 @@ void main() {
       final Status germanStatus = await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         germanProduct,
+        uriHelper: uriHelper,
       );
       expect(germanStatus.status, 1);
       expect(germanStatus.statusVerbose, 'fields saved');
@@ -149,6 +155,7 @@ void main() {
       );
       final frenchResult = await OpenFoodAPIClient.getProductV3(
         frenchConfig,
+        uriHelper: uriHelper,
       );
       expect(frenchResult.product, isNotNull);
       expect(frenchResult.product!.productName, frenchProductName);
@@ -162,6 +169,7 @@ void main() {
       );
       final germanResult = await OpenFoodAPIClient.getProductV3(
         germanConfig,
+        uriHelper: uriHelper,
       );
 
       expect(germanResult.product, isNotNull);
@@ -180,6 +188,7 @@ void main() {
       );
       final frenchGermanResult = await OpenFoodAPIClient.getProductV3(
         frenchGermanConfig,
+        uriHelper: uriHelper,
       );
 
       expect(frenchGermanResult.product, isNotNull);
@@ -207,6 +216,7 @@ Like that:
       Status status = await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         product,
+        uriHelper: uriHelper,
       );
 
       expect(status.status, 1);
@@ -226,6 +236,7 @@ Like that:
       Status status = await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         product,
+        uriHelper: uriHelper,
       );
 
       expect(status.status, 1);
@@ -245,6 +256,7 @@ Like that:
       Status status = await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         product,
+        uriHelper: uriHelper,
       );
 
       expect(status.status, 1);
@@ -268,6 +280,7 @@ Like that:
       Status status = await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         product,
+        uriHelper: uriHelper,
       );
 
       expect(status.status, 1);
@@ -283,6 +296,7 @@ Like that:
       Status status = await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         product,
+        uriHelper: uriHelper,
       );
 
       expect(status.status, 1);
@@ -295,6 +309,7 @@ Like that:
       ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         configurations,
         user: TestConstants.TEST_USER,
+        uriHelper: uriHelper,
       );
 
       expect(result.product!.labels,
@@ -337,6 +352,7 @@ Like that:
         final Status status = await OpenFoodAPIClient.saveProduct(
           USER,
           newProduct,
+          uriHelper: uriHelper,
         );
 
         expect(status.status, 1);
@@ -349,6 +365,7 @@ Like that:
             version: ProductQueryVersion.v3,
           ),
           user: USER,
+          uriHelper: uriHelper,
         );
 
         expect(result.status, ProductResultV3.statusSuccess);
@@ -397,6 +414,7 @@ Like that:
           password: generateRandomString(16),
         ),
         product,
+        uriHelper: uriHelper,
       );
       expect(status.isWrongUsernameOrPassword(), isTrue);
     });
@@ -417,6 +435,7 @@ Like that:
         ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
           configurations,
           user: TestConstants.TEST_USER,
+          uriHelper: uriHelper,
         );
         expect(result.status, ProductResultV3.statusSuccess);
         expect(result.product, isNotNull);
@@ -436,6 +455,7 @@ Like that:
         final Status status = await OpenFoodAPIClient.saveProduct(
           TestConstants.TEST_USER,
           savedProduct,
+          uriHelper: uriHelper,
         );
         expect(status.status, 1);
         expect(status.error, null);
@@ -444,6 +464,7 @@ Like that:
         result = await OpenFoodAPIClient.getProductV3(
           configurations,
           user: TestConstants.TEST_USER,
+          uriHelper: uriHelper,
         );
         expect(result.status, ProductResultV3.statusSuccess);
         expect(result.product, isNotNull);

--- a/test/api_save_product_v3_test.dart
+++ b/test/api_save_product_v3_test.dart
@@ -6,7 +6,7 @@ import 'test_constants.dart';
 /// Integration tests around the "save packagings V3" feature.
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.TEST;
+  const UriProductHelper uriHelper = uriHelperFoodTest;
 
   group('$OpenFoodAPIClient save product V3', () {
     const String barcode = '12345678';
@@ -33,7 +33,7 @@ void main() {
           await OpenFoodAPIClient.temporarySaveProductV3(
         TestConstants.TEST_USER,
         barcode,
-        queryType: QueryType.TEST,
+        uriHelper: uriHelper,
         country: country,
         language: language,
         packagings: inputPackagings,
@@ -80,7 +80,7 @@ void main() {
             await OpenFoodAPIClient.temporarySaveProductV3(
           TestConstants.TEST_USER,
           barcode,
-          queryType: QueryType.TEST,
+          uriHelper: uriHelper,
           country: country,
           language: language,
           packagingsComplete: value,
@@ -106,6 +106,7 @@ void main() {
             ],
           ),
           user: TestConstants.TEST_USER,
+          uriHelper: uriHelper,
         );
 
         expect(readStatus.status, ProductResultV3.statusSuccess);

--- a/test/api_search_products_test.dart
+++ b/test/api_search_products_test.dart
@@ -7,7 +7,6 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
   const ProductQueryVersion version = ProductQueryVersion.v3;
 
@@ -632,7 +631,6 @@ void main() {
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         TestConstants.PROD_USER,
         configuration,
-        queryType: QueryType.PROD,
       );
 
       expect(result.products, isNotNull);
@@ -654,7 +652,7 @@ void main() {
       await OpenFoodAPIClient.saveProduct(
         TestConstants.TEST_USER,
         product,
-        queryType: QueryType.TEST,
+        uriHelper: uriHelperFoodTest,
       );
 
       final parameters = <Parameter>[
@@ -673,7 +671,7 @@ void main() {
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         TestConstants.TEST_USER,
         configuration,
-        queryType: QueryType.TEST,
+        uriHelper: uriHelperFoodTest,
       );
 
       expect(result.products!.length, 1);

--- a/test/api_suggestion_manager_test.dart
+++ b/test/api_suggestion_manager_test.dart
@@ -26,7 +26,6 @@ class _SuggestionManagerTest extends SuggestionManager {
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
   OpenFoodAPIConfiguration.globalUser = TestConstants.PROD_USER;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   const TagType tagType = TagType.COUNTRIES;
   const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -4,16 +4,16 @@ import 'package:test/test.dart';
 import 'test_constants.dart';
 
 void main() {
+  const UriProductHelper uriHelper = uriHelperFoodProd;
   setUp(() {
     OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-    OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
   });
 
   test('Get Uri with no user agent', () {
     OpenFoodAPIConfiguration.userAgent = null;
 
     expect(
-      () => UriHelper.getUri(
+      () => uriHelper.getUri(
         path: '/test/test.pl',
       ),
       throwsA(
@@ -25,7 +25,7 @@ void main() {
   test('Get Uri', () {
     OpenFoodAPIConfiguration.uuid = null;
 
-    Uri uri = UriHelper.getUri(
+    Uri uri = uriHelper.getUri(
       path: '/test/test.pl',
     );
 
@@ -35,7 +35,7 @@ void main() {
     );
     expect(uri.queryParameters, HttpHelper.addUserAgentParameters(null));
 
-    Uri uri1 = UriHelper.getUri(
+    Uri uri1 = uriHelper.getUri(
       path: '/test/test.pl',
       queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
     );
@@ -53,7 +53,7 @@ void main() {
     OpenFoodAPIConfiguration.uuid = null;
     Uri uri;
 
-    uri = UriHelper.getUri(
+    uri = uriHelper.getUri(
       path: '/test/test.pl',
     );
     expect(
@@ -61,7 +61,7 @@ void main() {
       'https://world.openfoodfacts.org/test/test.pl?app_name=$name&app_version=$version',
     );
 
-    uri = UriHelper.getUri(
+    uri = uriHelper.getUri(
       path: '/test/test.pl',
       queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
     );
@@ -70,7 +70,7 @@ void main() {
       'https://world.openfoodfacts.org/test/test.pl?test=true&queryType=PROD&app_name=$name&app_version=$version',
     );
 
-    uri = UriHelper.getUri(
+    uri = uriHelper.getUri(
       path: '/test/test.pl',
       addUserAgentParameters: false,
     );
@@ -79,7 +79,7 @@ void main() {
       'https://world.openfoodfacts.org/test/test.pl',
     );
 
-    uri = UriHelper.getUri(
+    uri = uriHelper.getUri(
       path: '/test/test.pl',
       queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
       addUserAgentParameters: false,
@@ -95,7 +95,7 @@ void main() {
     OpenFoodAPIConfiguration.uuid = uuid;
     Uri uri;
 
-    uri = UriHelper.getUri(
+    uri = uriHelper.getUri(
       path: '/test/test.pl',
     );
     expect(
@@ -103,7 +103,7 @@ void main() {
       'https://world.openfoodfacts.org/test/test.pl?$_appNameValue&app_uuid=$uuid',
     );
 
-    uri = UriHelper.getUri(
+    uri = uriHelper.getUri(
       path: '/test/test.pl',
       queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
     );
@@ -112,7 +112,7 @@ void main() {
       'https://world.openfoodfacts.org/test/test.pl?test=true&queryType=PROD&$_appNameValue&app_uuid=$uuid',
     );
 
-    uri = UriHelper.getUri(
+    uri = uriHelper.getUri(
       path: '/test/test.pl',
       addUserAgentParameters: false,
     );
@@ -121,7 +121,7 @@ void main() {
       'https://world.openfoodfacts.org/test/test.pl',
     );
 
-    uri = UriHelper.getUri(
+    uri = uriHelper.getUri(
       path: '/test/test.pl',
       queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
       addUserAgentParameters: false,
@@ -134,18 +134,16 @@ void main() {
 
   test('Get Test Uri', () {
     OpenFoodAPIConfiguration.uuid = null;
-    Uri uri = UriHelper.getUri(
+    Uri uri = uriHelperFoodTest.getUri(
       path: '/test/test.pl',
-      queryType: QueryType.TEST,
     );
     expect(
       uri.toString(),
       'https://world.openfoodfacts.net/test/test.pl?$_appNameValue',
     );
 
-    Uri uri1 = UriHelper.getUri(
+    Uri uri1 = uriHelperFoodTest.getUri(
       path: '/test/test.pl',
-      queryType: QueryType.TEST,
       queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
     );
     expect(
@@ -157,7 +155,7 @@ void main() {
   test('Get Robotoff Uri', () {
     OpenFoodAPIConfiguration.userAgent = null;
     OpenFoodAPIConfiguration.uuid = null;
-    Uri uri = UriHelper.getRobotoffUri(
+    Uri uri = uriHelperRobotoffProd.getUri(
       path: '/test/test.pl',
     );
     expect(
@@ -165,7 +163,7 @@ void main() {
       'https://robotoff.openfoodfacts.org/test/test.pl',
     );
 
-    Uri uri1 = UriHelper.getRobotoffUri(
+    Uri uri1 = uriHelperRobotoffProd.getUri(
       path: '/test/test.pl',
       queryParameters: <String, dynamic>{'test': 'true', 'queryType': 'PROD'},
     );
@@ -178,18 +176,16 @@ void main() {
   test('Get Robotoff Test Uri', () {
     OpenFoodAPIConfiguration.userAgent = null;
     OpenFoodAPIConfiguration.uuid = null;
-    Uri uri = UriHelper.getRobotoffUri(
+    Uri uri = uriHelperRobotoffTest.getUri(
       path: '/test/test.pl',
-      queryType: QueryType.TEST,
     );
     expect(
       uri.toString(),
       'https://robotoff.openfoodfacts.net/test/test.pl',
     );
 
-    Uri uri1 = UriHelper.getRobotoffUri(
+    Uri uri1 = uriHelperRobotoffTest.getUri(
       path: '/test/test.pl',
-      queryType: QueryType.TEST,
       queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
     );
     expect(
@@ -200,8 +196,12 @@ void main() {
 
   test('Get Uri with different uriScheme', () {
     OpenFoodAPIConfiguration.uuid = null;
-    OpenFoodAPIConfiguration.uriScheme = 'http';
-    Uri uri = UriHelper.getUri(
+    final UriProductHelper uriHelper = UriProductHelper(
+      host: 'world.openfoodfacts.org',
+      scheme: 'http',
+      imageUrlBase: 'whatever',
+    );
+    final Uri uri = uriHelper.getUri(
       path: '/test/test.pl',
     );
     expect(
@@ -209,7 +209,7 @@ void main() {
       'http://world.openfoodfacts.org/test/test.pl?$_appNameValue',
     );
 
-    Uri uri1 = UriHelper.getUri(
+    Uri uri1 = uriHelper.getUri(
       path: '/test/test.pl',
       queryParameters: <String, String>{'test': 'true', 'queryType': 'PROD'},
     );

--- a/test/ordered_nutrient_test.dart
+++ b/test/ordered_nutrient_test.dart
@@ -6,7 +6,6 @@ import 'test_constants.dart';
 /// Tests related to [OrderedNutrient] and [OrderedNutrients]
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   // Very long list, experimentally created from the 3 initial URLs.
   // Don't hesitate to edit this list if you have clear functional ideas

--- a/test/user_management_test_prod.dart
+++ b/test/user_management_test_prod.dart
@@ -7,7 +7,6 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  OpenFoodAPIConfiguration.globalQueryType = QueryType.PROD;
 
   group('Create existing user (without specifying a country, nor a language)',
       () {

--- a/test/user_management_test_test_env.dart
+++ b/test/user_management_test_test_env.dart
@@ -7,7 +7,7 @@ import 'test_constants.dart';
 
 void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
-  const QueryType user_test_queryType = QueryType.TEST;
+  const UriProductHelper uriHelper = uriHelperFoodTest;
 
   group('Create user', () {
     test('Create user', () async {
@@ -32,7 +32,7 @@ void main() {
           user: User(userId: userId, password: password),
           name: name,
           email: email,
-          queryType: user_test_queryType,
+          uriHelper: uriHelper,
           newsletter: false,
         );
 
@@ -43,7 +43,7 @@ void main() {
 
       final LoginStatus? status = await OpenFoodAPIClient.login2(
         User(userId: userId, password: password),
-        queryType: user_test_queryType,
+        uriHelper: uriHelper,
       );
       expect(status, isNotNull);
       expect(status!.successful, isTrue);
@@ -56,7 +56,7 @@ void main() {
     test('Login with invalid credentials', () async {
       final LoginStatus? status = await OpenFoodAPIClient.login2(
         User(userId: '123', password: '123'),
-        queryType: user_test_queryType,
+        uriHelper: uriHelper,
       );
       expect(status?.successful, false);
       expect(status?.statusVerbose, 'user not signed-in');


### PR DESCRIPTION
### What
- We had a clumsy management of URLs, that was good enough as long as we were working on a single environment (e.g.: openfoodfacts, on PROD).
- With https://github.com/openfoodfacts/smooth-app/issues/4626 we need more flexibility.
- With the current PR, we're able to query multiple environments without side-effects.
- For instance, this is definitely a food app, the barcode is scanned and we cannot find it as a food, let's have a go in beauty/product/pet food, with the rest of the app (e.g. async background tasks) still working with food URLs.

### Fixes bug(s)
- Closes: #801

### Files
Deleted file:
* `query_type.dart`

Impacted files:
* `abstract_query_configuration.dart`: replaced `QueryType` with `UriHelper`
* `api_add_product_image_test.dart`: explicit usage of `uriHelperFoodTest`
* `api_events_test.dart`: explicit usage of `uriHelperEventsTest`
* `api_folksonomy_test.dart`: removed implicit usage of prod env
* `api_get_product_image_ids_test.dart`: removed implicit usage of prod env
* `api_get_product_test.dart`: removed implicit usage of prod env
* `api_get_robotoff_test.dart`: removed implicit usage of prod env
* `api_get_save_product_test.dart`: explicit usage of `uriHelperFoodTest`
* `api_get_suggestions_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_additives_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_allergens_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_categories_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_countries_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_ingredients_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_labels_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_languages_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_nova_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_origins_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_packaging_materials_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_packaging_recycling_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_packaging_shapes_server_test.dart`: removed implicit usage of prod env
* `api_get_taxonomy_packagings_server_test.dart`: removed implicit usage of prod env
* `api_get_to_be_completed_products_test.dart`: removed implicit usage of prod env
* `api_get_user_products_test.dart`: removed implicit usage of prod env
* `api_json_to_from_test.dart`: removed implicit usage of prod env
* `api_matched_product_v1_test.dart`: removed implicit usage of prod env
* `api_matched_product_v2_test.dart`: removed implicit usage of prod env
* `api_ocr_ingredients_test.dart`: removed implicit usage of prod env
* `api_post_robotoff_test.dart`: explicit usage of `uriHelperRobotoffTest`
* `api_product_preferences_test.dart`: removed implicit usage of prod env
* `api_save_product_test.dart`: explicit usage of `uriHelperFoodTest`
* `api_save_product_v3_test.dart`: explicit usage of `uriHelperFoodTest`
* `api_search_products_test.dart`: removed implicit usage of prod env
* `api_suggestion_manager_test.dart`: removed implicit usage of prod env
* `configuration_test.dart`: replaced `QueryType` with `UriHelper`
* `events.dart`: replaced `QueryType` with `UriHelper`
* `folksonomy.dart`: replaced `QueryType` with `UriHelper`
* `http_helper.dart`: replaced `QueryType` with `UriHelper`
* `image_helper.dart`: replaced `QueryType` with `UriHelper`
* `open_food_api_client.dart`: replaced `QueryType` with `UriHelper`
* `open_food_api_configuration.dart`: replaced all static `String`s with `const` instances of `UriHelper`
* `openfoodfacts.dart`: removed `query_type.dart`
* `ordered_nutrient_test.dart`: removed implicit usage of prod env
* `product_helper.dart`: now using `UriHelper` instead of `QueryType`
* `product_query_configurations.dart`: replaced `QueryType` with `UriHelper`
* `robot_off_api_client.dart`: replaced `QueryType` with `UriHelper`
* `suggestion_manager.dart`: replaced `QueryType` with `UriHelper`
* `taxonomy_query_configuration.dart`: replaced `QueryType` with `UriHelper`
* `uri_helper.dart`: made the class non static for more flexibility; replaced `QueryType` with `UriHelper`
* `user_management_test_prod.dart`: removed implicit usage of prod env
* `user_management_test_test_env.dart`: explicit usage of `uriHelperFoodTest`