### PR TITLE
chore: 960 - refreshed pubspec.yaml, again

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 dev_dependencies:
   analyzer: 6.11.0
   build_runner: 2.4.9
-  json_serializable: 6.9.0
+  json_serializable: 6.8.0
   lints: ">=3.0.0 <5.0.0"
   test: 1.25.5
   coverage: 1.8.0


### PR DESCRIPTION
### What
- Same as #1021, but with a little twist.
- Looks like recent versions of `json_serializable` use that brand new stupid syntax with `if(... case ...)`, which is not supported everywhere.
- Therefore, we have to use the best version of `json_serializable` without that syntax.

### Fixes bug(s)
- Fixes: #1023

### Part of 
- #960