### PR TITLE
fix: 829 - no more crash if the user name is not ASCII/ISO-8859-1

### DIFF
--- a/test/user_management_test_test_env.dart
+++ b/test/user_management_test_test_env.dart
@@ -61,6 +61,15 @@ void main() {
       expect(status?.successful, false);
       expect(status?.statusVerbose, 'user not signed-in');
     });
+
+    test('Login with problematic charset', () async {
+      final LoginStatus? status = await OpenFoodAPIClient.login2(
+        User(userId: 'លីវយី', password: ''),
+        uriHelper: uriHelper,
+      );
+      expect(status?.successful, false);
+      expect(status?.statusVerbose, 'user not signed-in');
+    });
   });
 }
 


### PR DESCRIPTION
### What
- We populate the `From` http header with the user name
- Which may be problematic, as data in the http header is supposed to be ASCII/ISO-8859-1 encoded.
- In order to prevent the http header from being rejected, we transform user name if from another charset.
- cf. https://github.com/openfoodfacts/smooth-app/issues/4813

### Fixes bug(s)
- #829

### Impacted files
* `http_helper.dart`: safer `From` http header.
* `user_management_test_test_env.dart`: new test if the login crashes with a non-ASCII/ISO-8859-1 username
