### PR TITLE
fix: 937 - removed home-made user agent header when for web

### DIFF
--- a/lib/src/open_prices_api_client.dart
+++ b/lib/src/open_prices_api_client.dart
@@ -481,7 +481,7 @@ class OpenPricesAPIClient {
         if (currency != null) 'currency': currency.name,
       },
     );
-    final List<int> fileBytes = await UriReader.instance!.readAsBytes(imageUri);
+    final List<int> fileBytes = await UriReader.instance.readAsBytes(imageUri);
     final String filename = basename(imageUri.toString());
     final http.MultipartFile multipartFile = http.MultipartFile.fromBytes(
       'file',

--- a/lib/src/utils/http_helper.dart
+++ b/lib/src/utils/http_helper.dart
@@ -204,8 +204,7 @@ class HttpHelper {
     // add all file entries to the request
     if (files != null) {
       for (MapEntry<String, Uri> entry in files.entries) {
-        List<int> fileBytes =
-            await UriReader.instance!.readAsBytes(entry.value);
+        List<int> fileBytes = await UriReader.instance.readAsBytes(entry.value);
         var multipartFile = http.MultipartFile.fromBytes(entry.key, fileBytes,
             filename: basename(entry.value.toString()));
         request.files.add(multipartFile);
@@ -273,7 +272,8 @@ class HttpHelper {
 
     headers.addAll({
       'Accept': 'application/json',
-      'User-Agent': OpenFoodAPIConfiguration.userAgent!.toValueString(),
+      if (!UriReader.instance.isWeb)
+        'User-Agent': OpenFoodAPIConfiguration.userAgent!.toValueString(),
       'From': _getSafeString(
         OpenFoodAPIConfiguration.getUser(user)?.userId ?? FROM,
       ),

--- a/lib/src/utils/uri_reader.dart
+++ b/lib/src/utils/uri_reader.dart
@@ -7,10 +7,14 @@ import 'uri_reader_stub.dart'
 
 /// Abstract reader of URI data, declined in "not web" and "web" versions
 abstract class UriReader {
-  static UriReader? _instance;
+  static late final UriReader _instance;
+  static bool _initialized = false;
 
-  static UriReader? get instance {
-    _instance ??= getUriReaderInstance();
+  static UriReader get instance {
+    if (!_initialized) {
+      _initialized = true;
+      _instance = getUriReaderInstance();
+    }
     return _instance;
   }
 
@@ -32,4 +36,6 @@ abstract class UriReader {
   }
 
   Future<List<int>> readFileAsBytes(final Uri uri);
+
+  bool get isWeb => false;
 }

--- a/lib/src/utils/uri_reader_js.dart
+++ b/lib/src/utils/uri_reader_js.dart
@@ -7,4 +7,7 @@ class UriReaderJs extends UriReader {
   @override
   Future<List<int>> readFileAsBytes(final Uri uri) async =>
       throw Exception('Cannot read files in web version');
+
+  @override
+  bool get isWeb => true;
 }

--- a/test/api_add_product_image_test.dart
+++ b/test/api_add_product_image_test.dart
@@ -49,7 +49,7 @@ void main() {
 
   /// Returns the width and height (pixels) and size (bytes) of a JPEG URL file
   Future<List<int>> getJpegUrlSize(final String url) async => getJpegSize(
-        await UriReader.instance!.readAsBytes(Uri.parse(url)),
+        await UriReader.instance.readAsBytes(Uri.parse(url)),
       );
 
   /// Returns the imgid, i.e. the unique id for (uploaded image x product)


### PR DESCRIPTION
### What
- Our home-made user agent prevents our dart package to work when used in web mode.
- We use this specific user agent for stats.
- The solution implemented here removes the user agent http header when in web mode, so that the package can be used.
- Possible improvements would be to change the way we build our user agent string (but that would have an impact on our previous/next stats), or where we put that home-made string (e.g. different http header tag) (but that would have an impact on our stats consistency too)
- We'll see how many requests we get from web mode. Later we can select one of the suggested improvements, or something else.

### Fixes bug(s)
- Fixes: #937

### Impacted files
* `api_add_product_image_test.dart`: minor refactoring
* `http_helper.dart`: removed home-made user agent header when for web; minor refactoring
* `open_prices_api_client.dart`: minor refactoring
* `uri_reader.dart`: added an `isWeb` getter; minor refactoring
* `uri_reader_js.dart`: implemented the `isWeb` getter