### PR TITLE
feat: 922 - default currency for each country

### DIFF
--- a/lib/src/prices/currency.dart
+++ b/lib/src/prices/currency.dart
@@ -4,311 +4,927 @@
 /// See https://en.wikipedia.org/wiki/ISO_4217 for a list of valid currency
 /// codes.
 enum Currency {
-  ADP,
-  AED,
-  AFA,
-  AFN,
-  ALK,
-  ALL,
-  AMD,
-  ANG,
-  AOA,
-  AOK,
-  AON,
-  AOR,
-  ARA,
-  ARL,
-  ARM,
-  ARP,
-  ARS,
-  ATS,
-  AUD,
-  AWG,
-  AZM,
-  AZN,
-  BAD,
-  BAM,
-  BAN,
-  BBD,
-  BDT,
-  BEC,
-  BEF,
-  BEL,
-  BGL,
-  BGM,
-  BGN,
-  BGO,
-  BHD,
-  BIF,
-  BMD,
-  BND,
-  BOB,
-  BOL,
-  BOP,
-  BOV,
-  BRB,
-  BRC,
-  BRE,
-  BRL,
-  BRN,
-  BRR,
-  BRZ,
-  BSD,
-  BTN,
-  BUK,
-  BWP,
-  BYB,
-  BYN,
-  BYR,
-  BZD,
-  CAD,
-  CDF,
-  CHE,
-  CHF,
-  CHW,
-  CLE,
-  CLF,
-  CLP,
-  CNH,
-  CNX,
-  CNY,
-  COP,
-  COU,
-  CRC,
-  CSD,
-  CSK,
-  CUC,
-  CUP,
-  CVE,
-  CYP,
-  CZK,
-  DDM,
-  DEM,
-  DJF,
-  DKK,
-  DOP,
-  DZD,
-  ECS,
-  ECV,
-  EEK,
-  EGP,
-  ERN,
-  ESA,
-  ESB,
-  ESP,
-  ETB,
-  EUR,
-  FIM,
-  FJD,
-  FKP,
-  FRF,
-  GBP,
-  GEK,
-  GEL,
-  GHC,
-  GHS,
-  GIP,
-  GMD,
-  GNF,
-  GNS,
-  GQE,
-  GRD,
-  GTQ,
-  GWE,
-  GWP,
-  GYD,
-  HKD,
-  HNL,
-  HRD,
-  HRK,
-  HTG,
-  HUF,
-  IDR,
-  IEP,
-  ILP,
-  ILR,
-  ILS,
-  INR,
-  IQD,
-  IRR,
-  ISJ,
-  ISK,
-  ITL,
-  JMD,
-  JOD,
-  JPY,
-  KES,
-  KGS,
-  KHR,
-  KMF,
-  KPW,
-  KRH,
-  KRO,
-  KRW,
-  KWD,
-  KYD,
-  KZT,
-  LAK,
-  LBP,
-  LKR,
-  LRD,
-  LSL,
-  LTL,
-  LTT,
-  LUC,
-  LUF,
-  LUL,
-  LVL,
-  LVR,
-  LYD,
-  MAD,
-  MAF,
-  MCF,
-  MDC,
-  MDL,
-  MGA,
-  MGF,
-  MKD,
-  MKN,
-  MLF,
-  MMK,
-  MNT,
-  MOP,
-  MRO,
-  MRU,
-  MTL,
-  MTP,
-  MUR,
-  MVP,
-  MVR,
-  MWK,
-  MXN,
-  MXP,
-  MXV,
-  MYR,
-  MZE,
-  MZM,
-  MZN,
-  NAD,
-  NGN,
-  NIC,
-  NIO,
-  NLG,
-  NOK,
-  NPR,
-  NZD,
-  OMR,
-  PAB,
-  PEI,
-  PEN,
-  PES,
-  PGK,
-  PHP,
-  PKR,
-  PLN,
-  PLZ,
-  PTE,
-  PYG,
-  QAR,
-  RHD,
-  ROL,
-  RON,
-  RSD,
-  RUB,
-  RUR,
-  RWF,
-  SAR,
-  SBD,
-  SCR,
-  SDD,
-  SDG,
-  SDP,
-  SEK,
-  SGD,
-  SHP,
-  SIT,
-  SKK,
-  SLE,
-  SLL,
-  SOS,
-  SRD,
-  SRG,
-  SSP,
-  STD,
-  STN,
-  SUR,
-  SVC,
-  SYP,
-  SZL,
-  THB,
-  TJR,
-  TJS,
-  TMM,
-  TMT,
-  TND,
-  TOP,
-  TPE,
-  TRL,
-  TRY,
-  TTD,
-  TWD,
-  TZS,
-  UAH,
-  UAK,
-  UGS,
-  UGX,
-  USD,
-  USN,
-  USS,
-  UYI,
-  UYP,
-  UYU,
-  UYW,
-  UZS,
-  VEB,
-  VED,
-  VEF,
-  VES,
-  VND,
-  VNN,
-  VUV,
-  WST,
-  XAF,
-  XAG,
-  XAU,
-  XBA,
-  XBB,
-  XBC,
-  XBD,
-  XCD,
-  XDR,
-  XEU,
-  XFO,
-  XFU,
-  XOF,
-  XPD,
-  XPF,
-  XPT,
-  XRE,
-  XSU,
-  XTS,
-  XUA,
-  XXX,
-  YDD,
-  YER,
-  YUD,
-  YUM,
-  YUN,
-  YUR,
-  ZAL,
-  ZAR,
-  ZMK,
-  ZMW,
-  ZRN,
-  ZRZ,
-  ZWD,
-  ZWL,
-  ZWR;
+  /// Andorran peseta
+  ADP(historicalCode: true),
 
-  const Currency();
+  /// United Arab Emirates dirham
+  AED,
+
+  /// Afghan afghani
+  AFA(historicalCode: true),
+
+  /// Afghan afghani
+  AFN,
+
+  /// Old Albanian lek
+  ALK(historicalCode: true),
+
+  /// Albanian lek
+  ALL,
+
+  /// Armenian dram
+  AMD,
+
+  /// Netherlands Antillean guilder
+  ANG,
+
+  /// Angolan kwanza
+  AOA,
+
+  /// Angolan kwanza
+  AOK(historicalCode: true),
+
+  /// Angolan novo kwanza
+  AON(historicalCode: true),
+
+  /// Angolan kwanza reajustado
+  AOR(historicalCode: true),
+
+  /// Argentine austral
+  ARA(historicalCode: true),
+
+  /// Argentine peso ley
+  ARL(unofficialCode: true),
+
+  ARM(noCountry: true),
+
+  /// Argentine peso argentino
+  ARP(historicalCode: true),
+
+  /// Argentine peso
+  ARS,
+
+  /// Austrian schilling
+  ATS(historicalCode: true),
+
+  /// Australian dollar
+  AUD,
+
+  /// Aruban florin
+  AWG,
+
+  /// Azerbaijani manat
+  AZM(historicalCode: true),
+
+  /// Azerbaijani manat
+  AZN,
+
+  /// Bosnia and Herzegovina dinar
+  BAD(historicalCode: true),
+
+  /// Bosnia and Herzegovina convertible mark
+  BAM,
+
+  BAN(noCountry: true),
+
+  /// Barbados dollar
+  BBD,
+
+  /// Bangladeshi taka
+  BDT,
+
+  /// Belgian convertible franc (funds code)
+  BEC(historicalCode: true, fundsCode: true),
+
+  /// Belgian franc
+  BEF(historicalCode: true),
+
+  /// Belgian financial franc (funds code)
+  BEL(historicalCode: true, fundsCode: true),
+
+  /// Bulgarian lev
+  BGL(historicalCode: true),
+
+  BGM(noCountry: true),
+
+  /// Bulgarian lev
+  BGN,
+
+  BGO(noCountry: true),
+
+  /// Bahraini dinar
+  BHD,
+
+  /// Burundian franc
+  BIF,
+
+  /// Bermudian dollar
+  BMD,
+
+  /// Brunei dollar
+  BND,
+
+  /// Boliviano
+  BOB,
+
+  BOL(noCountry: true),
+
+  /// Bolivian peso
+  BOP(historicalCode: true),
+
+  /// Bolivian Mvdol (funds code)
+  BOV(fundsCode: true),
+
+  /// Brazilian cruzeiro
+  BRB(historicalCode: true),
+
+  /// Brazilian cruzado
+  BRC(historicalCode: true),
+
+  /// Brazilian cruzeiro
+  BRE(historicalCode: true),
+
+  /// Brazilian real
+  BRL,
+
+  /// Brazilian cruzado novo
+  BRN(historicalCode: true),
+
+  /// Brazilian cruzeiro real
+  BRR(historicalCode: true),
+
+  BRZ(noCountry: true),
+
+  /// Bahamian dollar
+  BSD,
+
+  /// Bhutanese ngultrum
+  BTN,
+
+  /// Burmese kyat
+  BUK(historicalCode: true),
+
+  /// Botswana pula
+  BWP,
+
+  /// Belarusian ruble
+  BYB(historicalCode: true),
+
+  /// Belarusian ruble
+  BYN,
+
+  /// Belarusian ruble
+  BYR(historicalCode: true),
+
+  /// Belize dollar
+  BZD,
+
+  /// Canadian dollar
+  CAD,
+
+  /// Congolese franc
+  CDF,
+
+  /// WIR euro (complementary currency)
+  CHE(complementaryCurrency: true),
+
+  /// Swiss franc
+  CHF,
+
+  /// WIR franc (complementary currency)
+  CHW(complementaryCurrency: true),
+
+  CLE(noCountry: true),
+
+  /// Unidad de Fomento (funds code)
+  CLF(fundsCode: true),
+
+  /// Chilean peso
+  CLP,
+
+  CNH(noCountry: true),
+
+  CNX(noCountry: true),
+
+  /// Renminbi
+  CNY,
+
+  /// Colombian peso
+  COP,
+
+  /// Unidad de Valor Real (UVR) (funds code)
+  COU(fundsCode: true),
+
+  /// Costa Rican colon
+  CRC,
+
+  /// Serbian dinar
+  CSD(historicalCode: true),
+
+  /// Czechoslovak koruna
+  CSK(historicalCode: true),
+
+  /// Cuban convertible peso
+  CUC(historicalCode: true),
+
+  /// Cuban peso
+  CUP,
+
+  /// Cape Verdean escudo
+  CVE,
+
+  /// Cypriot pound
+  CYP(historicalCode: true),
+
+  /// Czech koruna
+  CZK,
+
+  /// East German mark
+  DDM(historicalCode: true),
+
+  /// German mark
+  DEM(historicalCode: true),
+
+  /// Djiboutian franc
+  DJF,
+
+  /// Danish krone
+  DKK,
+
+  /// Dominican peso
+  DOP,
+
+  /// Algerian dinar
+  DZD,
+
+  /// Ecuadorian sucre
+  ECS(historicalCode: true),
+
+  /// Ecuador Unidad de Valor Constante (funds code)
+  ECV(historicalCode: true, fundsCode: true),
+
+  /// Estonian kroon
+  EEK(historicalCode: true),
+
+  /// Egyptian pound
+  EGP,
+
+  /// Eritrean nakfa
+  ERN,
+
+  /// Spanish peseta (account A)
+  ESA(historicalCode: true),
+
+  /// Spanish peseta (account B)
+  ESB(historicalCode: true),
+
+  /// Spanish peseta
+  ESP(historicalCode: true),
+
+  /// Ethiopian birr
+  ETB,
+
+  /// Euro
+  EUR,
+
+  /// Finnish markka
+  FIM(historicalCode: true),
+
+  /// Fiji dollar
+  FJD,
+
+  /// Falkland Islands pound
+  FKP,
+
+  /// French franc
+  FRF(historicalCode: true),
+
+  /// Pound sterling
+  GBP,
+
+  /// Georgian kuponi
+  GEK(historicalCode: true),
+
+  /// Georgian lari
+  GEL,
+
+  /// Ghanaian cedi
+  GHC(historicalCode: true),
+
+  /// Ghanaian cedi
+  GHS,
+
+  /// Gibraltar pound
+  GIP,
+
+  /// Gambian dalasi
+  GMD,
+
+  /// Guinean franc
+  GNF,
+
+  /// Guinean syli
+  GNS(historicalCode: true),
+
+  /// Equatorial Guinean ekwele
+  GQE(historicalCode: true),
+
+  /// Greek drachma
+  GRD(historicalCode: true),
+
+  /// Guatemalan quetzal
+  GTQ,
+
+  /// Guinean escudo
+  GWE(historicalCode: true),
+
+  /// Guinea-Bissau peso
+  GWP(historicalCode: true),
+
+  /// Guyanese dollar
+  GYD,
+
+  /// Hong Kong dollar
+  HKD,
+
+  /// Honduran lempira
+  HNL,
+
+  /// Croatian dinar
+  HRD(historicalCode: true),
+
+  /// Croatian kuna
+  HRK(historicalCode: true),
+
+  /// Haitian gourde
+  HTG,
+
+  /// Hungarian forint
+  HUF,
+
+  /// Indonesian rupiah
+  IDR,
+
+  /// Irish pound
+  IEP(historicalCode: true),
+
+  /// Israeli pound
+  ILP(historicalCode: true),
+
+  /// Israeli shekel
+  ILR(historicalCode: true),
+
+  /// Israeli new shekel
+  ILS,
+
+  /// Indian rupee
+  INR,
+
+  /// Iraqi dinar
+  IQD,
+
+  /// Iranian rial
+  IRR,
+
+  /// Icelandic króna
+  ISJ(historicalCode: true),
+
+  /// Icelandic króna
+  ISK,
+
+  /// Italian lira
+  ITL(historicalCode: true),
+
+  /// Jamaican dollar
+  JMD,
+
+  /// Jordanian dinar
+  JOD,
+
+  /// Japanese yen
+  JPY,
+
+  /// Kenyan shilling
+  KES,
+
+  /// Kyrgyzstani som
+  KGS,
+
+  /// Cambodian riel
+  KHR,
+
+  /// Comoro franc
+  KMF,
+
+  /// North Korean won
+  KPW,
+
+  KRH(noCountry: true),
+
+  KRO(noCountry: true),
+
+  /// South Korean won
+  KRW,
+
+  /// Kuwaiti dinar
+  KWD,
+
+  /// Cayman Islands dollar
+  KYD,
+
+  /// Kazakhstani tenge
+  KZT,
+
+  /// Lao kip
+  LAK,
+
+  /// Lebanese pound
+  LBP,
+
+  /// Sri Lankan rupee
+  LKR,
+
+  /// Liberian dollar
+  LRD,
+
+  /// Lesotho loti
+  LSL,
+
+  /// Lithuanian litas
+  LTL(historicalCode: true),
+
+  /// Lithuanian talonas
+  LTT(historicalCode: true),
+
+  /// Luxembourg convertible franc (funds code)
+  LUC(historicalCode: true, fundsCode: true),
+
+  /// Luxembourg franc
+  LUF(historicalCode: true),
+
+  /// Luxembourg financial franc (funds code)
+  LUL(historicalCode: true, fundsCode: true),
+
+  /// Latvian lats
+  LVL(historicalCode: true),
+
+  /// Latvian rublis
+  LVR(historicalCode: true),
+
+  /// Libyan dinar
+  LYD,
+
+  /// Moroccan dirham
+  MAD,
+
+  /// Malian franc
+  MAF(historicalCode: true, unofficialCode: true),
+
+  /// Monégasque franc
+  MCF(historicalCode: true, unofficialCode: true),
+
+  MDC(noCountry: true),
+
+  /// Moldovan leu
+  MDL,
+
+  /// Malagasy ariary
+  MGA,
+
+  /// Malagasy franc
+  MGF(historicalCode: true),
+
+  /// Macedonian denar
+  MKD,
+
+  /// First denar
+  MKN(historicalCode: true, unofficialCode: true),
+
+  /// Malian franc
+  MLF(historicalCode: true),
+
+  /// Myanmar kyat
+  MMK,
+
+  /// Mongolian tögrög
+  MNT,
+
+  /// Macanese pataca
+  MOP,
+
+  /// Mauritanian ouguiya
+  MRO(historicalCode: true),
+
+  /// Mauritanian ouguiya
+  MRU,
+
+  /// Maltese lira
+  MTL(historicalCode: true),
+
+  /// Maltese pound
+  MTP(historicalCode: true),
+
+  /// Mauritian rupee
+  MUR,
+
+  MVP(noCountry: true),
+
+  /// Maldivian rufiyaa
+  MVR,
+
+  /// Malawian kwacha
+  MWK,
+
+  /// Mexican peso
+  MXN,
+
+  /// Mexican peso
+  MXP(historicalCode: true),
+
+  /// Mexican Unidad de Inversion (UDI) (funds code)
+  MXV(fundsCode: true),
+
+  /// Malaysian ringgit
+  MYR,
+
+  /// Mozambican escudo
+  MZE(historicalCode: true),
+
+  /// Mozambican metical
+  MZM(historicalCode: true),
+
+  /// Mozambican metical
+  MZN,
+
+  /// Namibian dollar
+  NAD,
+
+  /// Nigerian naira
+  NGN,
+
+  /// Nicaraguan córdoba
+  NIC(historicalCode: true),
+
+  /// Nicaraguan córdoba
+  NIO,
+
+  /// Dutch guilder
+  NLG(historicalCode: true),
+
+  /// Norwegian krone
+  NOK,
+
+  /// Nepalese rupee
+  NPR,
+
+  /// New Zealand dollar
+  NZD,
+
+  /// Omani rial
+  OMR,
+
+  /// Panamanian balboa
+  PAB,
+
+  /// Peruvian inti
+  PEI(historicalCode: true),
+
+  /// Peruvian sol
+  PEN,
+
+  /// Peruvian sol
+  PES(historicalCode: true),
+
+  /// Papua New Guinean kina
+  PGK,
+
+  /// Philippine peso
+  PHP,
+
+  /// Pakistani rupee
+  PKR,
+
+  /// Polish złoty
+  PLN,
+
+  /// Polish zloty
+  PLZ(historicalCode: true),
+
+  /// Portuguese escudo
+  PTE(historicalCode: true),
+
+  /// Paraguayan guaraní
+  PYG,
+
+  /// Qatari riyal
+  QAR,
+
+  /// Rhodesian dollar
+  RHD(historicalCode: true),
+
+  /// Romanian leu
+  ROL(historicalCode: true),
+
+  /// Romanian leu
+  RON,
+
+  /// Serbian dinar
+  RSD,
+
+  /// Russian ruble
+  RUB,
+
+  /// Russian ruble
+  RUR(historicalCode: true),
+
+  /// Rwandan franc
+  RWF,
+
+  /// Saudi riyal
+  SAR,
+
+  /// Solomon Islands dollar
+  SBD,
+
+  /// Seychelles rupee
+  SCR,
+
+  /// Sudanese dinar
+  SDD(historicalCode: true),
+
+  /// Sudanese pound
+  SDG,
+
+  /// Sudanese old pound
+  SDP(historicalCode: true),
+
+  /// Swedish krona
+  SEK,
+
+  /// Singapore dollar
+  SGD,
+
+  /// Saint Helena pound
+  SHP,
+
+  /// Slovenian tolar
+  SIT(historicalCode: true),
+
+  /// Slovak koruna
+  SKK(historicalCode: true),
+
+  /// Sierra Leonean leone (new leone)
+  SLE,
+
+  /// Sierra Leonean leone (old leone)
+  SLL(historicalCode: true),
+
+  /// Somalian shilling
+  SOS,
+
+  /// Surinamese dollar
+  SRD,
+
+  /// Surinamese guilder
+  SRG(historicalCode: true),
+
+  /// South Sudanese pound
+  SSP,
+
+  /// São Tomé and Príncipe dobra
+  STD(historicalCode: true),
+
+  /// São Tomé and Príncipe dobra
+  STN,
+
+  /// Soviet Union ruble
+  SUR(historicalCode: true),
+
+  /// Salvadoran colón
+  SVC,
+
+  /// Syrian pound
+  SYP,
+
+  /// Swazi lilangeni
+  SZL,
+
+  /// Thai baht
+  THB,
+
+  /// Tajikistani ruble
+  TJR(historicalCode: true),
+
+  /// Tajikistani somoni
+  TJS,
+
+  /// Turkmenistani manat
+  TMM(historicalCode: true),
+
+  /// Turkmenistan manat
+  TMT,
+
+  /// Tunisian dinar
+  TND,
+
+  /// Tongan paʻanga
+  TOP,
+
+  /// Portuguese Timorese escudo
+  TPE(historicalCode: true),
+
+  /// Turkish lira
+  TRL(historicalCode: true),
+
+  /// Turkish lira
+  TRY,
+
+  /// Trinidad and Tobago dollar
+  TTD,
+
+  /// New Taiwan dollar
+  TWD,
+
+  /// Tanzanian shilling
+  TZS,
+
+  /// Ukrainian hryvnia
+  UAH,
+
+  /// Ukrainian karbovanets
+  UAK(historicalCode: true),
+
+  /// Ugandan shilling
+  UGS(historicalCode: true),
+
+  /// Ugandan shilling
+  UGX,
+
+  /// United States dollar
+  USD,
+
+  /// United States dollar (next day) (funds code)
+  USN(fundsCode: true),
+
+  /// United States dollar (same day) (funds code)
+  USS(historicalCode: true, fundsCode: true),
+
+  /// Uruguay Peso en Unidades Indexadas (URUIURUI) (funds code)
+  UYI(fundsCode: true),
+
+  /// Uruguay new peso
+  UYP(historicalCode: true),
+
+  /// Uruguayan peso
+  UYU,
+
+  /// Unidad previsional
+  UYW(noCountry: true),
+
+  /// Uzbekistani sum
+  UZS,
+
+  /// Venezuelan bolívar
+  VEB(historicalCode: true),
+
+  /// Venezuelan digital bolívar
+  VED,
+
+  /// Venezuelan bolívar fuerte
+  VEF(historicalCode: true),
+
+  /// Venezuelan sovereign bolívar
+  VES(historicalCode: true),
+
+  /// Vietnamese đồng
+  VND,
+
+  VNN(noCountry: true),
+
+  /// Vanuatu vatu
+  VUV,
+
+  /// Samoan tala
+  WST,
+
+  /// CFA franc BEAC
+  XAF,
+
+  /// Silver (one troy ounce)
+  XAG(noCountry: true),
+
+  /// Gold (one troy ounce)
+  XAU(noCountry: true),
+
+  /// European Composite Unit (EURCO) (bond market unit)
+  XBA(noCountry: true),
+
+  /// European Monetary Unit (E.M.U.-6) (bond market unit)
+  XBB(noCountry: true),
+
+  /// European Unit of Account 9 (E.U.A.-9) (bond market unit)
+  XBC(noCountry: true),
+
+  /// European Unit of Account 17 (E.U.A.-17) (bond market unit)
+  XBD(noCountry: true),
+
+  /// East Caribbean dollar
+  XCD,
+
+  /// Special drawing rights
+  XDR(noCountry: true),
+
+  /// European Currency Unit
+  XEU(historicalCode: true),
+
+  /// Gold franc (special settlement currency)
+  XFO(historicalCode: true),
+
+  /// UIC franc (special settlement currency
+  XFU(historicalCode: true),
+
+  /// CFA franc BCEAO
+  XOF,
+
+  /// Palladium (one troy ounce)
+  XPD(noCountry: true),
+
+  /// CFP franc (franc Pacifique)
+  XPF,
+
+  /// Platinum (one troy ounce)
+  XPT(noCountry: true),
+
+  /// RINET funds code
+  XRE(historicalCode: true, fundsCode: true),
+
+  /// SUCRE
+  XSU(noCountry: true),
+
+  /// Code reserved for testing
+  XTS(noCountry: true),
+
+  /// ADB Unit of Account
+  XUA(noCountry: true),
+
+  /// No currency
+  XXX(noCountry: true),
+
+  /// South Yemeni dinar
+  YDD(historicalCode: true),
+
+  /// Yemeni rial
+  YER,
+
+  /// Yugoslav dinar
+  YUD(historicalCode: true),
+
+  /// Yugoslav dinar
+  YUM(historicalCode: true),
+
+  /// Yugoslav dinar
+  YUN(historicalCode: true),
+
+  /// Reformed Yugoslav dinar
+  YUR(historicalCode: true, unofficialCode: true),
+
+  /// South African financial rand (funds code)
+  ZAL(historicalCode: true, fundsCode: true),
+
+  /// South African rand
+  ZAR,
+
+  /// Zambian kwacha
+  ZMK(historicalCode: true),
+
+  /// Zambian kwacha
+  ZMW,
+
+  /// Zairean new zaire
+  ZRN(historicalCode: true),
+
+  /// Zairean zaire
+  ZRZ(historicalCode: true),
+
+  /// Zimbabwean dollar
+  ZWD(historicalCode: true),
+
+  /// Zimbabwean dollar
+  ZWL,
+
+  /// Zimbabwean dollar
+  ZWR(historicalCode: true);
+
+  const Currency({
+    this.historicalCode = false,
+    this.unofficialCode = false,
+    this.fundsCode = false,
+    this.complementaryCurrency = false,
+    this.noCountry = false,
+  });
+
+  /// ISO 4217 currency codes until their replacement by another currency.
+  final bool historicalCode;
+
+  /// Non-standard codes
+  final bool unofficialCode;
+
+  /// Funds code
+  final bool fundsCode;
+
+  /// Complementary currency
+  final bool complementaryCurrency;
+
+  /// Not really attached to a specific country at all.
+  final bool noCountry;
 }

