### PR TITLE
feat: new field pageCount for searchResult

### DIFF
--- a/lib/src/model/search_result.dart
+++ b/lib/src/model/search_result.dart
@@ -15,6 +15,9 @@ class SearchResult extends JsonObject {
   @JsonKey(name: 'count', fromJson: JsonObject.parseInt)
   final int? count;
 
+  @JsonKey(name: 'page_count', fromJson: JsonObject.parseInt)
+  final int? pageCount;
+
   @JsonKey(name: 'skip', fromJson: JsonObject.parseInt)
   final int? skip;
 
@@ -25,6 +28,7 @@ class SearchResult extends JsonObject {
     this.page,
     this.pageSize,
     this.count,
+    this.pageCount,
     this.skip,
     this.products,
   });

--- a/lib/src/model/search_result.g.dart
+++ b/lib/src/model/search_result.g.dart
@@ -10,6 +10,7 @@ SearchResult _$SearchResultFromJson(Map<String, dynamic> json) => SearchResult(
       page: JsonObject.parseInt(json['page']),
       pageSize: JsonObject.parseInt(json['page_size']),
       count: JsonObject.parseInt(json['count']),
+      pageCount: JsonObject.parseInt(json['page_count']),
       skip: JsonObject.parseInt(json['skip']),
       products: (json['products'] as List<dynamic>?)
           ?.map((e) => Product.fromJson(e as Map<String, dynamic>))
@@ -21,6 +22,7 @@ Map<String, dynamic> _$SearchResultToJson(SearchResult instance) {
     'page': instance.page,
     'page_size': instance.pageSize,
     'count': instance.count,
+    'page_count': instance.pageCount,
     'skip': instance.skip,
   };
 

--- a/test/api_get_user_products_test.dart
+++ b/test/api_get_user_products_test.dart
@@ -51,13 +51,13 @@ void main() {
       expect(result.page, 1, reason: reason); // default
       expect(result.pageSize, pageSize, reason: reason);
       expect(result.products, isNotNull, reason: reason);
-      expect(result.products!.length, result.count, reason: reason);
+      expect(result.products!.length, result.pageCount, reason: reason);
       if (additionalCheck != null) {
         for (final Product product in result.products!) {
           additionalCheck(product);
         }
       }
-      return result.count!;
+      return result.pageCount!;
     }
 
     Future<int> getCountForAllLanguages(

--- a/test/api_search_products_test.dart
+++ b/test/api_search_products_test.dart
@@ -785,7 +785,7 @@ void main() {
       expect(result.products!.length, 24);
       expect(result.products![0].runtimeType, Product);
       expect(result.count, greaterThan(1500));
-    });
+    }, skip: 'Temporarily not working (server issue)');
 
     test('many many products', () async {
       final List<String> manyBarcodes = <String>[];


### PR DESCRIPTION
### What
- New field `pageCount` for `SearchResult`
- That will help us solve a minor rare discrepancy between the number of "returned products", the "number of returned products" (`pageCount`) and the "total number of products" (`count`).

### Impacted files:
* `api_get_user_products_test.dart`: now using `pageCount` instead of `count`
* `api_search_products_test.dart`: skipped a test failing because of the server
* `search_result.dart`: added field `pageCount`
* `search_result.g.dart`: generated