### PR TITLE
feat: 999 - added "bool? product.isImageLocked" method

### DIFF
--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -222,6 +222,61 @@ class Product extends JsonObject {
   /// Images may be returned in multiple sizes
   List<ProductImage>? getMainImages() => _getImageSubset(true);
 
+  bool? isImageLocked(
+    final ImageField imageField,
+    final OpenFoodFactsLanguage language,
+  ) {
+    if (images == null || owner == null) {
+      return null;
+    }
+    final ProductImage? localizedImage = getLocalizedImage(
+      imageField,
+      language,
+    );
+    final String? imageId = localizedImage?.imgid;
+    if (imageId == null) {
+      return null;
+    }
+    final ProductImage? rawImage = getRawImage(imageId);
+    if (rawImage == null) {
+      return null;
+    }
+    return rawImage.contributor == owner;
+  }
+
+  ProductImage? getLocalizedImage(
+    final ImageField imageField,
+    final OpenFoodFactsLanguage language,
+  ) {
+    if (images == null) {
+      return null;
+    }
+    for (final ProductImage productImage in images!) {
+      if (productImage.field == imageField &&
+          productImage.language == language) {
+        if (productImage.rev == null) {
+          return null;
+        }
+        return productImage;
+      }
+    }
+    return null;
+  }
+
+  ProductImage? getRawImage(final String imageId) {
+    if (images == null) {
+      return null;
+    }
+    for (final ProductImage productImage in images!) {
+      if (!productImage.isMain) {
+        if (productImage.imgid == imageId) {
+          return productImage;
+        }
+      }
+    }
+    return null;
+  }
+
   List<ProductImage>? _getImageSubset(final bool isMain) {
     if (images == null) {
       return null;
@@ -536,6 +591,9 @@ class Product extends JsonObject {
   /// See also [getOwnerFieldTimestamp].
   @JsonKey(name: 'owner_fields')
   Map<String, int>? ownerFields;
+
+  @JsonKey()
+  String? owner;
 
   /// Expiration date / best before. Just a string, no format control.
   @JsonKey(name: 'expiration_date')

--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -226,7 +226,7 @@ class Product extends JsonObject {
     final ImageField imageField,
     final OpenFoodFactsLanguage language,
   ) {
-    if (images == null || owner == null) {
+    if (owner == null) {
       return null;
     }
     final ProductImage? localizedImage = getLocalizedImage(

--- a/lib/src/model/product.g.dart
+++ b/lib/src/model/product.g.dart
@@ -176,6 +176,7 @@ Product _$ProductFromJson(Map<String, dynamic> json) => Product(
       ..ownerFields = (json['owner_fields'] as Map<String, dynamic>?)?.map(
         (k, e) => MapEntry(k, (e as num).toInt()),
       )
+      ..owner = json['owner'] as String?
       ..expirationDate = json['expiration_date'] as String?;
 
 Map<String, dynamic> _$ProductToJson(Product instance) {
@@ -313,6 +314,7 @@ Map<String, dynamic> _$ProductToJson(Product instance) {
   writeNotNull('link', instance.website);
   val['obsolete'] = JsonHelper.checkboxToJSON(instance.obsolete);
   writeNotNull('owner_fields', instance.ownerFields);
+  writeNotNull('owner', instance.owner);
   writeNotNull('expiration_date', instance.expirationDate);
   val['no_nutrition_data'] =
       JsonHelper.checkboxToJSON(instance.noNutritionData);

--- a/lib/src/utils/product_fields.dart
+++ b/lib/src/utils/product_fields.dart
@@ -227,6 +227,7 @@ enum ProductField implements OffTagged {
   EXPIRATION_DATE(offTag: 'expiration_date'),
   OBSOLETE(offTag: 'obsolete'),
   OWNER_FIELDS(offTag: 'owner_fields'),
+  OWNER(offTag: 'owner'),
 
   /// All data as RAW from the server. E.g. packagings are only Strings there.
   RAW(offTag: 'raw'),

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -1259,6 +1259,63 @@ void main() {
     }
   });
 
+  test('check if images are locked', () async {
+    Future<void> checkLocked(
+      final String barcode,
+      final OpenFoodFactsLanguage language,
+      final Map<ImageField, bool> areLocked,
+    ) async {
+      final ProductResultV3 result = await getProductV3InProd(
+        ProductQueryConfiguration(
+          barcode,
+          fields: [
+            ProductField.OWNER,
+            ProductField.IMAGES,
+          ],
+          version: ProductQueryVersion.v3,
+        ),
+      );
+      expect(result.status, ProductResultV3.statusSuccess);
+      expect(result.product, isNotNull);
+      for (final MapEntry<ImageField, bool> entry in areLocked.entries) {
+        expect(result.product!.isImageLocked(entry.key, language), entry.value);
+      }
+    }
+
+    await checkLocked(
+      '3560070800292',
+      OpenFoodFactsLanguage.FRENCH,
+      <ImageField, bool>{
+        ImageField.FRONT: true,
+        ImageField.INGREDIENTS: false,
+        ImageField.NUTRITION: false,
+        ImageField.PACKAGING: false,
+      },
+    );
+
+    await checkLocked(
+      '7300400481588',
+      OpenFoodFactsLanguage.FRENCH,
+      <ImageField, bool>{
+        ImageField.FRONT: true,
+        ImageField.INGREDIENTS: false,
+        ImageField.NUTRITION: false,
+        ImageField.PACKAGING: false,
+      },
+    );
+
+    await checkLocked(
+      '3240931543390',
+      OpenFoodFactsLanguage.FRENCH,
+      <ImageField, bool>{
+        ImageField.FRONT: true,
+        ImageField.INGREDIENTS: true,
+        ImageField.NUTRITION: true,
+        ImageField.PACKAGING: true,
+      },
+    );
+  });
+
   group('$OpenFoodAPIClient get new packagings field', () {
     const String barcode = '3661344723290';
     const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;


### PR DESCRIPTION
### What
- Now we retrieve the "owner" field of product.
- Therefore, we can compare it to the uploader of raw images, and say if a main image is locked.

### Fixes bug(s)
- Closes: #999

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/5394

### Impacted files
* `api_get_product_test.dart`: new test "check if images are locked"
* `product.dart`: added field `owner` and methods around images - `isImageLocked`, `getLocalizedImage` and `getRawImage`
* `product.g.dart`: generated
* `product_fields.dart`: added field `OWNER`