--- a/lib/src/utils/country_helper.dart
+++ b/lib/src/utils/country_helper.dart
@@ -763,7 +763,7 @@ enum OpenFoodFactsCountry implements OffTagged {
   final String offTag;
 
   // TODO(monsieurtanuki): remove ANTARCTICA, with no products and no currency?
-  /// Country most probably and up-to-date currency.
+  /// Country most probable and up-to-date currency.
   final Currency? currency;
 
   /// Returns the [OpenFoodFactsCountry] that matches the [offTag].

--- a/lib/src/utils/country_helper.dart
+++ b/lib/src/utils/country_helper.dart
@@ -1,764 +1,770 @@
 import '../model/off_tagged.dart';
+import '../prices/currency.dart';
 
 /// Countries.
 ///
 /// cf. https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 enum OpenFoodFactsCountry implements OffTagged {
   /// Andorra
-  ANDORRA(offTag: 'ad'),
+  ANDORRA(offTag: 'ad', currency: Currency.EUR),
 
   /// United Arab Emirates
-  UNITED_ARAB_EMIRATES(offTag: 'ae'),
+  UNITED_ARAB_EMIRATES(offTag: 'ae', currency: Currency.AED),
 
   /// Afghanistan
-  AFGHANISTAN(offTag: 'af'),
+  AFGHANISTAN(offTag: 'af', currency: Currency.AFN),
 
   /// Antigua and Barbuda
-  ANTIGUA_AND_BARBUDA(offTag: 'ag'),
+  ANTIGUA_AND_BARBUDA(offTag: 'ag', currency: Currency.XCD),
 
   /// Anguilla
-  ANGUILLA(offTag: 'ai'),
+  ANGUILLA(offTag: 'ai', currency: Currency.XCD),
 
   /// Albania
-  ALBANIA(offTag: 'al'),
+  ALBANIA(offTag: 'al', currency: Currency.ALL),
 
   /// Armenia
-  ARMENIA(offTag: 'am'),
+  ARMENIA(offTag: 'am', currency: Currency.AMD),
 
   /// Angola
-  ANGOLA(offTag: 'ao'),
+  ANGOLA(offTag: 'ao', currency: Currency.AOA),
 
   /// Antarctica
-  ANTARCTICA(offTag: 'aq'),
+  ANTARCTICA(offTag: 'aq', currency: null),
 
   /// Argentina
-  ARGENTINA(offTag: 'ar'),
+  ARGENTINA(offTag: 'ar', currency: Currency.ARS),
 
   /// American Samoa
-  AMERICAN_SAMOA(offTag: 'as'),
+  AMERICAN_SAMOA(offTag: 'as', currency: Currency.USD),
 
   /// Austria
-  AUSTRIA(offTag: 'at'),
+  AUSTRIA(offTag: 'at', currency: Currency.EUR),
 
   /// Australia
-  AUSTRALIA(offTag: 'au'),
+  AUSTRALIA(offTag: 'au', currency: Currency.AUD),
 
   /// Aruba
-  ARUBA(offTag: 'aw'),
+  ARUBA(offTag: 'aw', currency: Currency.AWG),
 
   /// Åland Islands
-  ALAND_ISLANDS(offTag: 'ax'),
+  ALAND_ISLANDS(offTag: 'ax', currency: Currency.EUR),
 
   /// Azerbaijan
-  AZERBAIJAN(offTag: 'az'),
+  AZERBAIJAN(offTag: 'az', currency: Currency.AZN),
 
   /// Bosnia and Herzegovina
-  BOSNIA_AND_HERZEGOVINA(offTag: 'ba'),
+  BOSNIA_AND_HERZEGOVINA(offTag: 'ba', currency: Currency.BAM),
 
   /// Barbados
-  BARBADOS(offTag: 'bb'),
+  BARBADOS(offTag: 'bb', currency: Currency.BBD),
 
   /// Bangladesh
-  BANGLADESH(offTag: 'bd'),
+  BANGLADESH(offTag: 'bd', currency: Currency.BDT),
 
   /// Belgium
-  BELGIUM(offTag: 'be'),
+  BELGIUM(offTag: 'be', currency: Currency.EUR),
 
   /// Burkina Faso
-  BURKINA_FASO(offTag: 'bf'),
+  BURKINA_FASO(offTag: 'bf', currency: Currency.XOF),
 
   /// Bulgaria
-  BULGARIA(offTag: 'bg'),
+  BULGARIA(offTag: 'bg', currency: Currency.BGN),
 
   /// Bahrain
-  BAHRAIN(offTag: 'bh'),
+  BAHRAIN(offTag: 'bh', currency: Currency.BHD),
 
   /// Burundi
-  BURUNDI(offTag: 'bi'),
+  BURUNDI(offTag: 'bi', currency: Currency.BIF),
 
   /// Benin
-  BENIN(offTag: 'bj'),
+  BENIN(offTag: 'bj', currency: Currency.XOF),
 
   /// Saint Barthélemy
-  SAINT_BARTHELEMY(offTag: 'bl'),
+  SAINT_BARTHELEMY(offTag: 'bl', currency: Currency.EUR),
 
   /// Bermuda
-  BERMUDA(offTag: 'bm'),
+  BERMUDA(offTag: 'bm', currency: Currency.BMD),
 
   /// Brunei Darussalam
-  BRUNEI_DARUSSALAM(offTag: 'bn'),
+  BRUNEI_DARUSSALAM(offTag: 'bn', currency: Currency.BND),
 
   /// Bolivia (Plurinational State of)
-  BOLIVIA(offTag: 'bo'),
+  BOLIVIA(offTag: 'bo', currency: Currency.BOB),
 
   /// Bonaire, Sint Eustatius and Saba
-  BONAIRE(offTag: 'bq'),
+  BONAIRE(offTag: 'bq', currency: Currency.USD),
 
   /// Brazil
-  BRAZIL(offTag: 'br'),
+  BRAZIL(offTag: 'br', currency: Currency.BRL),
 
   /// Bahamas
-  BAHAMAS(offTag: 'bs'),
+  BAHAMAS(offTag: 'bs', currency: Currency.BSD),
 
   /// Bhutan
-  BHUTAN(offTag: 'bt'),
+  BHUTAN(offTag: 'bt', currency: Currency.BTN),
 
   /// Bouvet Island
-  BOUVET_ISLAND(offTag: 'bv'),
+  BOUVET_ISLAND(offTag: 'bv', currency: Currency.NOK),
 
   /// Botswana
-  BOTSWANA(offTag: 'bw'),
+  BOTSWANA(offTag: 'bw', currency: Currency.BWP),
 
   /// Belarus
-  BELARUS(offTag: 'by'),
+  BELARUS(offTag: 'by', currency: Currency.BYN),
 
   /// Belize
-  BELIZE(offTag: 'bz'),
+  BELIZE(offTag: 'bz', currency: Currency.BZD),
 
   /// Canada
-  CANADA(offTag: 'ca'),
+  CANADA(offTag: 'ca', currency: Currency.CAD),
 
   /// Cocos (Keeling) Islands
-  COCOS_ISLANDS(offTag: 'cc'),
+  COCOS_ISLANDS(offTag: 'cc', currency: Currency.AUD),
 
   /// Congo, Democratic Republic of the
-  DEMOCRATIC_REPUBLIC_OF_THE_CONGO(offTag: 'cd'),
+  DEMOCRATIC_REPUBLIC_OF_THE_CONGO(offTag: 'cd', currency: Currency.CDF),
 
   /// Central African Republic
-  CENTRAL_AFRICAN_REPUBLIC(offTag: 'cf'),
+  CENTRAL_AFRICAN_REPUBLIC(offTag: 'cf', currency: Currency.XAF),
 
   /// Congo
-  CONGO(offTag: 'cg'),
+  CONGO(offTag: 'cg', currency: Currency.XAF),
 
   /// Switzerland
-  SWITZERLAND(offTag: 'ch'),
+  SWITZERLAND(offTag: 'ch', currency: Currency.CHF),
 
   /// Côte d'Ivoire
-  COTE_D_IVOIRE(offTag: 'ci'),
+  COTE_D_IVOIRE(offTag: 'ci', currency: Currency.XOF),
 
   /// Cook Islands
-  COOK_ISLANDS(offTag: 'ck'),
+  COOK_ISLANDS(offTag: 'ck', currency: Currency.NZD),
 
   /// Chile
-  CHILE(offTag: 'cl'),
+  CHILE(offTag: 'cl', currency: Currency.CLP),
 
   /// Cameroon
-  CAMEROON(offTag: 'cm'),
+  CAMEROON(offTag: 'cm', currency: Currency.XAF),
 
   /// China
-  CHINA(offTag: 'cn'),
+  CHINA(offTag: 'cn', currency: Currency.CNY),
 
   /// Colombia
-  COLOMBIA(offTag: 'co'),
+  COLOMBIA(offTag: 'co', currency: Currency.COP),
 
   /// Costa Rica
-  COSTA_RICA(offTag: 'cr'),
+  COSTA_RICA(offTag: 'cr', currency: Currency.CRC),
 
   /// Cuba
-  CUBA(offTag: 'cu'),
+  CUBA(offTag: 'cu', currency: Currency.CUP),
 
   /// Cabo Verde
-  CABO_VERDE(offTag: 'cv'),
+  CABO_VERDE(offTag: 'cv', currency: Currency.CVE),
 
   /// Curaçao
-  CURACAO(offTag: 'cw'),
+  CURACAO(offTag: 'cw', currency: Currency.ANG),
 
   /// Christmas Island
-  CHRISTMAS_ISLAND(offTag: 'cx'),
+  CHRISTMAS_ISLAND(offTag: 'cx', currency: Currency.AUD),
 
   ///Cyprus
-  CYPRUS(offTag: 'cy'),
+  CYPRUS(offTag: 'cy', currency: Currency.EUR),
 
   /// Czechia
-  CZECHIA(offTag: 'cz'),
+  CZECHIA(offTag: 'cz', currency: Currency.CZK),
 
   /// Germany
-  GERMANY(offTag: 'de'),
+  GERMANY(offTag: 'de', currency: Currency.EUR),
 
   /// Djibouti
-  DJIBOUTI(offTag: 'dj'),
+  DJIBOUTI(offTag: 'dj', currency: Currency.DJF),
 
   /// Denmark
-  DENMARK(offTag: 'dk'),
+  DENMARK(offTag: 'dk', currency: Currency.DKK),
 
   /// Dominica
-  DOMINICA(offTag: 'dm'),
+  DOMINICA(offTag: 'dm', currency: Currency.XCD),
 
   /// Dominican Republic
-  DOMINICAN_REPUBLIC(offTag: 'do'),
+  DOMINICAN_REPUBLIC(offTag: 'do', currency: Currency.DOP),
 
   /// Algeria
-  ALGERIA(offTag: 'dz'),
+  ALGERIA(offTag: 'dz', currency: Currency.DZD),
 
   /// Ecuador
-  ECUADOR(offTag: 'ec'),
+  ECUADOR(offTag: 'ec', currency: Currency.USD),
 
   /// Estonia
-  ESTONIA(offTag: 'ee'),
+  ESTONIA(offTag: 'ee', currency: Currency.EUR),
 
   /// Egypt
-  EGYPT(offTag: 'eg'),
+  EGYPT(offTag: 'eg', currency: Currency.EGP),
 
   /// Western Sahara
-  WESTERN_SAHARA(offTag: 'eh'),
+  WESTERN_SAHARA(offTag: 'eh', currency: Currency.MAD),
 
   /// Eritrea
-  ERITREA(offTag: 'er'),
+  ERITREA(offTag: 'er', currency: Currency.ERN),
 
   /// Spain
-  SPAIN(offTag: 'es'),
+  SPAIN(offTag: 'es', currency: Currency.EUR),
 
   /// Ethiopia
-  ETHIOPIA(offTag: 'et'),
+  ETHIOPIA(offTag: 'et', currency: Currency.ETB),
 
   /// Finland
-  FINLAND(offTag: 'fi'),
+  FINLAND(offTag: 'fi', currency: Currency.EUR),
 
   /// Fiji
-  FIJI(offTag: 'fj'),
+  FIJI(offTag: 'fj', currency: Currency.FJD),
 
   /// Falkland Islands (Malvinas)
-  FALKLAND_ISLANDS(offTag: 'fk'),
+  FALKLAND_ISLANDS(offTag: 'fk', currency: Currency.FKP),
 
   /// Micronesia (Federated States of)
-  MICRONESIA(offTag: 'fm'),
+  MICRONESIA(offTag: 'fm', currency: Currency.USD),
 
   /// Faroe Islands
-  FAROE_ISLANDS(offTag: 'fo'),
+  FAROE_ISLANDS(offTag: 'fo', currency: Currency.DKK),
 
   /// France
-  FRANCE(offTag: 'fr'),
+  FRANCE(offTag: 'fr', currency: Currency.EUR),
 
   /// Gabon
-  GABON(offTag: 'ga'),
+  GABON(offTag: 'ga', currency: Currency.XAF),
 
   /// United Kingdom of Great Britain and Northern Ireland
   // in OFF this is not 'gb'
-  UNITED_KINGDOM(offTag: 'uk'),
+  UNITED_KINGDOM(offTag: 'uk', currency: Currency.GBP),
 
   /// Grenada
-  GRENADA(offTag: 'gd'),
+  GRENADA(offTag: 'gd', currency: Currency.XCD),
 
   /// Georgia
-  GEORGIA(offTag: 'ge'),
+  GEORGIA(offTag: 'ge', currency: Currency.GEL),
 
   /// French Guiana
-  FRENCH_GUIANA(offTag: 'gf'),
+  FRENCH_GUIANA(offTag: 'gf', currency: Currency.EUR),
 
   /// Guernsey
-  GUERNSEY(offTag: 'gg'),
+  GUERNSEY(offTag: 'gg', currency: Currency.GBP),
 
   /// Ghana
-  GHANA(offTag: 'gh'),
+  GHANA(offTag: 'gh', currency: Currency.GHS),
 
   /// Gibraltar
-  GIBRALTAR(offTag: 'gi'),
+  GIBRALTAR(offTag: 'gi', currency: Currency.GIP),
 
   /// Greenland
-  GREENLAND(offTag: 'gl'),
+  GREENLAND(offTag: 'gl', currency: Currency.DKK),
 
   /// Gambia
-  GAMBIA(offTag: 'gm'),
+  GAMBIA(offTag: 'gm', currency: Currency.GMD),
 
   /// Guinea
-  GUINEA(offTag: 'gn'),
+  GUINEA(offTag: 'gn', currency: Currency.GNF),
 
   /// Guadeloupe
-  GUADELOUPE(offTag: 'gp'),
+  GUADELOUPE(offTag: 'gp', currency: Currency.EUR),
 
   /// Equatorial Guinea
-  EQUATORIAL_GUINEA(offTag: 'gq'),
+  EQUATORIAL_GUINEA(offTag: 'gq', currency: Currency.XAF),
 
   /// Greece
-  GREECE(offTag: 'gr'),
+  GREECE(offTag: 'gr', currency: Currency.EUR),
 
   /// South Georgia and the South Sandwich Islands
-  SOUTH_GEORGIA(offTag: 'gs'),
+  SOUTH_GEORGIA(offTag: 'gs', currency: Currency.FKP),
 
   /// Guatemala
-  GUATEMALA(offTag: 'gt'),
+  GUATEMALA(offTag: 'gt', currency: Currency.GTQ),
 
   /// Guam
-  GUAM(offTag: 'gu'),
+  GUAM(offTag: 'gu', currency: Currency.USD),
 
   /// Guinea-Bissau
-  GUINEA_BISSAU(offTag: 'gw'),
+  GUINEA_BISSAU(offTag: 'gw', currency: Currency.XOF),
 
   /// Guyana
-  GUYANA(offTag: 'gy'),
+  GUYANA(offTag: 'gy', currency: Currency.GYD),
 
   /// Hong Kong
-  HONG_KONG(offTag: 'hk'),
+  HONG_KONG(offTag: 'hk', currency: Currency.HKD),
 
   /// Heard Island and McDonald Islands
-  HEARD_ISLAND(offTag: 'hm'),
+  HEARD_ISLAND(offTag: 'hm', currency: Currency.AUD),
 
   /// Honduras
-  HONDURAS(offTag: 'hn'),
+  HONDURAS(offTag: 'hn', currency: Currency.HNL),
 
   /// Croatia
-  CROATIA(offTag: 'hr'),
+  CROATIA(offTag: 'hr', currency: Currency.EUR),
 
   /// Haiti
-  HAITI(offTag: 'ht'),
+  HAITI(offTag: 'ht', currency: Currency.HTG),
 
   /// Hungary
-  HUNGARY(offTag: 'hu'),
+  HUNGARY(offTag: 'hu', currency: Currency.HUF),
 
   /// Indonesia
-  INDONESIA(offTag: 'id'),
+  INDONESIA(offTag: 'id', currency: Currency.IDR),
 
   /// Ireland
-  IRELAND(offTag: 'ie'),
+  IRELAND(offTag: 'ie', currency: Currency.EUR),
 
   /// Israel
-  ISRAEL(offTag: 'il'),
+  ISRAEL(offTag: 'il', currency: Currency.ILS),
 
   /// Isle of Man
-  ISLE_OF_MAN(offTag: 'im'),
+  ISLE_OF_MAN(offTag: 'im', currency: Currency.GBP),
 
   /// India
-  INDIA(offTag: 'in'),
+  INDIA(offTag: 'in', currency: Currency.INR),
 
   /// British Indian Ocean Territory
-  BRITISH_INDIAN_OCEAN_TERRITORY(offTag: 'io'),
+  BRITISH_INDIAN_OCEAN_TERRITORY(offTag: 'io', currency: Currency.USD),
 
   /// Iraq
-  IRAQ(offTag: 'iq'),
+  IRAQ(offTag: 'iq', currency: Currency.IQD),
 
   /// Iran (Islamic Republic of)
-  IRAN(offTag: 'ir'),
+  IRAN(offTag: 'ir', currency: Currency.IRR),
 
   /// Iceland
-  ICELAND(offTag: 'is'),
+  ICELAND(offTag: 'is', currency: Currency.ISK),
 
   /// Italy
-  ITALY(offTag: 'it'),
+  ITALY(offTag: 'it', currency: Currency.EUR),
 
   /// Jersey
-  JERSEY(offTag: 'je'),
+  JERSEY(offTag: 'je', currency: Currency.GBP),
 
   /// Jamaica
-  JAMAICA(offTag: 'jm'),
+  JAMAICA(offTag: 'jm', currency: Currency.JMD),
 
   /// Jordan
-  JORDAN(offTag: 'jo'),
+  JORDAN(offTag: 'jo', currency: Currency.JOD),
 
   /// Japan
-  JAPAN(offTag: 'jp'),
+  JAPAN(offTag: 'jp', currency: Currency.JPY),
 
   /// Kenya
-  KENYA(offTag: 'ke'),
+  KENYA(offTag: 'ke', currency: Currency.KES),
 
   /// Kyrgyzstan
-  KYRGYZSTAN(offTag: 'kg'),
+  KYRGYZSTAN(offTag: 'kg', currency: Currency.KGS),
 
   /// Cambodia
-  CAMBODIA(offTag: 'kh'),
+  CAMBODIA(offTag: 'kh', currency: Currency.KHR),
 
   /// Kiribati
-  KIRIBATI(offTag: 'ki'),
+  KIRIBATI(offTag: 'ki', currency: Currency.AUD),
 
   /// Comoros
-  COMOROS(offTag: 'km'),
+  COMOROS(offTag: 'km', currency: Currency.KMF),
 
   /// Saint Kitts and Nevis
-  SAINT_KITTS_AND_NEVIS(offTag: 'kn'),
+  SAINT_KITTS_AND_NEVIS(offTag: 'kn', currency: Currency.XCD),
 
   /// Korea (Democratic People's Republic of)
-  NORTH_KOREA(offTag: 'kp'),
+  NORTH_KOREA(offTag: 'kp', currency: Currency.KPW),
 
   /// Korea, Republic of
-  SOUTH_KOREA(offTag: 'kr'),
+  SOUTH_KOREA(offTag: 'kr', currency: Currency.KRW),
 
   /// Kuwait
-  KUWAIT(offTag: 'kw'),
+  KUWAIT(offTag: 'kw', currency: Currency.KWD),
 
   /// Cayman Islands
-  CAYMAN_ISLANDS(offTag: 'ky'),
+  CAYMAN_ISLANDS(offTag: 'ky', currency: Currency.KYD),
 
   /// Kazakhstan
-  KAZAKHSTAN(offTag: 'kz'),
+  KAZAKHSTAN(offTag: 'kz', currency: Currency.KZT),
 
   /// Lao People's Democratic Republic
-  LAOS(offTag: 'la'),
+  LAOS(offTag: 'la', currency: Currency.LAK),
 
   /// Lebanon
-  LEBANON(offTag: 'lb'),
+  LEBANON(offTag: 'lb', currency: Currency.LBP),
 
   /// Saint Lucia
-  SAINT_LUCIA(offTag: 'lc'),
+  SAINT_LUCIA(offTag: 'lc', currency: Currency.XCD),
 
   /// Liechtenstein
-  LIECHTENSTEIN(offTag: 'li'),
+  LIECHTENSTEIN(offTag: 'li', currency: Currency.CHF),
 
   /// Sri Lanka
-  SRI_LANKA(offTag: 'lk'),
+  SRI_LANKA(offTag: 'lk', currency: Currency.LKR),
 
   /// Liberia
-  LIBERIA(offTag: 'lr'),
+  LIBERIA(offTag: 'lr', currency: Currency.LRD),
 
   /// Lesotho
-  LESOTHO(offTag: 'ls'),
+  LESOTHO(offTag: 'ls', currency: Currency.LSL),
 
   /// Lithuania
-  LITHUANIA(offTag: 'lt'),
+  LITHUANIA(offTag: 'lt', currency: Currency.EUR),
 
   /// Luxembourg
-  LUXEMBOURG(offTag: 'lu'),
+  LUXEMBOURG(offTag: 'lu', currency: Currency.EUR),
 
   /// Latvia
-  LATVIA(offTag: 'lv'),
+  LATVIA(offTag: 'lv', currency: Currency.EUR),
 
   /// Libya
-  LIBYA(offTag: 'ly'),
+  LIBYA(offTag: 'ly', currency: Currency.LYD),
 
   /// Morocco
-  MOROCCO(offTag: 'ma'),
+  MOROCCO(offTag: 'ma', currency: Currency.MAD),
 
   /// Monaco
-  MONACO(offTag: 'mc'),
+  MONACO(offTag: 'mc', currency: Currency.EUR),
 
   /// Moldova, Republic of
-  MOLDOVA(offTag: 'md'),
+  MOLDOVA(offTag: 'md', currency: Currency.MDL),
 
   /// Montenegro
-  MONTENEGRO(offTag: 'me'),
+  MONTENEGRO(offTag: 'me', currency: Currency.EUR),
 
   /// Saint Martin (French part)
-  SAINT_MARTIN(offTag: 'mf'),
+  SAINT_MARTIN(offTag: 'mf', currency: Currency.EUR),
 
   /// Madagascar
-  MADAGASCAR(offTag: 'mg'),
+  MADAGASCAR(offTag: 'mg', currency: Currency.MGA),
 
   /// Marshall Islands
-  MARSHALL_ISLANDS(offTag: 'mh'),
+  MARSHALL_ISLANDS(offTag: 'mh', currency: Currency.USD),
 
   /// North Macedonia
-  NORTH_MACEDONIA(offTag: 'mk'),
+  NORTH_MACEDONIA(offTag: 'mk', currency: Currency.MKD),
 
   /// Mali
-  MALI(offTag: 'ml'),
+  MALI(offTag: 'ml', currency: Currency.XOF),
 
   /// Myanmar
-  MYANMAR(offTag: 'mm'),
+  MYANMAR(offTag: 'mm', currency: Currency.MMK),
 
   /// Mongolia
-  MONGOLIA(offTag: 'mn'),
+  MONGOLIA(offTag: 'mn', currency: Currency.MNT),
 
   /// Macao
-  MACAO(offTag: 'mo'),
+  MACAO(offTag: 'mo', currency: Currency.MOP),
 
   /// Northern Mariana Islands
-  NORTHERN_MARIANA_ISLANDS(offTag: 'mp'),
+  NORTHERN_MARIANA_ISLANDS(offTag: 'mp', currency: Currency.USD),
 
   /// Martinique
-  MARTINIQUE(offTag: 'mq'),
+  MARTINIQUE(offTag: 'mq', currency: Currency.EUR),
 
   /// Mauritania
-  MAURITANIA(offTag: 'mr'),
+  MAURITANIA(offTag: 'mr', currency: Currency.MRU),
 
   /// Montserrat
-  MONTSERRAT(offTag: 'ms'),
+  MONTSERRAT(offTag: 'ms', currency: Currency.XCD),
 
   /// Malta
-  MALTA(offTag: 'mt'),
+  MALTA(offTag: 'mt', currency: Currency.EUR),
 
   /// Mauritius
-  MAURITIUS(offTag: 'mu'),
+  MAURITIUS(offTag: 'mu', currency: Currency.MUR),
 
   /// Maldives
-  MALDIVES(offTag: 'mv'),
+  MALDIVES(offTag: 'mv', currency: Currency.MVR),
 
   /// Malawi
-  MALAWI(offTag: 'mw'),
+  MALAWI(offTag: 'mw', currency: Currency.MWK),
 
   /// Mexico
-  MEXICO(offTag: 'mx'),
+  MEXICO(offTag: 'mx', currency: Currency.MXN),
 
   /// Malaysia
-  MALAYSIA(offTag: 'my'),
+  MALAYSIA(offTag: 'my', currency: Currency.MYR),
 
   /// Mozambique
-  MOZAMBIQUE(offTag: 'mz'),
+  MOZAMBIQUE(offTag: 'mz', currency: Currency.MZN),
 
   /// Namibia
-  NAMIBIA(offTag: 'na'),
+  NAMIBIA(offTag: 'na', currency: Currency.NAD),
 
   /// New Caledonia
-  NEW_CALEDONIA(offTag: 'nc'),
+  NEW_CALEDONIA(offTag: 'nc', currency: Currency.XPF),
 
   /// Niger
-  NIGER(offTag: 'ne'),
+  NIGER(offTag: 'ne', currency: Currency.XOF),
 
   /// Norfolk Island
-  NORFOLK_ISLAND(offTag: 'nf'),
+  NORFOLK_ISLAND(offTag: 'nf', currency: Currency.AUD),
 
   /// Nigeria
-  NIGERIA(offTag: 'ng'),
+  NIGERIA(offTag: 'ng', currency: Currency.NGN),
 
   /// Nicaragua
-  NICARAGUA(offTag: 'ni'),
+  NICARAGUA(offTag: 'ni', currency: Currency.NIO),
 
   /// Netherlands
-  NETHERLANDS(offTag: 'nl'),
+  NETHERLANDS(offTag: 'nl', currency: Currency.EUR),
 
   /// Norway
-  NORWAY(offTag: 'no'),
+  NORWAY(offTag: 'no', currency: Currency.NOK),
 
   /// Nepal
-  NEPAL(offTag: 'np'),
+  NEPAL(offTag: 'np', currency: Currency.NPR),
 
   /// Nauru
-  NAURU(offTag: 'nr'),
+  NAURU(offTag: 'nr', currency: Currency.AUD),
 
   /// Niue
-  NIUE(offTag: 'nu'),
+  NIUE(offTag: 'nu', currency: Currency.NZD),
 
   /// New Zealand
-  NEW_ZEALAND(offTag: 'nz'),
+  NEW_ZEALAND(offTag: 'nz', currency: Currency.NZD),
 
   /// Oman
-  OMAN(offTag: 'om'),
+  OMAN(offTag: 'om', currency: Currency.OMR),
 
   /// Panama
-  PANAMA(offTag: 'pa'),
+  PANAMA(offTag: 'pa', currency: Currency.PAB),
 
   /// Peru
-  PERU(offTag: 'pe'),
+  PERU(offTag: 'pe', currency: Currency.PEN),
 
   /// French Polynesia
-  FRENCH_POLYNESIA(offTag: 'pf'),
+  FRENCH_POLYNESIA(offTag: 'pf', currency: Currency.XPF),
 
   /// Papua New Guinea
-  PAPUA_NEW_GUINEA(offTag: 'pg'),
+  PAPUA_NEW_GUINEA(offTag: 'pg', currency: Currency.PGK),
 
   /// Philippines
-  PHILIPPINES(offTag: 'ph'),
+  PHILIPPINES(offTag: 'ph', currency: Currency.PHP),
 
   /// Pakistan
-  PAKISTAN(offTag: 'pk'),
+  PAKISTAN(offTag: 'pk', currency: Currency.PKR),
 
   /// Poland
-  POLAND(offTag: 'pl'),
+  POLAND(offTag: 'pl', currency: Currency.PLN),
 
   /// Saint Pierre and Miquelon
-  SAINT_PIERRE_AND_MIQUELON(offTag: 'pm'),
+  SAINT_PIERRE_AND_MIQUELON(offTag: 'pm', currency: Currency.EUR),
 
   /// Pitcairn
-  PITCAIRN(offTag: 'pn'),
+  PITCAIRN(offTag: 'pn', currency: Currency.NZD),
 
   /// Puerto Rico
-  PUERTO_RICO(offTag: 'pr'),
+  PUERTO_RICO(offTag: 'pr', currency: Currency.USD),
 
   /// Palestine, State of
-  PALESTINE(offTag: 'ps'),
+  PALESTINE(offTag: 'ps', currency: Currency.ILS),
 
   /// Portugal
-  PORTUGAL(offTag: 'pt'),
+  PORTUGAL(offTag: 'pt', currency: Currency.EUR),
 
   /// Palau
-  PALAU(offTag: 'pw'),
+  PALAU(offTag: 'pw', currency: Currency.USD),
 
   /// Paraguay
-  PARAGUAY(offTag: 'py'),
+  PARAGUAY(offTag: 'py', currency: Currency.PYG),
 
   /// Qatar
-  QATAR(offTag: 'qa'),
+  QATAR(offTag: 'qa', currency: Currency.QAR),
 
   /// Réunion
-  REUNION(offTag: 're'),
+  REUNION(offTag: 're', currency: Currency.EUR),
 
   /// Romania
-  ROMANIA(offTag: 'ro'),
+  ROMANIA(offTag: 'ro', currency: Currency.RON),
 
   /// Serbia
-  SERBIA(offTag: 'rs'),
+  SERBIA(offTag: 'rs', currency: Currency.RSD),
 
   /// Russian Federation
-  RUSSIA(offTag: 'ru'),
+  RUSSIA(offTag: 'ru', currency: Currency.RUB),
 
   /// Rwanda
-  RWANDA(offTag: 'rw'),
+  RWANDA(offTag: 'rw', currency: Currency.RWF),
 
   /// Saudi Arabia
-  SAUDI_ARABIA(offTag: 'sa'),
+  SAUDI_ARABIA(offTag: 'sa', currency: Currency.SAR),
 
   /// Solomon Islands
-  SOLOMON_ISLANDS(offTag: 'sb'),
+  SOLOMON_ISLANDS(offTag: 'sb', currency: Currency.SBD),
 
   /// Seychelles
-  SEYCHELLES(offTag: 'sc'),
+  SEYCHELLES(offTag: 'sc', currency: Currency.SCR),
 
   /// Sudan
-  SUDAN(offTag: 'sd'),
+  SUDAN(offTag: 'sd', currency: Currency.SDG),
 
   /// Sweden
-  SWEDEN(offTag: 'se'),
+  SWEDEN(offTag: 'se', currency: Currency.SEK),
 
   /// Singapore
-  SINGAPORE(offTag: 'sg'),
+  SINGAPORE(offTag: 'sg', currency: Currency.SGD),
 
   /// Saint Helena, Ascension and Tristan da Cunha
-  SAINT_HELENA(offTag: 'sh'),
+  SAINT_HELENA(offTag: 'sh', currency: Currency.SHP),
 
   /// Slovenia
-  SLOVENIA(offTag: 'si'),
+  SLOVENIA(offTag: 'si', currency: Currency.EUR),
 
   /// Svalbard and Jan Mayen
-  SVALBARD_AND_JAN_MAYEN(offTag: 'sj'),
+  SVALBARD_AND_JAN_MAYEN(offTag: 'sj', currency: Currency.NOK),
 
   /// Slovakia
-  SLOVAKIA(offTag: 'sk'),
+  SLOVAKIA(offTag: 'sk', currency: Currency.EUR),
 
   /// Sierra Leone
-  SIERRA_LEONE(offTag: 'sl'),
+  SIERRA_LEONE(offTag: 'sl', currency: Currency.SLE),
 
   /// San Marino
-  SAN_MARINO(offTag: 'sm'),
+  SAN_MARINO(offTag: 'sm', currency: Currency.EUR),
 
   /// Senegal
-  SENEGAL(offTag: 'sn'),
+  SENEGAL(offTag: 'sn', currency: Currency.XOF),
 
   /// Somalia
-  SOMALIA(offTag: 'so'),
+  SOMALIA(offTag: 'so', currency: Currency.SOS),
 
   /// Suriname
-  SURINAME(offTag: 'sr'),
+  SURINAME(offTag: 'sr', currency: Currency.SRD),
 
   /// South Sudan
-  SOUTH_SUDAN(offTag: 'ss'),
+  SOUTH_SUDAN(offTag: 'ss', currency: Currency.SSP),
 
   /// Sao Tome and Principe
-  SAO_TOME_AND_PRINCIPE(offTag: 'st'),
+  SAO_TOME_AND_PRINCIPE(offTag: 'st', currency: Currency.STN),
 
   /// El Salvador
-  EL_SALVADOR(offTag: 'sv'),
+  EL_SALVADOR(offTag: 'sv', currency: Currency.SVC),
 
   /// Sint Maarten (Dutch part)
-  SINT_MAARTEN(offTag: 'sx'),
+  SINT_MAARTEN(offTag: 'sx', currency: Currency.ANG),
 
   /// Syrian Arab Republic
-  SYRIA(offTag: 'sy'),
+  SYRIA(offTag: 'sy', currency: Currency.SYP),
 
   /// Eswatini
-  ESWATINI(offTag: 'sz'),
+  ESWATINI(offTag: 'sz', currency: Currency.SZL),
 
   /// Turks and Caicos Islands
-  TURKS_AND_CAICOS_ISLANDS(offTag: 'tc'),
+  TURKS_AND_CAICOS_ISLANDS(offTag: 'tc', currency: Currency.USD),
 
   /// Chad
-  CHAD(offTag: 'td'),
+  CHAD(offTag: 'td', currency: Currency.XAF),
 
   /// French Southern Territories
-  FRENCH_SOUTHERN_TERRITORIES(offTag: 'tf'),
+  FRENCH_SOUTHERN_TERRITORIES(offTag: 'tf', currency: Currency.EUR),
 
   /// Togo
-  TOGO(offTag: 'tg'),
+  TOGO(offTag: 'tg', currency: Currency.XOF),
 
   /// Thailand
-  THAILAND(offTag: 'th'),
+  THAILAND(offTag: 'th', currency: Currency.THB),
 
   /// Tajikistan
-  TAJIKISTAN(offTag: 'tj'),
+  TAJIKISTAN(offTag: 'tj', currency: Currency.TJS),
 
   /// Tokelau
-  TOKELAU(offTag: 'tk'),
+  TOKELAU(offTag: 'tk', currency: Currency.NZD),
 
   /// Timor-Leste
-  TIMOR_LESTE(offTag: 'tl'),
+  TIMOR_LESTE(offTag: 'tl', currency: Currency.USD),
 
   /// Turkmenistan
-  TURKMENISTAN(offTag: 'tm'),
+  TURKMENISTAN(offTag: 'tm', currency: Currency.TMT),
 
   /// Tunisia
-  TUNISIA(offTag: 'tn'),
+  TUNISIA(offTag: 'tn', currency: Currency.TND),
 
   /// Tonga
-  TONGA(offTag: 'to'),
+  TONGA(offTag: 'to', currency: Currency.TOP),
 
   /// Turkey
-  TURKEY(offTag: 'tr'),
+  TURKEY(offTag: 'tr', currency: Currency.TRY),
 
   /// Trinidad and Tobago
-  TRINIDAD_AND_TOBAGO(offTag: 'tt'),
+  TRINIDAD_AND_TOBAGO(offTag: 'tt', currency: Currency.TTD),
 
   /// Tuvalu
-  TUVALU(offTag: 'tv'),
+  TUVALU(offTag: 'tv', currency: Currency.AUD),
 
   /// Taiwan, Province of China
-  TAIWAN(offTag: 'tw'),
+  TAIWAN(offTag: 'tw', currency: Currency.TWD),
 
   /// Tanzania, United Republic of
-  TANZANIA(offTag: 'tz'),
+  TANZANIA(offTag: 'tz', currency: Currency.TZS),
 
   /// Ukraine
-  UKRAINE(offTag: 'ua'),
+  UKRAINE(offTag: 'ua', currency: Currency.UAH),
 
   /// Uganda
-  UGANDA(offTag: 'ug'),
+  UGANDA(offTag: 'ug', currency: Currency.UGX),
 
   /// United States Minor Outlying Islands
-  UNITED_STATES_MINOR_OUTLYING_ISLANDS(offTag: 'um'),
+  UNITED_STATES_MINOR_OUTLYING_ISLANDS(offTag: 'um', currency: Currency.USD),
 
   /// United States of America
-  USA(offTag: 'us'),
+  USA(offTag: 'us', currency: Currency.USD),
 
   /// Uruguay
-  URUGUAY(offTag: 'uy'),
+  URUGUAY(offTag: 'uy', currency: Currency.UYU),
 
   /// Uzbekistan
-  UZBEKISTAN(offTag: 'uz'),
+  UZBEKISTAN(offTag: 'uz', currency: Currency.UZS),
 
   /// Holy See
-  HOLY_SEE(offTag: 'va'),
+  HOLY_SEE(offTag: 'va', currency: Currency.EUR),
 
   /// Saint Vincent and the Grenadines
-  SAINT_VINCENT_AND_THE_GRENADINES(offTag: 'vc'),
+  SAINT_VINCENT_AND_THE_GRENADINES(offTag: 'vc', currency: Currency.XCD),
 
   /// Venezuela (Bolivarian Republic of)
-  VENEZUELA(offTag: 've'),
+  VENEZUELA(offTag: 've', currency: Currency.VED),
 
   /// Virgin Islands (British)
-  BRITISH_VIRGIN_ISLANDS(offTag: 'vg'),
+  BRITISH_VIRGIN_ISLANDS(offTag: 'vg', currency: Currency.USD),
 
   /// Virgin Islands (U.S.)
-  US_VIRGIN_ISLANDS(offTag: 'vi'),
+  US_VIRGIN_ISLANDS(offTag: 'vi', currency: Currency.USD),
 
   /// Viet Nam
-  VIET_NAM(offTag: 'vn'),
+  VIET_NAM(offTag: 'vn', currency: Currency.VND),
 
   /// Vanuatu
-  VANUATU(offTag: 'vu'),
+  VANUATU(offTag: 'vu', currency: Currency.VUV),
 
   /// Wallis and Futuna
-  WALLIS_AND_FUTUNA(offTag: 'wf'),
+  WALLIS_AND_FUTUNA(offTag: 'wf', currency: Currency.XPF),
 
   /// Samoa
-  SAMOA(offTag: 'ws'),
+  SAMOA(offTag: 'ws', currency: Currency.WST),
 
   /// Yemen
-  YEMEN(offTag: 'ye'),
+  YEMEN(offTag: 'ye', currency: Currency.YER),
 
   /// Mayotte
-  MAYOTTE(offTag: 'yt'),
+  MAYOTTE(offTag: 'yt', currency: Currency.EUR),
 
   /// South Africa
-  SOUTH_AFRICA(offTag: 'za'),
+  SOUTH_AFRICA(offTag: 'za', currency: Currency.ZAR),
 
   /// Zambia
-  ZAMBIA(offTag: 'zm'),
+  ZAMBIA(offTag: 'zm', currency: Currency.ZMW),
 
   /// Zimbabwe
-  ZIMBABWE(offTag: 'zw');
+  ZIMBABWE(offTag: 'zw', currency: Currency.ZWL);
 
   const OpenFoodFactsCountry({
     required this.offTag,
+    required this.currency,
   });
 
   /// Lowercase ISO 639-1, except for [UNITED_KINGDOM].
   @override
   final String offTag;
+
+  // TODO(monsieurtanuki): remove ANTARCTICA, with no products and no currency?
+  /// Country most probably and up-to-date currency.
+  final Currency? currency;
 
   /// Returns the [OpenFoodFactsCountry] that matches the [offTag].
   ///

--- a/test/api_off_tag_test.dart
+++ b/test/api_off_tag_test.dart
@@ -22,4 +22,56 @@ void main() {
       expect(OpenFoodFactsCountry.fromOffTag(entry.key), entry.value);
     }
   });
