### PR TITLE
fix: If `product -> images` is `null`, `getProductImageIds`shouldn't crash

### DIFF
--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -328,7 +328,10 @@ class OpenFoodAPIClient {
     final json = HttpHelper().jsonDecode(jsonStr);
     if (json['status'] != 'success') {
       throw Exception('Error: ${json['status']}');
+    } else if (json['product']['images'] == null) {
+      return <int>[];
     }
+
     final Map<String, dynamic> images = json['product']['images'];
     final List<int> result = <int>[];
     for (final String key in images.keys) {

--- a/test/api_get_product_image_ids_test.dart
+++ b/test/api_get_product_image_ids_test.dart
@@ -14,4 +14,13 @@ void main() {
     );
     expect(result.length, greaterThanOrEqualTo(34)); // was 34 on 2023-01-25
   });
+
+  test('get product image ids without any image', () async {
+    const String barcode = '98765432186';
+    final List<int> result = await OpenFoodAPIClient.getProductImageIds(
+      barcode,
+      user: TestConstants.PROD_USER,
+    );
+    expect(result.length, greaterThanOrEqualTo(0));
+  });
 }


### PR DESCRIPTION
Hi everyone!

As noticed in the OFF app, when in the json, `product -> images` is `null`, the code crashes because we assign it to a non-null Map.