### PR TITLE
feat: 891 - new "uploaded timestamp" field for raw images

### DIFF
--- a/lib/src/model/product_image.dart
+++ b/lib/src/model/product_image.dart
@@ -130,6 +130,7 @@ class ProductImage {
     required String this.imgid,
     this.width,
     this.height,
+    this.uploaded,
   })  : language = null,
         field = null;
 
@@ -137,6 +138,9 @@ class ProductImage {
   final ImageSize? size;
   final OpenFoodFactsLanguage? language;
   String? url;
+
+  /// Upload timestamp, for uploaded images only, in seconds since Unix Epoch.
+  int? uploaded;
 
   /// Revision number
   int? rev;
@@ -232,6 +236,7 @@ class ProductImage {
       '${language == null ? '' : ',language=${language.code}'}'
       '${angle == null ? '' : ',angle=${angle!.degreesClockwise}'}'
       '${url == null ? '' : ',url=$url'}'
+      '${uploaded == null ? '' : ',uploaded=$uploaded'}'
       '${imgid == null ? '' : ',imgid=$imgid'}'
       '${rev == null ? '' : ',rev=$rev'}'
       '${coordinatesImageSize == null ? '' : ',coordinatesImageSize=$coordinatesImageSize'}'
@@ -262,6 +267,7 @@ class ProductImage {
         other.size == size &&
         other.language == language &&
         other.url == url &&
+        other.uploaded == uploaded &&
         other.rev == rev &&
         other.imgid == imgid &&
         other.angle == angle &&

--- a/lib/src/model/product_image.dart
+++ b/lib/src/model/product_image.dart
@@ -140,7 +140,7 @@ class ProductImage {
   String? url;
 
   /// Upload timestamp, for uploaded images only, in seconds since Unix Epoch.
-  int? uploaded;
+  DateTime? uploaded;
 
   /// Revision number
   int? rev;

--- a/lib/src/utils/json_helper.dart
+++ b/lib/src/utils/json_helper.dart
@@ -152,7 +152,8 @@ class JsonHelper {
       }
 
       if (imageId != null) {
-        final int? uploaded = fieldObject[_ALL_IMAGES_TAG_UPLOADED] as int?;
+        final DateTime? uploaded =
+            timestampToDate(fieldObject[_ALL_IMAGES_TAG_UPLOADED]);
         // get each number object (e.g. 200)
         for (var size in ImageSize.values) {
           var number = size.number;
@@ -290,7 +291,8 @@ class JsonHelper {
           first = false;
           if (!productImage.isMain) {
             if (productImage.uploaded != null) {
-              item[_ALL_IMAGES_TAG_UPLOADED] = productImage.uploaded;
+              item[_ALL_IMAGES_TAG_UPLOADED] =
+                  dateToTimestamp(productImage.uploaded);
             }
           } else {
             if (productImage.rev != null) {

--- a/test/api_json_to_from_test.dart
+++ b/test/api_json_to_from_test.dart
@@ -37,6 +37,7 @@ void main() {
           for (final ProductImage productImage2 in imagesBackAndForth) {
             if (productImage1 == productImage2) {
               count++;
+              expect(productImage1.toString(), productImage2.toString());
             }
           }
           expect(count, 1);
@@ -61,6 +62,7 @@ void main() {
       for (final ProductImage productImage
           in productResult.product!.getMainImages()!) {
         expect(productImage.isMain, true);
+        expect(productImage.uploaded, isNull);
         count++;
       }
       expect(count, countMain);
@@ -69,6 +71,7 @@ void main() {
       for (final ProductImage productImage
           in productResult.product!.getRawImages()!) {
         expect(productImage.isMain, false);
+        expect(productImage.uploaded, isNotNull);
         count++;
       }
       expect(count, countRaw);


### PR DESCRIPTION
### What
- Now we use the "uploaded timestamp" field that the server provided for raw images, but that we just didn't retrieve.
- With this field we'll be able to say if an uploaded image is "too old", e.g. if it was uploaded more than a year ago.

### Fixes bug(s)
- #891

### Part of 
- https://github.com/openfoodfacts/openfoodfacts-server/issues/9226
- https://github.com/openfoodfacts/smooth-app/issues/4674

### Impacted files:
* `api_json_to_from_test.dart`: added tests around new field `uploaded`
* `json_helper.dart`: added the `uploaded` field to from/to json conversion methods; refactored
* `product_image.dart`: added field `uploaded`, for uploaded images only