+
+  test('$OpenFoodAPIClient country/currency', () async {
+    final Set<Currency> countryCurrencies = <Currency>{};
+    for (final OpenFoodFactsCountry country in OpenFoodFactsCountry.values) {
+      final Currency? currency = country.currency;
+      if (currency == null) {
+        expect(country, OpenFoodFactsCountry.ANTARCTICA);
+        continue;
+      }
+      countryCurrencies.add(currency);
+    }
+    for (final Currency currency in Currency.values) {
+      if (countryCurrencies.contains(currency)) {
+        expect(
+          currency.complementaryCurrency,
+          isFalse,
+          reason: 'Problem with currency $currency',
+        );
+        expect(
+          currency.unofficialCode,
+          isFalse,
+          reason: 'Problem with currency $currency',
+        );
+        expect(
+          currency.historicalCode,
+          isFalse,
+          reason: 'Problem with currency $currency',
+        );
+        expect(
+          currency.fundsCode,
+          isFalse,
+          reason: 'Problem with currency $currency',
+        );
+        expect(
+          currency.noCountry,
+          isFalse,
+          reason: 'Problem with currency $currency',
+        );
+
+        continue;
+      }
+      expect(
+        currency.complementaryCurrency ||
+            currency.unofficialCode ||
+            currency.historicalCode ||
+            currency.fundsCode ||
+            currency.noCountry,
+        isTrue,
+        reason: 'Problem with currency $currency',
+      );
+    }
+  });
 }


### PR DESCRIPTION
### What
- Now each country has a default currency. Except Antarctica.

### Fixes bug(s)
- Fixes: #922

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/5201

### Impacted files
* `api_off_tag_test.dart`: added a test about the relationship between country and currency
* `country_helper.dart`: added a `Currency` field to `OpenFoodFactsCountry`
* `currency.dart`: added fields in order to detect the most important currencies; added comments.
