### PR TITLE
feat: Add the name of the image contributor

### DIFF
--- a/lib/src/model/product_image.dart
+++ b/lib/src/model/product_image.dart
@@ -1,7 +1,7 @@
-import 'off_tagged.dart';
 import '../utils/language_helper.dart';
 import '../utils/open_food_api_configuration.dart';
 import '../utils/uri_helper.dart';
+import 'off_tagged.dart';
 
 enum ImageField implements OffTagged {
   FRONT(offTag: 'front'),
@@ -122,6 +122,7 @@ class ProductImage {
     this.y2,
     this.width,
     this.height,
+    this.contributor,
   });
 
   ProductImage.raw({
@@ -131,6 +132,7 @@ class ProductImage {
     this.width,
     this.height,
     this.uploaded,
+    this.contributor,
   })  : language = null,
         field = null;
 
@@ -141,6 +143,9 @@ class ProductImage {
 
   /// Upload timestamp, for uploaded images only, in seconds since Unix Epoch.
   DateTime? uploaded;
+
+  /// Contributor of this image
+  String? contributor;
 
   /// Revision number
   int? rev;

--- a/lib/src/utils/json_helper.dart
+++ b/lib/src/utils/json_helper.dart
@@ -98,6 +98,7 @@ class JsonHelper {
 
   // only for raw images
   static const String _ALL_IMAGES_TAG_UPLOADED = 'uploaded_t';
+  static const String _ALL_IMAGES_TAG_UPLOADER = 'uploader';
 
   // common to main and raw images
   static const String _ALL_IMAGES_TAG_IMAGE_ID = 'imgid';
@@ -169,6 +170,7 @@ class JsonHelper {
               height: JsonObject.parseInt(numberObject[_ALL_IMAGES_TAG_HEIGHT]),
               url: numberObject[_ALL_IMAGES_TAG_URL],
               uploaded: uploaded,
+              contributor: fieldObject[_ALL_IMAGES_TAG_UPLOADER],
             ),
           );
         }


### PR DESCRIPTION
Hi everyone,

On the `images` field, the API returns the contributor's name.
Eg:

```json
        "images": {
            "1": {
                "sizes": {
                    "100": {
                        "h": 71,
                        "w": 100
                    },
                    "400": {
                        "h": 284,
                        "w": 400
                    },
                    "full": {
                        "h": 1089,
                        "w": 1536
                    }
                },
                "uploaded_t": 1345799270,
                "uploader": "openfoodfacts-contributors"


```