### PR TITLE
feat: 990 - new knowledge panel "halfWidthOnMobile" field

### DIFF
--- a/lib/src/model/knowledge_panel.dart
+++ b/lib/src/model/knowledge_panel.dart
@@ -105,6 +105,9 @@ class KnowledgePanel extends JsonObject {
   @JsonKey(unknownEnumValue: KnowledgePanelSize.UNKNOWN)
   final KnowledgePanelSize? size;
 
+  @JsonKey(name: 'half_width_on_mobile')
+  final bool? halfWidthOnMobile;
+
   const KnowledgePanel({
     this.titleElement,
     this.level,
@@ -113,6 +116,7 @@ class KnowledgePanel extends JsonObject {
     this.topics,
     this.evaluation,
     this.size,
+    this.halfWidthOnMobile,
   });
 
   factory KnowledgePanel.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/model/knowledge_panel.g.dart
+++ b/lib/src/model/knowledge_panel.g.dart
@@ -25,6 +25,7 @@ KnowledgePanel _$KnowledgePanelFromJson(Map<String, dynamic> json) =>
           unknownValue: Evaluation.UNKNOWN),
       size: $enumDecodeNullable(_$KnowledgePanelSizeEnumMap, json['size'],
           unknownValue: KnowledgePanelSize.UNKNOWN),
+      halfWidthOnMobile: json['half_width_on_mobile'] as bool?,
     );
 
 Map<String, dynamic> _$KnowledgePanelToJson(KnowledgePanel instance) =>
@@ -36,6 +37,7 @@ Map<String, dynamic> _$KnowledgePanelToJson(KnowledgePanel instance) =>
       'topics': instance.topics,
       'evaluation': _$EvaluationEnumMap[instance.evaluation],
       'size': _$KnowledgePanelSizeEnumMap[instance.size],
+      'half_width_on_mobile': instance.halfWidthOnMobile,
     };
 
 const _$LevelEnumMap = {

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -51,6 +51,32 @@ void main() {
   }
 
   group('$OpenFoodAPIClient get products', () {
+    test('get KP halfWidthOnMobile', () async {
+      const String barcode = '737628064502';
+
+      final ProductQueryConfiguration configurations =
+          ProductQueryConfiguration(
+        barcode,
+        language: OpenFoodFactsLanguage.ENGLISH,
+        fields: [ProductField.KNOWLEDGE_PANELS],
+        version: ProductQueryVersion.v3,
+      );
+      final ProductResultV3 result = await getProductV3InProd(
+        configurations,
+      );
+      expect(result.status, ProductResultV3.statusSuccess);
+      expect(result.barcode, barcode);
+      expect(result.product, isNotNull);
+      bool found = false;
+      for (final KnowledgePanel panel
+          in result.product!.knowledgePanels!.panelIdToPanelMap.values) {
+        if (panel.halfWidthOnMobile == true) {
+          found = true;
+        }
+      }
+      expect(found, isTrue);
+    });
+
     test('get product tiny twists - Rold Gold Pretzels - 16 OZ. (1 LB) 453.6g',
         () async {
       //Refactor the test once the issue  #48 is fixed


### PR DESCRIPTION
### What
- New knowledge panel `bool? halfWidthOnMobile`  field

### Fixes bug(s)
- Closes: #990

### Impacted files
* `api_get_product_test.dart`: added a test for the new KP `halfWidthOnMobile` field
* `knowledge_panel.dart`: added `halfWidthOnMobile` field
* `knowledge_panel.g.dart`: wtf