### PR TITLE
test: Lang field read only

### DIFF
--- a/test/api_add_product_main_language.dart
+++ b/test/api_add_product_main_language.dart
@@ -1,0 +1,51 @@
+import 'dart:math';
+
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:test/test.dart';
+
+import 'test_constants.dart';
+
+void main() {
+  OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
+  const UriProductHelper uriHelper = uriHelperFoodTest;
+
+  group('$OpenFoodAPIClient Save product main language', () {
+    String barcode_1 = '3017620425035';
+
+    test('Save product main language', () async {
+      ProductResultV3 result =
+          await OpenFoodAPIClient.getProductV3(ProductQueryConfiguration(
+        barcode_1,
+        version: ProductQueryVersion.v3,
+      ));
+
+      Product? product = result.product;
+
+      expect(product, isNotNull);
+
+      print('Start lang: ${product!.lang}');
+
+      product.lang = OpenFoodFactsLanguage.GERMAN;
+
+      await OpenFoodAPIClient.saveProduct(
+        TestConstants.TEST_USER,
+        product,
+        uriHelper: uriHelper,
+      );
+
+      ProductResultV3 result_1 =
+          await OpenFoodAPIClient.getProductV3(ProductQueryConfiguration(
+        barcode_1,
+        version: ProductQueryVersion.v3,
+      ));
+
+      Product? product_1 = result_1.product;
+
+      expect(product_1, isNotNull);
+
+      print('End lang: ${product_1!.lang}');
+
+      expect(product_1.lang, OpenFoodFactsLanguage.GERMAN);
+    });
+  });
+}


### PR DESCRIPTION
### What

Related to: https://github.com/openfoodfacts/smooth-app/issues/4771#issuecomment-2004500769


```
Start lang: OpenFoodFactsLanguage.FRENCH

End lang: OpenFoodFactsLanguage.FRENCH

00:18 +0 -1: OpenFoodAPIClient Save product main language Save product main language [E]

  Expected: OpenFoodFactsLanguage:<OpenFoodFactsLanguage.GERMAN>
    Actual: OpenFoodFactsLanguage:<OpenFoodFactsLanguage.FRENCH>

00:18 +0 -1: Some tests failed.

```

It looks like we have a good old read only field
