### PR TITLE
feat: product_type as new product field

### DIFF
--- a/lib/src/utils/product_fields.dart
+++ b/lib/src/utils/product_fields.dart
@@ -4,6 +4,7 @@ import '../model/off_tagged.dart';
 /// Fields of a [Product]
 enum ProductField implements OffTagged {
   BARCODE(offTag: 'code'),
+  PRODUCT_TYPE(offTag: 'product_type'),
   NAME(
     offTag: 'product_name',
     inLanguagesProductField: ProductField.NAME_IN_LANGUAGES,


### PR DESCRIPTION
### What
- Now the server provides the product field "product_type", so let's retrieve it.

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/5855

### Impacted files
* `api_not_food_get_product_test.dart`: additional tests with new product field product_type
* `product_fields.dart`: added product_type as new product field