### PR TITLE
feat: 831 - more parameters for the "get prices" API query

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -89,6 +89,9 @@ export 'src/personalized_search/preference_importance.dart';
 export 'src/personalized_search/product_preferences_manager.dart';
 export 'src/personalized_search/product_preferences_selection.dart';
 export 'src/prices/currency.dart';
+// export 'src/prices/get_parameters_helper.dart'; // uncomment if really needed
+export 'src/prices/get_prices_order.dart';
+export 'src/prices/get_prices_parameters.dart';
 export 'src/prices/get_prices_result.dart';
 export 'src/prices/get_prices_results.dart';
 export 'src/prices/location.dart';

--- a/lib/src/prices/get_parameters_helper.dart
+++ b/lib/src/prices/get_parameters_helper.dart
@@ -1,0 +1,81 @@
+import 'package:meta/meta.dart';
+
+/// Helper class for API query parameters.
+abstract class GetParametersHelper {
+  int? pageSize;
+  int? pageNumber;
+
+  final Map<String, String> _result = <String, String>{};
+
+  @protected
+  Map<String, String> get result => _result;
+
+  /// Returns the parameters as a query parameter map.
+  Map<String, String> getQueryParameters() {
+    _checkIntValue('page_number', pageSize, min: 1);
+    _checkIntValue('page_size', pageSize, min: 1, max: 100);
+    _result.clear();
+    addNonNullInt(pageNumber, 'page');
+    addNonNullInt(pageSize, 'size');
+    return _result;
+  }
+
+  void _checkIntValue(
+    final String field,
+    final int? value, {
+    final int? min,
+    final int? max,
+  }) {
+    if (value == null) {
+      return;
+    }
+    if (min != null) {
+      if (value < min) {
+        throw Exception(
+          '$field minimum value is $min (actual value is $value)',
+        );
+      }
+    }
+    if (max != null) {
+      if (value > max) {
+        throw Exception(
+          '$field maximum value is $max (actual value is $value)',
+        );
+      }
+    }
+  }
+
+  void addNonNullString(final String? value, final String tag) {
+    if (value != null) {
+      _result[tag] = value;
+    }
+  }
+
+  void addNonNullInt(final int? value, final String tag) =>
+      addNonNullString(value?.toString(), tag);
+
+  void addNonNullBool(final bool? value, final String tag) =>
+      addNonNullString(value?.toString(), tag);
+
+  void addNonNullDate(
+    final DateTime? value,
+    final String tag, {
+    required final bool dayOnly,
+  }) {
+    if (value != null) {
+      addNonNullString(formatDate(value, dayOnly: dayOnly), tag);
+    }
+  }
+
+  /// Formats a date as DateFormat('yyyy-MM-dd') but without the `intl` package.
+  static String formatDate(
+    final DateTime date, {
+    bool dayOnly = true,
+  }) {
+    final String result = date.toIso8601String();
+    if (dayOnly) {
+      return result.substring(0, 10);
+    }
+    return result;
+  }
+}

--- a/lib/src/prices/get_prices_order.dart
+++ b/lib/src/prices/get_prices_order.dart
@@ -1,0 +1,27 @@
+import 'package:openfoodfacts/src/model/off_tagged.dart';
+
+/// Field for the "order by" clause of "get prices".
+enum GetPricesOrderField implements OffTagged {
+  created(offTag: 'created'),
+  date(offTag: 'date'),
+  price(offTag: 'price');
+
+  const GetPricesOrderField({required this.offTag});
+
+  @override
+  final String offTag;
+}
+
+/// Order clause for "get prices".
+class GetPricesOrder implements OffTagged {
+  const GetPricesOrder({
+    required this.field,
+    required this.ascending,
+  });
+
+  final GetPricesOrderField field;
+  final bool ascending;
+
+  @override
+  String get offTag => '${ascending ? '' : '-'}${field.offTag}';
+}

--- a/lib/src/prices/get_prices_parameters.dart
+++ b/lib/src/prices/get_prices_parameters.dart
@@ -1,0 +1,60 @@
+import 'currency.dart';
+import 'get_parameters_helper.dart';
+import 'get_prices_order.dart';
+import 'location_osm_type.dart';
+
+/// Parameters for the "get prices" API query.
+///
+/// cf. https://prices.openfoodfacts.org/api/docs
+class GetPricesParameters extends GetParametersHelper {
+  String? productCode;
+  int? productId;
+  bool? productIdIsNull;
+  String? categoryTag;
+  String? labelsTagsLike;
+  String? originsTagsLike;
+  int? locationOSMId;
+  LocationOSMType? locationOSMType;
+  int? locationId;
+  Currency? currency;
+  DateTime? date;
+  DateTime? dateGt;
+  DateTime? dateGte;
+  DateTime? dateLt;
+  DateTime? dateLte;
+  String? owner;
+  DateTime? createdGte;
+  List<GetPricesOrder>? getPricesOrder;
+
+  @override
+  Map<String, String> getQueryParameters() {
+    super.getQueryParameters();
+    addNonNullString(productCode, 'product_code');
+    addNonNullInt(productId, 'product_id');
+    addNonNullBool(productIdIsNull, 'product_id__isnull');
+    addNonNullString(categoryTag, 'category_tag');
+    addNonNullString(labelsTagsLike, 'labels_tags__like');
+    addNonNullString(originsTagsLike, 'origins_tags__like');
+    addNonNullInt(locationOSMId, 'location_osm_id');
+    addNonNullString(locationOSMType?.offTag, 'location_osm_type');
+    addNonNullInt(locationId, 'location_id');
+    addNonNullString(currency?.name, 'currency');
+    addNonNullDate(date, 'date', dayOnly: true);
+    addNonNullDate(dateGt, 'date__gt', dayOnly: true);
+    addNonNullDate(dateGte, 'date__gte', dayOnly: true);
+    addNonNullDate(dateLt, 'date__lt', dayOnly: true);
+    addNonNullDate(dateLte, 'date__lte', dayOnly: true);
+    addNonNullString(owner, 'owner');
+    addNonNullDate(createdGte, 'created__gte', dayOnly: false);
+    if (getPricesOrder != null) {
+      final List<String> orders = <String>[];
+      for (final GetPricesOrder order in getPricesOrder!) {
+        orders.add(order.offTag);
+      }
+      if (orders.isNotEmpty) {
+        addNonNullString(orders.join(','), 'order_by');
+      }
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
### What
- More refined parameters for the "get prices" API query.
- Including the "order by" clause, useful for Smoothie (get the latest prices for that product).

### Part of 
- #831

### Files
New files:
* `get_parameters_helper.dart`: Helper class for API query parameters.
* `get_prices_order.dart`: Order clause for "get prices".
* `get_prices_parameters.dart`: Parameters for the "get prices" API query.

Impacted files:
* `api_prices_test.dart`: elaborated the test of "get prices"
* `open_prices_api_client.dart`: refactored
* `openfoodfacts.dart`: 2 new exported files