### PR TITLE
fix: unit test value + better json decode

### DIFF
--- a/lib/src/utils/http_helper.dart
+++ b/lib/src/utils/http_helper.dart
@@ -254,6 +254,19 @@ class HttpHelper {
         throw Exception(
             'JSON expected, software error found: ${string.split('\n')[1]}');
       }
+      if (string.startsWith('<!DOCTYPE html>')) {
+        const String titleOpen = '<title>';
+        const String titleClose = '</title>';
+        int pos1 = string.indexOf(titleOpen);
+        if (pos1 >= 0) {
+          pos1 += titleOpen.length;
+          final int pos2 = string.indexOf(titleClose);
+          if (pos2 >= 0 && pos1 < pos2) {
+            throw Exception(
+                'JSON expected, server error found: ${string.substring(pos1, pos2)}');
+          }
+        }
+      }
       rethrow;
     }
   }

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -347,7 +347,7 @@ void main() {
       nutriments = result.product!.nutriments!;
       expect(
         nutriments.getValue(Nutrient.transFat, PerSize.oneHundredGrams),
-        0.1,
+        0.2,
       );
       expect(
         nutriments.getValue(Nutrient.transFat, PerSize.serving),

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -347,7 +347,7 @@ void main() {
       nutriments = result.product!.nutriments!;
       expect(
         nutriments.getValue(Nutrient.transFat, PerSize.oneHundredGrams),
-        0.2,
+        0.1,
       );
       expect(
         nutriments.getValue(Nutrient.transFat, PerSize.serving),


### PR DESCRIPTION
### What
- Fixed a unit test value
- Improved the json decoding when the server is down. Something like
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>ð Service Downtime Notification - Open Food Facts ð</title>
    <style>
```
![image](https://github.com/openfoodfacts/openfoodfacts-dart/assets/11576431/408579cb-bae2-4d55-98c7-443694d9d729)

![image](https://github.com/openfoodfacts/openfoodfacts-dart/assets/11576431/5ed67f07-b0a4-42e7-86ae-2763a27f55a7)

### Impacted files
* `api_get_product_test.dart`: updated expected value
* `http_helper.dart`: handled the `<!DOCTYPE html>` returned from the server when jsondecoding