### PR TITLE
chore: 960 - refreshed pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,12 +15,12 @@ dependencies:
   meta: ^1.8.0
 
 dev_dependencies:
-  analyzer: ^6.2.0
-  build_runner: ^2.4.9
-  json_serializable: ^6.8.0
+  analyzer: 6.11.0
+  build_runner: 2.4.9
+  json_serializable: 6.9.0
   lints: ">=3.0.0 <5.0.0"
-  test: ^1.25.5
-  coverage: ^1.8.0
+  test: 1.25.5
+  coverage: 1.8.0
 
 funding:
   - "https://donate.openfoodfacts.org/"


### PR DESCRIPTION
### What
- As we're between 2 major flutter versions, we need to be more precise regarding the package version numbers we use in `pubspec.yaml`.

### Part of 
- #960

cc. @AffanShaikhsurab