### PR TITLE
feat: 1011 - new "getPriceProducts" method

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -100,6 +100,9 @@ export 'src/prices/get_locations_result.dart';
 // export 'src/prices/get_parameters_helper.dart'; // uncomment if really needed
 export 'src/prices/get_prices_order.dart';
 export 'src/prices/get_prices_parameters.dart';
+export 'src/prices/get_price_products_order.dart';
+export 'src/prices/get_price_products_parameters.dart';
+export 'src/prices/get_price_products_result.dart';
 export 'src/prices/get_prices_result.dart';
 export 'src/prices/get_price_count_parameters_helper.dart';
 export 'src/prices/get_proofs_order.dart';

--- a/lib/src/open_prices_api_client.dart
+++ b/lib/src/open_prices_api_client.dart
@@ -12,6 +12,8 @@ import 'prices/proof.dart';
 import 'prices/get_locations_parameters.dart';
 import 'prices/get_locations_result.dart';
 import 'prices/get_parameters_helper.dart';
+import 'prices/get_price_products_parameters.dart';
+import 'prices/get_price_products_result.dart';
 import 'prices/get_prices_parameters.dart';
 import 'prices/get_prices_result.dart';
 import 'prices/get_proofs_parameters.dart';
@@ -161,6 +163,34 @@ class OpenPricesAPIClient {
       }
     }
     return MaybeError<Location>.responseError(response);
