### PR TITLE
feat: 986 - new Prices fields

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -109,6 +109,7 @@ export 'src/prices/get_users_parameters.dart';
 export 'src/prices/get_users_result.dart';
 export 'src/prices/location.dart';
 export 'src/prices/location_osm_type.dart';
+export 'src/prices/location_type.dart';
 export 'src/prices/maybe_error.dart';
 export 'src/prices/order_by.dart';
 export 'src/prices/price.dart';

--- a/lib/src/prices/location.dart
+++ b/lib/src/prices/location.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 
 import 'location_osm_type.dart';
+import 'location_type.dart';
 import '../interface/json_object.dart';
 import '../utils/json_helper.dart';
 
@@ -14,6 +15,10 @@ class Location extends JsonObject {
   /// ID of the location in OpenStreetMap: the store where the product was bought.
   @JsonKey(name: 'osm_id')
   late int osmId;
+
+  /// Type of the location object.
+  @JsonKey(name: 'type')
+  late LocationType locationType;
 
   /// Type of the OpenStreetMap location object.
   ///
@@ -72,6 +77,9 @@ class Location extends JsonObject {
 
   @JsonKey(name: 'osm_lon')
   double? longitude;
+
+  @JsonKey(name: 'website_url')
+  String? websiteUrl;
 
   /// Date when the product was bought.
   @JsonKey(fromJson: JsonHelper.stringTimestampToDate)

--- a/lib/src/prices/location.g.dart
+++ b/lib/src/prices/location.g.dart
@@ -8,6 +8,7 @@ part of 'location.dart';
 
 Location _$LocationFromJson(Map<String, dynamic> json) => Location()
   ..osmId = (json['osm_id'] as num).toInt()
+  ..locationType = $enumDecode(_$LocationTypeEnumMap, json['type'])
   ..type = $enumDecode(_$LocationOSMTypeEnumMap, json['osm_type'])
   ..priceCount = (json['price_count'] as num?)?.toInt()
   ..userCount = (json['user_count'] as num?)?.toInt()
@@ -24,11 +25,13 @@ Location _$LocationFromJson(Map<String, dynamic> json) => Location()
   ..osmValue = json['osm_tag_value'] as String?
   ..latitude = (json['osm_lat'] as num?)?.toDouble()
   ..longitude = (json['osm_lon'] as num?)?.toDouble()
+  ..websiteUrl = json['website_url'] as String?
   ..created = JsonHelper.stringTimestampToDate(json['created'])
   ..updated = JsonHelper.nullableStringTimestampToDate(json['updated']);
 
 Map<String, dynamic> _$LocationToJson(Location instance) => <String, dynamic>{
       'osm_id': instance.osmId,
+      'type': _$LocationTypeEnumMap[instance.locationType]!,
       'osm_type': _$LocationOSMTypeEnumMap[instance.type]!,
       'price_count': instance.priceCount,
       'user_count': instance.userCount,
@@ -45,9 +48,15 @@ Map<String, dynamic> _$LocationToJson(Location instance) => <String, dynamic>{
       'osm_tag_value': instance.osmValue,
       'osm_lat': instance.latitude,
       'osm_lon': instance.longitude,
+      'website_url': instance.websiteUrl,
       'created': instance.created.toIso8601String(),
       'updated': instance.updated?.toIso8601String(),
     };
+
+const _$LocationTypeEnumMap = {
+  LocationType.osm: 'OSM',
+  LocationType.online: 'ONLINE',
+};
 
 const _$LocationOSMTypeEnumMap = {
   LocationOSMType.node: 'NODE',

--- a/lib/src/prices/location_type.dart
+++ b/lib/src/prices/location_type.dart
@@ -1,0 +1,22 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import '../model/off_tagged.dart';
+
+/// Type of the Location.
+enum LocationType implements OffTagged {
+  @JsonValue('OSM')
+  osm(offTag: 'OSM'),
+  @JsonValue('ONLINE')
+  online(offTag: 'ONLINE');
+
+  const LocationType({
+    required this.offTag,
+  });
+
+  @override
+  final String offTag;
+
+  /// Returns the first [LocationType] that matches the [offTag].
+  static LocationType? fromOffTag(final String? offTag) =>
+      OffTagged.fromOffTag(offTag, LocationType.values) as LocationType?;
+}

--- a/lib/src/prices/maybe_error.dart
+++ b/lib/src/prices/maybe_error.dart
@@ -6,21 +6,28 @@ import 'package:http/http.dart';
 class MaybeError<T> {
   const MaybeError.value(T this._value)
       : error = null,
-        statusCode = null;
+        statusCode = null,
+        isError = false;
   MaybeError.responseError(final Response response)
       : _value = null,
         error = utf8.decode(response.bodyBytes),
-        statusCode = response.statusCode;
+        statusCode = response.statusCode,
+        isError = true;
+  MaybeError.unreadableResponse(final Response response)
+      : _value = null,
+        error = utf8.decode(response.bodyBytes),
+        statusCode = response.statusCode,
+        isError = false;
   MaybeError.error({
     required String this.error,
     required int this.statusCode,
-  }) : _value = null;
+  })  : _value = null,
+        isError = true;
 
   final T? _value;
+  final bool isError;
   final String? error;
   final int? statusCode;
-
-  bool get isError => _value == null;
 
   T get value => _value!;
 

--- a/lib/src/prices/price.dart
+++ b/lib/src/prices/price.dart
@@ -130,6 +130,10 @@ class Price extends JsonObject {
   @JsonKey()
   PriceProduct? product;
 
+  /// Receipt's price quantity (user input).
+  @JsonKey(name: 'receipt_quantity')
+  int? receiptQuantity;
+
   /// Owner. Read-only.
   @JsonKey()
   late String owner;

--- a/lib/src/prices/price.g.dart
+++ b/lib/src/prices/price.g.dart
@@ -36,6 +36,7 @@ Price _$PriceFromJson(Map<String, dynamic> json) => Price()
   ..product = json['product'] == null
       ? null
       : PriceProduct.fromJson(json['product'] as Map<String, dynamic>)
+  ..receiptQuantity = (json['receipt_quantity'] as num?)?.toInt()
   ..owner = json['owner'] as String
   ..created = JsonHelper.stringTimestampToDate(json['created'])
   ..updated = JsonHelper.nullableStringTimestampToDate(json['updated']);
@@ -61,6 +62,7 @@ Map<String, dynamic> _$PriceToJson(Price instance) => <String, dynamic>{
       'proof': instance.proof,
       'location': instance.location,
       'product': instance.product,
+      'receipt_quantity': instance.receiptQuantity,
       'owner': instance.owner,
       'created': instance.created.toIso8601String(),
       'updated': instance.updated?.toIso8601String(),

--- a/lib/src/prices/price_total_stats.dart
+++ b/lib/src/prices/price_total_stats.dart
@@ -31,6 +31,12 @@ class PriceTotalStats extends JsonObject {
   @JsonKey(name: 'location_with_price_count')
   int? locationWithPriceCount;
 
+  @JsonKey(name: 'location_type_osm_count')
+  int? locationTypeOsmCount;
+
+  @JsonKey(name: 'location_type_online_count')
+  int? locationTypeOnlineCount;
+
   @JsonKey(name: 'proof_count')
   int? proofCount;
 
@@ -42,6 +48,12 @@ class PriceTotalStats extends JsonObject {
 
   @JsonKey(name: 'proof_type_receipt_count')
   int? proofTypeReceiptCount;
+
+  @JsonKey(name: 'proof_type_gdpr_request_count')
+  int? proofTypeGdprRequestCount;
+
+  @JsonKey(name: 'proof_type_shop_import_count')
+  int? proofTypeShopImportCount;
 
   @JsonKey(name: 'user_count')
   int? userCount;

--- a/lib/src/prices/price_total_stats.g.dart
+++ b/lib/src/prices/price_total_stats.g.dart
@@ -19,12 +19,20 @@ PriceTotalStats _$PriceTotalStatsFromJson(Map<String, dynamic> json) =>
       ..locationCount = (json['location_count'] as num?)?.toInt()
       ..locationWithPriceCount =
           (json['location_with_price_count'] as num?)?.toInt()
+      ..locationTypeOsmCount =
+          (json['location_type_osm_count'] as num?)?.toInt()
+      ..locationTypeOnlineCount =
+          (json['location_type_online_count'] as num?)?.toInt()
       ..proofCount = (json['proof_count'] as num?)?.toInt()
       ..proofWithPriceCount = (json['proof_with_price_count'] as num?)?.toInt()
       ..proofTypePriceTagCount =
           (json['proof_type_price_tag_count'] as num?)?.toInt()
       ..proofTypeReceiptCount =
           (json['proof_type_receipt_count'] as num?)?.toInt()
+      ..proofTypeGdprRequestCount =
+          (json['proof_type_gdpr_request_count'] as num?)?.toInt()
+      ..proofTypeShopImportCount =
+          (json['proof_type_shop_import_count'] as num?)?.toInt()
       ..userCount = (json['user_count'] as num?)?.toInt()
       ..userWithPriceCount = (json['user_with_price_count'] as num?)?.toInt()
       ..updated = JsonHelper.nullableStringTimestampToDate(json['updated']);
@@ -38,10 +46,14 @@ Map<String, dynamic> _$PriceTotalStatsToJson(PriceTotalStats instance) =>
       'product_with_price_count': instance.productWithPriceCount,
       'location_count': instance.locationCount,
       'location_with_price_count': instance.locationWithPriceCount,
+      'location_type_osm_count': instance.locationTypeOsmCount,
+      'location_type_online_count': instance.locationTypeOnlineCount,
       'proof_count': instance.proofCount,
       'proof_with_price_count': instance.proofWithPriceCount,
       'proof_type_price_tag_count': instance.proofTypePriceTagCount,
       'proof_type_receipt_count': instance.proofTypeReceiptCount,
+      'proof_type_gdpr_request_count': instance.proofTypeGdprRequestCount,
+      'proof_type_shop_import_count': instance.proofTypeShopImportCount,
       'user_count': instance.userCount,
       'user_with_price_count': instance.userWithPriceCount,
       'updated': instance.updated?.toIso8601String(),

--- a/lib/src/prices/proof.dart
+++ b/lib/src/prices/proof.dart
@@ -40,6 +40,14 @@ class Proof extends JsonObject {
   @JsonKey(name: 'price_count')
   late int priceCount;
 
+  /// Receipt's number of prices (user input).
+  @JsonKey(name: 'receipt_price_count')
+  int? receiptPriceCount;
+
+  /// Receipt's total amount (user input).
+  @JsonKey(name: 'receipt_price_total')
+  num? receiptPriceTotal;
+
   /// ID of the location in OpenStreetMap.
   ///
   /// The store where the product was bought.

--- a/lib/src/prices/proof.g.dart
+++ b/lib/src/prices/proof.g.dart
@@ -13,6 +13,8 @@ Proof _$ProofFromJson(Map<String, dynamic> json) => Proof()
   ..mimetype = json['mimetype'] as String
   ..type = $enumDecodeNullable(_$ProofTypeEnumMap, json['type'])
   ..priceCount = (json['price_count'] as num).toInt()
+  ..receiptPriceCount = (json['receipt_price_count'] as num?)?.toInt()
+  ..receiptPriceTotal = json['receipt_price_total'] as num?
   ..locationOSMId = (json['location_osm_id'] as num?)?.toInt()
   ..locationOSMType =
       $enumDecodeNullable(_$LocationOSMTypeEnumMap, json['location_osm_type'])
@@ -33,6 +35,8 @@ Map<String, dynamic> _$ProofToJson(Proof instance) => <String, dynamic>{
       'mimetype': instance.mimetype,
       'type': _$ProofTypeEnumMap[instance.type],
       'price_count': instance.priceCount,
+      'receipt_price_count': instance.receiptPriceCount,
+      'receipt_price_total': instance.receiptPriceTotal,
       'location_osm_id': instance.locationOSMId,
       'location_osm_type': _$LocationOSMTypeEnumMap[instance.locationOSMType],
       'location_id': instance.locationId,

--- a/lib/src/prices/update_price_parameters.dart
+++ b/lib/src/prices/update_price_parameters.dart
@@ -25,6 +25,9 @@ class UpdatePriceParameters extends JsonObject {
   /// Date when the product was bought.
   DateTime? date;
 
+  /// Receipt's price quantity (user input).
+  int? receiptQuantity;
+
   @override
   Map<String, dynamic> toJson() => <String, dynamic>{
         if (pricePer != null) 'price_per': pricePer!.offTag,
@@ -34,5 +37,6 @@ class UpdatePriceParameters extends JsonObject {
         if (price != null) 'price': price,
         if (currency != null) 'currency': currency!.name,
         if (date != null) 'date': GetParametersHelper.formatDate(date!),
+        if (receiptQuantity != null) 'receipt_quantity': receiptQuantity,
       };
 }

--- a/lib/src/prices/update_proof_parameters.dart
+++ b/lib/src/prices/update_proof_parameters.dart
@@ -1,6 +1,7 @@
 import '../interface/json_object.dart';
 import 'currency.dart';
 import 'get_parameters_helper.dart';
+import 'location_osm_type.dart';
 import 'proof_type.dart';
 
 /// Parameters for the "update proof" API query.
@@ -16,10 +17,27 @@ class UpdateProofParameters extends JsonObject {
   /// Currency of the price.
   Currency? currency;
 
+  /// ID of the location in OpenStreetMap.
+  int? locationOSMId;
+
+  /// Type of the OpenStreetMap location object.
+  LocationOSMType? locationOSMType;
+
+  /// Receipt's number of prices.
+  int? receiptPriceCount;
+
+  /// Receipt's total amount (user input).
+  num? receiptPriceTotal;
+
   @override
   Map<String, dynamic> toJson() => <String, dynamic>{
         if (type != null) 'type': type!.offTag,
         if (date != null) 'date': GetParametersHelper.formatDate(date!),
         if (currency != null) 'currency': currency!.name,
+        if (locationOSMId != null) 'location_osm_id': locationOSMId,
+        if (locationOSMType != null)
+          'location_osm_type': locationOSMType!.offTag,
+        if (receiptPriceCount != null) 'receipt_price_count': receiptPriceCount,
+        if (receiptPriceTotal != null) 'receipt_price_total': receiptPriceTotal,
       };
 }


### PR DESCRIPTION
### What
- Added latest Prices fields.
- Minor fix for `createPrice` - now we don't care if we cannot fully read the server response body, as long as the status code has the expected value. In order to prevent trying to recreate over and over a Price when the response body evolves.

### Fixes bug(s)
- Closes: #986

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/5689

### Files
New file:
* `location_type.dart`: Type of the Location.

Impacted files:
* `api_prices_test.dart`: refactored with the additional fields
* `location.dart`: added fields `locationType` and `websiteUrl`
* `location.g.dart`: generated
* `maybe_error.dart`: now we accept valid but unreadable responses
* `open_prices_api_client.dart`: safer `createPrice` method; refactored with the additional fields
* `openfoodfacts.dart`: added file `location_type.dart`
* `price.dart`: added field `receiptQuantity`
* `price.g.dart`: generated
* `price_total_stats.dart`: added fields `locationTypeOsmCount`, `locationTypeOnlineCount`, `proofTypeGdprRequestCount` and `proofTypeShopImportCount`
* `price_total_stats.g.dart`: generated
* `proof.dart`: added fields `receiptPriceCount` and `receiptPriceTotal`
* `proof.g.dart`: generated
* `update_price_parameters.dart`: added field `receiptQuantity`
* `update_proof_parameters.dart`: added fields `receiptPriceCount`, `receiptPriceTotal`, `locationOSMId` and `locationOSMType`
