### PR TITLE
chore: skip tesseract tests with server errors

### DIFF
--- a/test/api_ocr_ingredients_test.dart
+++ b/test/api_ocr_ingredients_test.dart
@@ -62,6 +62,7 @@ void main() {
         OpenFoodFactsLanguage.FRENCH,
         OcrField.TESSERACT,
       ),
+      skip: 'Server error',
     );
 
     test(
@@ -80,6 +81,7 @@ void main() {
         OpenFoodFactsLanguage.GERMAN,
         OcrField.TESSERACT,
       ),
+      skip: 'Server error',
     );
 
     test('Add ingredients image to OFF server and then extract the text',


### PR DESCRIPTION
### What
- Tesseract tests recently failed because of the server, cf. https://github.com/openfoodfacts/openfoodfacts-server/issues/9401
- Meanwhile we skip those tests here in off-dart.