### PR TITLE
fix: for online price locations, no OSM fields

### DIFF
--- a/lib/src/prices/location.dart
+++ b/lib/src/prices/location.dart
@@ -14,7 +14,7 @@ part 'location.g.dart';
 class Location extends JsonObject {
   /// ID of the location in OpenStreetMap: the store where the product was bought.
   @JsonKey(name: 'osm_id')
-  late int osmId;
+  int? osmId;
 
   /// Type of the location object.
   @JsonKey(name: 'type')
@@ -26,7 +26,7 @@ class Location extends JsonObject {
   /// It is necessary to be able to fetch the correct information about the
   /// store using the ID.
   @JsonKey(name: 'osm_type')
-  late LocationOSMType type;
+  LocationOSMType? type;
 
   /// Number of prices for this location.
   @JsonKey(name: 'price_count')

--- a/lib/src/prices/location.g.dart
+++ b/lib/src/prices/location.g.dart
@@ -7,9 +7,9 @@ part of 'location.dart';
 // **************************************************************************
 
 Location _$LocationFromJson(Map<String, dynamic> json) => Location()
-  ..osmId = (json['osm_id'] as num).toInt()
+  ..osmId = (json['osm_id'] as num?)?.toInt()
   ..locationType = $enumDecode(_$LocationTypeEnumMap, json['type'])
-  ..type = $enumDecode(_$LocationOSMTypeEnumMap, json['osm_type'])
+  ..type = $enumDecodeNullable(_$LocationOSMTypeEnumMap, json['osm_type'])
   ..priceCount = (json['price_count'] as num?)?.toInt()
   ..userCount = (json['user_count'] as num?)?.toInt()
   ..productCount = (json['product_count'] as num?)?.toInt()
@@ -32,7 +32,7 @@ Location _$LocationFromJson(Map<String, dynamic> json) => Location()
 Map<String, dynamic> _$LocationToJson(Location instance) => <String, dynamic>{
       'osm_id': instance.osmId,
       'type': _$LocationTypeEnumMap[instance.locationType]!,
-      'osm_type': _$LocationOSMTypeEnumMap[instance.type]!,
+      'osm_type': _$LocationOSMTypeEnumMap[instance.type],
       'price_count': instance.priceCount,
       'user_count': instance.userCount,
       'product_count': instance.productCount,

--- a/test/api_prices_test.dart
+++ b/test/api_prices_test.dart
@@ -514,8 +514,8 @@ void main() {
 
       final MaybeError<Location> maybeSameOSMLocation =
           await OpenPricesAPIClient.getOSMLocation(
-        locationOSMType: location.type,
-        locationOSMId: location.osmId,
+        locationOSMType: location.type!,
+        locationOSMId: location.osmId!,
         uriHelper: uriHelper,
       );
       expect(maybeSameOSMLocation.isError, isFalse);


### PR DESCRIPTION
### What
- Now that we have ONLINE price locations, the OSM fields can be null.
- Without the current fix, the tests always fail.

### Impacted files
* `api_prices_test.dart`: minor change
* `location.dart`: made OSM fields nullable
* `location.g.dart`: wtf