### PR TITLE
fix: 862 - added 1 nutrient

### DIFF
--- a/lib/src/model/nutrient.dart
+++ b/lib/src/model/nutrient.dart
@@ -15,6 +15,9 @@ enum Nutrient implements OffTagged {
   /// Sugars
   sugars(typicalUnit: Unit.G, offTag: 'sugars'),
 
+  /// Added Sugars
+  addedSugars(typicalUnit: Unit.G, offTag: 'added-sugars'),
+
   /// Fats
   fat(typicalUnit: Unit.G, offTag: 'fat'),
 


### PR DESCRIPTION
### What
- Added enumeration support for "added-sugars"
- Nutrient already supported server-side https://github.com/openfoodfacts/openfoodfacts-server/blob/acf96bb5625f02ea1bc3bc0bcbdb82153a896517/taxonomies/nutrients.txt#L2098

### Screenshot
![image](https://github.com/openfoodfacts/openfoodfacts-dart/assets/79552751/349ecb3a-8992-4689-b4dd-680ed072cdc4)

### Part of 
- #862 
