### PR TITLE
fix: 970 - refactored around new Prices API

### DIFF
--- a/lib/src/open_prices_api_client.dart
+++ b/lib/src/open_prices_api_client.dart
@@ -315,7 +315,7 @@ class OpenPricesAPIClient {
       uriHelper: uriHelper,
       bearerToken: bearerToken,
     );
-    if (response.statusCode == 200) {
+    if (response.statusCode == 204) {
       return MaybeError<bool>.value(true);
     }
     return MaybeError<bool>.responseError(response);
@@ -369,7 +369,7 @@ class OpenPricesAPIClient {
   ///
   /// This endpoint requires authentication.
   /// A user can update only owned prices.
-  static Future<MaybeError<Price>> updatePrice(
+  static Future<MaybeError<bool>> updatePrice(
     final int priceId, {
     required final UpdatePriceParameters parameters,
     final UriProductHelper uriHelper = uriHelperFoodProd,
@@ -388,14 +388,9 @@ class OpenPricesAPIClient {
       addUserAgentParameters: false,
     );
     if (response.statusCode == 200) {
-      try {
-        final dynamic decodedResponse = HttpHelper().jsonDecodeUtf8(response);
-        return MaybeError<Price>.value(Price.fromJson(decodedResponse));
-      } catch (e) {
-        //
-      }
+      return MaybeError<bool>.value(true);
     }
-    return MaybeError<Price>.responseError(response);
+    return MaybeError<bool>.responseError(response);
   }
 
   /// Deletes a price.
@@ -540,7 +535,7 @@ class OpenPricesAPIClient {
   ///
   /// This endpoint requires authentication.
   /// A user can update only owned proofs.
-  static Future<MaybeError<Proof>> updateProof(
+  static Future<MaybeError<bool>> updateProof(
     final int proofId, {
     required final UpdateProofParameters parameters,
     final UriProductHelper uriHelper = uriHelperFoodProd,
@@ -559,14 +554,9 @@ class OpenPricesAPIClient {
       addUserAgentParameters: false,
     );
     if (response.statusCode == 200) {
-      try {
-        final dynamic decodedResponse = HttpHelper().jsonDecodeUtf8(response);
-        return MaybeError<Proof>.value(Proof.fromJson(decodedResponse));
-      } catch (e) {
-        //
-      }
+      return MaybeError<bool>.value(true);
     }
-    return MaybeError<Proof>.responseError(response);
+    return MaybeError<bool>.responseError(response);
   }
 
   /// Deletes a proof.

--- a/lib/src/prices/price_user.dart
+++ b/lib/src/prices/price_user.dart
@@ -18,7 +18,7 @@ class PriceUser extends JsonObject {
 
   /// Number of prices for this user.
   @JsonKey(name: 'is_moderator')
-  late bool isModerator;
+  bool? isModerator;
 
   PriceUser();
 

--- a/lib/src/prices/price_user.g.dart
+++ b/lib/src/prices/price_user.g.dart
@@ -9,7 +9,7 @@ part of 'price_user.dart';
 PriceUser _$PriceUserFromJson(Map<String, dynamic> json) => PriceUser()
   ..userId = json['user_id'] as String
   ..priceCount = (json['price_count'] as num).toInt()
-  ..isModerator = json['is_moderator'] as bool;
+  ..isModerator = json['is_moderator'] as bool?;
 
 Map<String, dynamic> _$PriceUserToJson(PriceUser instance) => <String, dynamic>{
       'user_id': instance.userId,

--- a/lib/src/prices/session.dart
+++ b/lib/src/prices/session.dart
@@ -30,6 +30,16 @@ class Session extends JsonObject {
   @override
   Map<String, dynamic> toJson() => _$SessionToJson(this);
 
+  /// Status Code when the authentication fails.
   static const int invalidAuthStatusCode = 401;
+
+  /// Error message when the authentication fails.
   static const String invalidAuthMessage = 'Invalid authentication credentials';
+
+  /// Status Code when we try an edit operation with a wrong authentication.
+  static const int invalidActionWithAuthStatusCode = 403;
+
+  /// Error message when we try an edit operation with a wrong authentication.
+  static const String invalidActionWithAuthMessage =
+      'Authentication credentials were not provided.';
 }


### PR DESCRIPTION
### What
- Minor refactoring around minor changes in the new Prices API (Django).

### Fixes bug(s)
- #970

### Impacted files
* `api_prices_test.dart`: refactored around new Prices API
* `open_prices_api_client.dart`: different status code for "delete user session"; simplified `updatePrice` and `updateProof`
* `price_user.dart`: field `isModerator` is now optional
* `price_user.g.dart`: generated
* `session.dart`: additional status codes and error messages