### PR TITLE
feat: 972 - new "product_type" field for Product

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -48,6 +48,7 @@ export 'src/model/parameter/without_additives.dart';
 export 'src/model/per_size.dart';
 export 'src/model/product.dart';
 export 'src/model/product_freshness.dart';
+export 'src/model/product_type.dart';
 export 'src/model/product_image.dart';
 export 'src/model/product_packaging.dart';
 export 'src/model/product_result_field_answer.dart';

--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -13,6 +13,7 @@ import 'nutriments.dart';
 import 'owner_field.dart';
 import 'product_image.dart';
 import 'product_packaging.dart';
+import 'product_type.dart';
 import '../interface/json_object.dart';
 import '../utils/json_helper.dart';
 import '../utils/language_helper.dart';
@@ -89,6 +90,10 @@ class Product extends JsonObject {
   /// Barcode of the product. Will very very very often be not null.
   @JsonKey(name: 'code')
   String? barcode;
+
+  /// Type of the product (e.g. "pet food").
+  @JsonKey(name: 'product_type')
+  ProductType? productType;
 
   /// Product name, either set directly or taken from one of the localizations.
   ///

--- a/lib/src/model/product.g.dart
+++ b/lib/src/model/product.g.dart
@@ -101,6 +101,8 @@ Product _$ProductFromJson(Map<String, dynamic> json) => Product(
           : Nutriments.fromJson(json['nutriments'] as Map<String, dynamic>),
       noNutritionData: JsonHelper.checkboxFromJSON(json['no_nutrition_data']),
     )
+      ..productType =
+          $enumDecodeNullable(_$ProductTypeEnumMap, json['product_type'])
       ..genericNameInLanguages =
           LanguageHelper.fromJsonStringMap(json['generic_name_in_languages'])
       ..abbreviatedName = json['abbreviated_product_name'] as String?
@@ -179,6 +181,7 @@ Product _$ProductFromJson(Map<String, dynamic> json) => Product(
 Map<String, dynamic> _$ProductToJson(Product instance) {
   final val = <String, dynamic>{
     'code': instance.barcode,
+    'product_type': _$ProductTypeEnumMap[instance.productType],
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -316,6 +319,13 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   val['nutriments'] = Nutriments.toJsonHelper(instance.nutriments);
   return val;
 }
+
+const _$ProductTypeEnumMap = {
+  ProductType.food: 'food',
+  ProductType.beauty: 'beauty',
+  ProductType.petFood: 'petfood',
+  ProductType.product: 'product',
+};
 
 const _$ImageFieldEnumMap = {
   ImageField.FRONT: 'FRONT',

--- a/lib/src/model/product_type.dart
+++ b/lib/src/model/product_type.dart
@@ -1,0 +1,32 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'off_tagged.dart';
+import '../prices/flavor.dart';
+import '../utils/server_type.dart';
+
+/// Type used at the [Product] level (e.g. "this is a pet food product").
+///
+/// Somehow redundant with [ServerType] and [Flavor].
+enum ProductType implements OffTagged {
+  @JsonValue('food')
+  food(offTag: 'food'),
+
+  @JsonValue('beauty')
+  beauty(offTag: 'beauty'),
+
+  @JsonValue('petfood')
+  petFood(offTag: 'petfood'),
+
+  @JsonValue('product')
+  product(offTag: 'product');
+
+  const ProductType({
+    required this.offTag,
+  });
+
+  @override
+  final String offTag;
+
+  /// Returns the first [ProductType] that matches the [offTag].
+  static ProductType? fromOffTag(final String? offTag) =>
+      OffTagged.fromOffTag(offTag, ProductType.values) as ProductType?;
+}


### PR DESCRIPTION
### What
- New field for `Product`: `ProductType? productType`.
- Values for food, beauty, pet food and product.
- Later, the server will populate this field.
- For the moment, we can say "hey, I extract data from openbeautyfacts, therefore I can manually set the type to `beauty` for my local data".
- Then we're able to say things like "hey, this is a `beauty` product, don't show the nutriscore!"

### Fixes bug(s)
- Closes: #972

### Files
New file:
* `product_type.dart`: Type used at the product level (e.g. "this is a pet food product").

Impacted files:
* `openfoodfacts.dart`: exported new file `product_type.dart`
* `product.dart`: added a new `ProductType?` field
* `product.g.dart`: (generated)