### PR TITLE
feat: 878 - added the "obsolete" product field

### DIFF
--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -543,6 +543,13 @@ class Product extends JsonObject {
   @JsonKey(name: 'link', includeIfNull: false)
   String? website;
 
+  /// Is the product obsolete?
+  @JsonKey(
+    toJson: JsonHelper.checkboxToJSON,
+    fromJson: JsonHelper.checkboxFromJSON,
+  )
+  bool? obsolete;
+
   Product(
       {this.barcode,
       this.productName,

--- a/lib/src/model/product.g.dart
+++ b/lib/src/model/product.g.dart
@@ -164,7 +164,8 @@ Product _$ProductFromJson(Map<String, dynamic> json) => Product(
       ..manufacturingPlaces = json['manufacturing_places'] as String?
       ..origins = json['origins'] as String?
       ..novaGroup = json['nova_group'] as int?
-      ..website = json['link'] as String?;
+      ..website = json['link'] as String?
+      ..obsolete = JsonHelper.checkboxFromJSON(json['obsolete']);
 
 Map<String, dynamic> _$ProductToJson(Product instance) {
   final val = <String, dynamic>{
@@ -294,6 +295,7 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('origins', instance.origins);
   writeNotNull('nova_group', instance.novaGroup);
   writeNotNull('link', instance.website);
+  val['obsolete'] = JsonHelper.checkboxToJSON(instance.obsolete);
   val['no_nutrition_data'] =
       JsonHelper.checkboxToJSON(instance.noNutritionData);
   val['nutriments'] = Nutriments.toJsonHelper(instance.nutriments);

--- a/lib/src/utils/product_fields.dart
+++ b/lib/src/utils/product_fields.dart
@@ -98,6 +98,7 @@ enum ProductField implements OffTagged {
   ORIGINS(offTag: 'origins'),
   NOVA_GROUP(offTag: 'nova_group'),
   WEBSITE(offTag: 'link'),
+  OBSOLETE(offTag: 'obsolete'),
 
   /// All data as RAW from the server. E.g. packagings are only Strings there.
   RAW(offTag: 'raw'),

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -1042,6 +1042,32 @@ void main() {
     expect(result.product!.website, isNotEmpty);
 
     configuration = ProductQueryConfiguration(
+      '8076809517881',
+      fields: [ProductField.OBSOLETE],
+      version: ProductQueryVersion.v3,
+    );
+    result = await OpenFoodAPIClient.getProductV3(
+      configuration,
+    );
+    expect(result.status, ProductResultV3.statusSuccess);
+    expect(result.product, isNotNull);
+    expect(result.product!.obsolete, isNotNull);
+    expect(result.product!.obsolete, isTrue);
+
+    configuration = ProductQueryConfiguration(
+      '7300400481588',
+      fields: [ProductField.OBSOLETE],
+      version: ProductQueryVersion.v3,
+    );
+    result = await OpenFoodAPIClient.getProductV3(
+      configuration,
+    );
+    expect(result.status, ProductResultV3.statusSuccess);
+    expect(result.product, isNotNull);
+    expect(result.product!.obsolete, isNotNull);
+    expect(result.product!.obsolete, isFalse);
+
+    configuration = ProductQueryConfiguration(
       '3033710065066',
       fields: [
         ProductField.LAST_CHECKED,


### PR DESCRIPTION
### What
- New bool "obsolete" product field.

### Fixes bug(s)
- #878

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/5005

### Impacted files
* `api_get_product_test.dart`: tested the new product "obsolete" field on an obsolete and a non-obsolete product
* `product.dart`: added the "obsolete" field
* `product.g.dart`: wtf
* `product_fields.dart`: added the "OBSOLETE" product field