### PR TITLE
feat: 836 - localizable and clickable server error

### DIFF
--- a/lib/src/model/sign_up_status.dart
+++ b/lib/src/model/sign_up_status.dart
@@ -18,10 +18,9 @@ class SignUpStatus extends Status {
   factory SignUpStatus(Status status) {
     if (status.body == null) {
       return SignUpStatus._(
-        status: 500,
+        status: Status.serverErrorStatus,
         statusErrors: {SignUpStatusError.UNKNOWN},
-        error:
-            'No response, open an issue here: https://github.com/openfoodfacts/openfoodfacts-dart/issues/new',
+        error: Status.serverErrorInEnglish,
       );
     } else if (status.body!.contains('loggedin')) {
       return SignUpStatus._(

--- a/lib/src/model/status.dart
+++ b/lib/src/model/status.dart
@@ -7,8 +7,21 @@ part 'status.g.dart';
 
 @JsonSerializable()
 class Status extends JsonObject {
+  // TODO: deprecated from 2023-11-24; remove when old enough
+  @Deprecated('Use wrongUserOrPasswordErrorMessage instead')
   static const WRONG_USER_OR_PASSWORD_ERROR_MESSAGE =
+      wrongUserOrPasswordErrorMessage;
+
+  static const wrongUserOrPasswordErrorMessage =
       'Incorrect user name or password';
+
+  static const String openNewIssueUrl =
+      'https://github.com/openfoodfacts/openfoodfacts-dart/issues/new';
+
+  static const String serverErrorInEnglish =
+      'No response, open an issue here: $openNewIssueUrl';
+
+  static const int serverErrorStatus = 500;
 
   /// Commonly 1 = ok, 0 = failed
   final dynamic status;
@@ -54,8 +67,8 @@ class Status extends JsonObject {
   /// exception.
   static String _createStatusVerbose(String responseBody, Object exception) {
     String statusVerbose;
-    if (responseBody.contains(WRONG_USER_OR_PASSWORD_ERROR_MESSAGE)) {
-      statusVerbose = WRONG_USER_OR_PASSWORD_ERROR_MESSAGE;
+    if (responseBody.contains(wrongUserOrPasswordErrorMessage)) {
+      statusVerbose = wrongUserOrPasswordErrorMessage;
     } else {
       statusVerbose = exception.toString();
     }
@@ -78,8 +91,10 @@ class Status extends JsonObject {
   /// Returns true if this [Status] is caused by wrong username or password,
   /// false otherwise.
   bool isWrongUsernameOrPassword() =>
-      statusVerbose == WRONG_USER_OR_PASSWORD_ERROR_MESSAGE;
+      statusVerbose == wrongUserOrPasswordErrorMessage;
 
   @override
   Map<String, dynamic> toJson() => _$StatusToJson(this);
+
+  bool shouldOpenNewIssue() => status == serverErrorStatus;
 }

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -1056,9 +1056,8 @@ class OpenFoodAPIClient {
     );
     if (status.body == null) {
       return Status(
-        status: 500,
-        error:
-            'No response, open an issue here: https://github.com/openfoodfacts/openfoodfacts-dart/issues/new',
+        status: Status.serverErrorStatus,
+        error: Status.serverErrorInEnglish,
       );
     }
     // Possible strings found in the resulting html.


### PR DESCRIPTION
### What
- Some refactoring about "server error", where we put status=500 and an error message in English.
- Just use new method `shouldOpenNewIssue` in order to:
   - localize a standard "server error" message
   - use `openNewIssueUrl` as a "open new issue" url...

### Fixes bug(s)
- Closes: #836

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/4836

### Impacted files
* `open_food_api_client.dart`: minor refactoring
* `status.dart`: new method `shouldOpenNewIssue` and constant fields `openNewIssueUrl` and `serverErrorStatus`
* `sign_up_status.dart`: minor refactoring