+  }
+
+  static Future<MaybeError<GetPriceProductsResult>> getPriceProducts(
+    final GetPriceProductsParameters parameters, {
+    final UriProductHelper uriHelper = uriHelperFoodProd,
+    final String? bearerToken,
+  }) async {
+    final Uri uri = getUri(
+      path: '/api/v1/products',
+      queryParameters: parameters.getQueryParameters(),
+      uriHelper: uriHelper,
+    );
+    final Response response = await HttpHelper().doGetRequest(
+      uri,
+      uriHelper: uriHelper,
+      bearerToken: bearerToken,
+    );
+    if (response.statusCode == 200) {
+      try {
+        final dynamic decodedResponse = HttpHelper().jsonDecodeUtf8(response);
+        return MaybeError<GetPriceProductsResult>.value(
+          GetPriceProductsResult.fromJson(decodedResponse),
+        );
+      } catch (e) {
+        //
+      }
+    }
+    return MaybeError<GetPriceProductsResult>.responseError(response);
   }
 
   static Future<MaybeError<PriceProduct>> getPriceProductById(

--- a/lib/src/prices/get_parameters_helper.dart
+++ b/lib/src/prices/get_parameters_helper.dart
@@ -14,7 +14,7 @@ abstract class GetParametersHelper<T extends OrderByField> {
 
   /// Returns the parameters as a query parameter map.
   Map<String, String> getQueryParameters() {
-    _checkIntValue('page_number', pageSize, min: 1);
+    _checkIntValue('page_number', pageNumber, min: 1);
     _checkIntValue('page_size', pageSize, min: 1, max: 100);
     _result.clear();
     addNonNullInt(pageNumber, 'page');
@@ -32,7 +32,7 @@ abstract class GetParametersHelper<T extends OrderByField> {
   }
 
   void _checkIntValue(
-    final String field,
+    final String fieldDescription,
     final int? value, {
     final int? min,
     final int? max,
@@ -43,14 +43,14 @@ abstract class GetParametersHelper<T extends OrderByField> {
     if (min != null) {
       if (value < min) {
         throw Exception(
-          '$field minimum value is $min (actual value is $value)',
+          '$fieldDescription minimum value is $min (actual value is $value)',
         );
       }
     }
     if (max != null) {
       if (value > max) {
         throw Exception(
-          '$field maximum value is $max (actual value is $value)',
+          '$fieldDescription maximum value is $max (actual value is $value)',
         );
       }
     }

--- a/lib/src/prices/get_price_products_order.dart
+++ b/lib/src/prices/get_price_products_order.dart
@@ -1,0 +1,13 @@
+import 'order_by.dart';
+
+/// Field for the "order by" clause of "get price products".
+enum GetPriceProductsOrderField implements OrderByField {
+  priceCount(offTag: 'price_count'),
+  created(offTag: 'created'),
+  updated(offTag: 'updated');
+
+  const GetPriceProductsOrderField({required this.offTag});
+
+  @override
+  final String offTag;
+}

--- a/lib/src/prices/get_price_products_parameters.dart
+++ b/lib/src/prices/get_price_products_parameters.dart
@@ -1,0 +1,37 @@
+import 'package:openfoodfacts/src/prices/flavor.dart';
+
+import 'get_price_count_parameters_helper.dart';
+import 'get_price_products_order.dart';
+
+/// Parameters for the "get price products" API query.
+class GetPriceProductsParameters
+    extends GetPriceCountParametersHelper<GetPriceProductsOrderField> {
+  String? brandsLike;
+  String? brandsTagsContains;
+  String? categoriesTagsContains;
+  String? code;
+  String? ecoscoreGrade;
+  String? labelsTagsContains;
+  String? novaGroup;
+  String? nutriscoreGrade;
+  String? productNameLike;
+  int? uniqueScansNGte;
+  Flavor? source;
+
+  @override
+  Map<String, String> getQueryParameters() {
+    super.getQueryParameters();
+    addNonNullString(brandsLike, 'brands__like');
+    addNonNullString(brandsTagsContains, 'brands_tags__contains');
+    addNonNullString(categoriesTagsContains, 'categories_tags__contains');
+    addNonNullString(code, 'code');
+    addNonNullString(ecoscoreGrade, 'ecoscore_grade');
+    addNonNullString(labelsTagsContains, 'labels_tags__contains');
+    addNonNullString(novaGroup, 'nova_group');
+    addNonNullString(nutriscoreGrade, 'nutriscore_grade');
+    addNonNullString(productNameLike, 'product_name__like');
+    addNonNullInt(uniqueScansNGte, 'unique_scans_n__gte');
+    addNonNullString(source?.offTag, 'source');
+    return result;
+  }
+}

--- a/lib/src/prices/get_price_products_result.dart
+++ b/lib/src/prices/get_price_products_result.dart
@@ -1,0 +1,33 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+
+import '../interface/json_object.dart';
+
+part 'get_price_products_result.g.dart';
+
+/// List of price product objects returned by the "get price products" method.
+@JsonSerializable()
+class GetPriceProductsResult extends JsonObject {
+  @JsonKey()
+  List<PriceProduct>? items;
+
+  @JsonKey()
+  int? total;
+
+  @JsonKey(name: 'page')
+  int? pageNumber;
+
+  @JsonKey(name: 'size')
+  int? pageSize;
+
+  @JsonKey(name: 'pages')
+  int? numberOfPages;
+
+  GetPriceProductsResult();
+
+  factory GetPriceProductsResult.fromJson(Map<String, dynamic> json) =>
+      _$GetPriceProductsResultFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$GetPriceProductsResultToJson(this);
+}

--- a/lib/src/prices/get_price_products_result.g.dart
+++ b/lib/src/prices/get_price_products_result.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'get_price_products_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+GetPriceProductsResult _$GetPriceProductsResultFromJson(
+        Map<String, dynamic> json) =>
+    GetPriceProductsResult()
+      ..items = (json['items'] as List<dynamic>?)
+          ?.map((e) => PriceProduct.fromJson(e as Map<String, dynamic>))
+          .toList()
+      ..total = (json['total'] as num?)?.toInt()
+      ..pageNumber = (json['page'] as num?)?.toInt()
+      ..pageSize = (json['size'] as num?)?.toInt()
+      ..numberOfPages = (json['pages'] as num?)?.toInt();
+
+Map<String, dynamic> _$GetPriceProductsResultToJson(
+        GetPriceProductsResult instance) =>
+    <String, dynamic>{
+      'items': instance.items,
+      'total': instance.total,
+      'page': instance.pageNumber,
+      'size': instance.pageSize,
+      'pages': instance.numberOfPages,
+    };


### PR DESCRIPTION
### What
- New "get price products" method, needed for Smoothie's "top products" page

### Part of 
- #1011
- https://github.com/openfoodfacts/smooth-app/issues/5988

### Files
New files:
* `get_price_products_order.dart`: Field for the "order by" clause of "get price products".
* `get_price_products_parameters.dart`: Parameters for the "get price products" API query.
* `get_price_products_result.dart`: List of price product objects returned by the "get price products" method.
* `get_price_products_result.g.dart`: generated

Impacted files:
* `api_prices_test.dart`: new tests around new `getPriceProducts` method; minor refactoring
* `get_parameters_helper.dart`: minor refactoring
* `open_prices_api_client.dart`: new `getPriceProducts` method
* `openfoodfacts.dart`: exported the new 3 files