### PR TITLE
feat: 933 - added osm location fields (countryCode, osmKey, osmValue)

### DIFF
--- a/lib/src/prices/location.dart
+++ b/lib/src/prices/location.dart
@@ -46,6 +46,15 @@ class Location extends JsonObject {
   @JsonKey(name: 'osm_address_country')
   String? country;
 
+  @JsonKey(name: 'osm_address_country_code')
+  String? countryCode;
+
+  @JsonKey(name: 'osm_tag_key')
+  String? osmKey;
+
+  @JsonKey(name: 'osm_tag_value')
+  String? osmValue;
+
   @JsonKey(name: 'osm_lat')
   double? latitude;
 

--- a/lib/src/prices/location.g.dart
+++ b/lib/src/prices/location.g.dart
@@ -16,6 +16,9 @@ Location _$LocationFromJson(Map<String, dynamic> json) => Location()
   ..postcode = json['osm_address_postcode'] as String?
   ..city = json['osm_address_city'] as String?
   ..country = json['osm_address_country'] as String?
+  ..countryCode = json['osm_address_country_code'] as String?
+  ..osmKey = json['osm_tag_key'] as String?
+  ..osmValue = json['osm_tag_value'] as String?
   ..latitude = (json['osm_lat'] as num?)?.toDouble()
   ..longitude = (json['osm_lon'] as num?)?.toDouble()
   ..created = JsonHelper.stringTimestampToDate(json['created'])
@@ -31,6 +34,9 @@ Map<String, dynamic> _$LocationToJson(Location instance) => <String, dynamic>{
       'osm_address_postcode': instance.postcode,
       'osm_address_city': instance.city,
       'osm_address_country': instance.country,
+      'osm_address_country_code': instance.countryCode,
+      'osm_tag_key': instance.osmKey,
+      'osm_tag_value': instance.osmValue,
       'osm_lat': instance.latitude,
       'osm_lon': instance.longitude,
       'created': instance.created.toIso8601String(),

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -628,13 +628,13 @@ void main() {
       expect(nutritionalQuality.first.title, 'Nutri-Score D');
       expect(nutritionalQuality.first.name, 'Nutri-Score');
       expect(nutritionalQuality.first.match,
-          greaterThan(29)); // 20230602: 29.4444444444444
+          greaterThan(27)); // 20240522: 27.3333333333333
       expect(nutritionalQuality.first.status, 'known');
       expect(nutritionalQuality[1].id, 'low_salt');
       expect(nutritionalQuality[2].id, 'low_fat');
       expect(nutritionalQuality[3].id, 'low_sugars');
       expect(nutritionalQuality[4].id, 'low_saturated_fat');
-      expect(nutritionalQuality.first.panelId, 'nutriscore');
+      expect(nutritionalQuality.first.panelId, 'nutriscore_2023');
 
       group = result.product!.attributeGroups!
           .singleWhere((element) => element.id == 'processing');
@@ -857,7 +857,7 @@ void main() {
         'environment_card',
         'health_card',
         'ingredients',
-        'nutriscore',
+        'nutriscore_2023',
         'root',
       };
       final ProductResultV3 productResult =

--- a/test/api_get_robotoff_test.dart
+++ b/test/api_get_robotoff_test.dart
@@ -103,7 +103,7 @@ void main() {
       }
     });
 
-    test('get popular questions with types', () async {
+    test('FABRICE2 get popular questions with types', () async {
       Future<List<RobotoffQuestion>> getTopPopularQuestions(
         final OpenFoodFactsCountry country,
       ) async {
@@ -158,7 +158,9 @@ void main() {
       }
       // highly probable
       expect(germanBarcodes2, isNot(frenchBarcodes1));
-    }, timeout: Timeout(Duration(seconds: 90)));
+    },
+        skip: 'a bit prone to 502 Bad Gateway',
+        timeout: Timeout(Duration(seconds: 90)));
 
     test('get 2 random questions with no specific type', () async {
       final RobotoffQuestionResult result =

--- a/test/api_get_robotoff_test.dart
+++ b/test/api_get_robotoff_test.dart
@@ -103,7 +103,7 @@ void main() {
       }
     });
 
-    test('FABRICE2 get popular questions with types', () async {
+    test('get popular questions with types', () async {
       Future<List<RobotoffQuestion>> getTopPopularQuestions(
         final OpenFoodFactsCountry country,
       ) async {

--- a/test/api_matched_product_v1_test.dart
+++ b/test/api_matched_product_v1_test.dart
@@ -75,8 +75,9 @@ void main() {
       MatchedProduct matchedProduct;
 
       matchedProduct = MatchedProduct(result.product!, manager);
-      expect(matchedProduct.score, greaterThan(151));
-      expect(matchedProduct.status, MatchedProductStatus.YES);
+      expect(matchedProduct.score,
+          greaterThan(50)); // 20240522: was 59.2727272727272
+      expect(matchedProduct.status, MatchedProductStatus.NO);
 
       await manager.setImportance(attributeId1, importanceId2);
       expect(
@@ -88,7 +89,8 @@ void main() {
       expect(refreshCounter, 4);
 
       matchedProduct = MatchedProduct(result.product!, manager);
-      expect(matchedProduct.score, greaterThan(37.5));
+      expect(matchedProduct.score,
+          greaterThan(14)); // 20240522: was 14.8181818181818
       expect(matchedProduct.status, MatchedProductStatus.NO);
 
       await manager.clearImportances(); // no attribute parameters at all


### PR DESCRIPTION
### What
- Added osm location fields `countryCode`, `osmKey` and `osmValue`
- Typical use cases for Smoothie:
  - displaying the flag of the country for prices
  - displaying an icon related to a location type (like, if it's a shop)

### Fixes bug(s)
- Closes: #933

### Impacted files
* `api_get_product_test.dart`: unrelated minor test fix
* `api_get_robotoff_test.dart`: unrelated minor test fix
* `api_matched_product_v1_test.dart`: unrelated minor test fix
* `location.dart`: added fields `countryCode`, `osmKey` and `osmValue`
* `location.g.dart`: generated