### PR TITLE
feat: new localized product fields for generic name

### DIFF
--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -103,10 +103,17 @@ class Product extends JsonObject {
       includeIfNull: false)
   Map<OpenFoodFactsLanguage, String>? productNameInLanguages;
 
-  ///Common name
-  ///Example: Chocolate bar with milk and hazelnuts
+  /// Common name. Example: "Chocolate bar with milk and hazelnuts".
   @JsonKey(name: 'generic_name', includeIfNull: false)
   String? genericName;
+
+  /// Localized common name.
+  @JsonKey(
+      name: 'generic_name_in_languages',
+      fromJson: LanguageHelper.fromJsonStringMap,
+      toJson: LanguageHelper.toJsonStringMap,
+      includeIfNull: false)
+  Map<OpenFoodFactsLanguage, String>? genericNameInLanguages;
 
   @JsonKey(name: 'brands', includeIfNull: false)
   String? brands;
@@ -572,6 +579,11 @@ class Product extends JsonObject {
           result.productNameInLanguages ??= {};
           result.productNameInLanguages![language] = label;
           break;
+        case ProductField.GENERIC_NAME_IN_LANGUAGES:
+        case ProductField.GENERIC_NAME_ALL_LANGUAGES:
+          result.genericNameInLanguages ??= {};
+          result.genericNameInLanguages![language] = label;
+          break;
         case ProductField.INGREDIENTS_TEXT_IN_LANGUAGES:
         case ProductField.INGREDIENTS_TEXT_ALL_LANGUAGES:
           result.ingredientsTextInLanguages ??= {};
@@ -653,6 +665,7 @@ class Product extends JsonObject {
     ) {
       switch (productField) {
         case ProductField.NAME_IN_LANGUAGES:
+        case ProductField.GENERIC_NAME_IN_LANGUAGES:
         case ProductField.INGREDIENTS_TEXT_IN_LANGUAGES:
         case ProductField.PACKAGING_TEXT_IN_LANGUAGES:
           setLanguageString(productField, language, json[key]);

--- a/lib/src/model/product.g.dart
+++ b/lib/src/model/product.g.dart
@@ -101,6 +101,8 @@ Product _$ProductFromJson(Map<String, dynamic> json) => Product(
           : Nutriments.fromJson(json['nutriments'] as Map<String, dynamic>),
       noNutritionData: JsonHelper.checkboxFromJSON(json['no_nutrition_data']),
     )
+      ..genericNameInLanguages =
+          LanguageHelper.fromJsonStringMap(json['generic_name_in_languages'])
       ..brandsTagsInLanguages = LanguageHelper.fromJsonStringsListMap(
           json['brands_tags_in_languages'])
       ..imagesFreshnessInLanguages =
@@ -176,6 +178,8 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('product_name_in_languages',
       LanguageHelper.toJsonStringMap(instance.productNameInLanguages));
   writeNotNull('generic_name', instance.genericName);
+  writeNotNull('generic_name_in_languages',
+      LanguageHelper.toJsonStringMap(instance.genericNameInLanguages));
   writeNotNull('brands', instance.brands);
   writeNotNull('brands_tags', instance.brandsTags);
   writeNotNull('brands_tags_in_languages',

--- a/lib/src/utils/product_fields.dart
+++ b/lib/src/utils/product_fields.dart
@@ -8,6 +8,8 @@ enum ProductField implements OffTagged {
   NAME_IN_LANGUAGES(offTag: 'product_name_'),
   NAME_ALL_LANGUAGES(offTag: 'product_name_languages'),
   GENERIC_NAME(offTag: 'generic_name'),
+  GENERIC_NAME_IN_LANGUAGES(offTag: 'generic_name_'),
+  GENERIC_NAME_ALL_LANGUAGES(offTag: 'generic_name_languages'),
   BRANDS(offTag: 'brands'),
   BRANDS_TAGS(offTag: 'brands_tags'),
   BRANDS_TAGS_IN_LANGUAGES(offTag: 'brands_tags_'),
@@ -108,6 +110,7 @@ enum ProductField implements OffTagged {
 
 const Set<ProductField> fieldsInLanguages = {
   ProductField.NAME_IN_LANGUAGES,
+  ProductField.GENERIC_NAME_IN_LANGUAGES,
   ProductField.INGREDIENTS_TEXT_IN_LANGUAGES,
   ProductField.PACKAGING_TEXT_IN_LANGUAGES,
   ProductField.CATEGORIES_TAGS_IN_LANGUAGES,
@@ -125,6 +128,7 @@ const Set<ProductField> fieldsInLanguages = {
 
 const Set<ProductField> fieldsAllLanguages = {
   ProductField.NAME_ALL_LANGUAGES,
+  ProductField.GENERIC_NAME_ALL_LANGUAGES,
   ProductField.INGREDIENTS_TEXT_ALL_LANGUAGES,
   ProductField.PACKAGING_TEXT_ALL_LANGUAGES,
 };

--- a/test/api_get_save_product_test.dart
+++ b/test/api_get_save_product_test.dart
@@ -34,6 +34,8 @@ void main() {
   group('$OpenFoodAPIClient get-save products', () {
     test('get product Coca Cola Light', () async {
       final String barcode = getBookBarcode(0);
+      const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.GERMAN;
+      const String genericName = 'Softdrink';
       const List<String> ingredientsText = <String>[
         'Wasser',
         'Kohlensäure',
@@ -52,7 +54,7 @@ void main() {
       final Product inputProduct = Product(
         barcode: barcode,
         productName: 'Coca Cola Light',
-        genericName: 'Softdrink',
+        genericName: genericName,
         countries: 'Frankreich,Deutschland',
         brands: 'Coca Cola',
         nutrimentDataPer: PerSize.serving.offTag,
@@ -66,10 +68,11 @@ void main() {
         TestConstants.TEST_USER,
         inputProduct,
         uriHelper: uriHelper,
+        language: language,
       );
 
       final SendImage fontImage = SendImage(
-        lang: OpenFoodFactsLanguage.GERMAN,
+        lang: language,
         barcode: barcode,
         imageField: ImageField.FRONT,
         imageUri: Uri.file('test/test_assets/front_coca_light_de.jpg'),
@@ -83,7 +86,7 @@ void main() {
       final ProductQueryConfiguration configurations =
           ProductQueryConfiguration(
         barcode,
-        language: OpenFoodFactsLanguage.GERMAN,
+        language: language,
         fields: [ProductField.ALL],
         version: ProductQueryVersion.v3,
       );
@@ -99,7 +102,9 @@ void main() {
       expect(product.barcode, barcode);
       expect(product.lastModified, isNotNull);
 
-      expect(product.genericName, 'Softdrink');
+      expect(product.genericName, genericName);
+      expect(product.genericNameInLanguages, isNotNull);
+      expect(product.genericNameInLanguages![language], genericName);
 
       expect(product.ingredients, isNotNull);
       expect(product.ingredients!.length, ingredientsText.length);


### PR DESCRIPTION
### What
- One test started to fail yesterday.
- Obviously something changed on the server side regarding `genericName`, the same way it changed weeks ago about `productName`. In short, now you're supposed to be explicit regarding the language you use, which is a good news. I fixed the test.
- En passant, I also added a localized version of "generic name".

### Impacted files
* `api_get_save_product_test.dart`: set explicit language for `genericName` test to pass; also tested new field `genericNameInLanguages`
* `product.dart`: added field `genericNameInLanguages`
* `product.g.dart`: generated
* `product_fields.dart`: added fields `GENERIC_NAME_IN_LANGUAGES` and `GENERIC_NAME_ALL_LANGUAGES`