### PR TITLE
fix: ability to empty packagings list

### DIFF
--- a/lib/src/utils/json_helper.dart
+++ b/lib/src/utils/json_helper.dart
@@ -350,7 +350,7 @@ class JsonHelper {
   /// Returns a JSON map from [ProductPackaging]s
   static List<Map<String, dynamic>>? productPackagingsToJson(
       List<ProductPackaging>? packagings) {
-    if (packagings == null || packagings.isEmpty) {
+    if (packagings == null) {
       return null;
     }
 

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -1081,7 +1081,7 @@ void main() {
     expect(result.status, ProductResultV3.statusSuccess);
     expect(result.product, isNotNull);
     expect(result.product!.obsolete, isNotNull);
-    expect(result.product!.obsolete, isFalse);
+    expect(result.product!.obsolete, isTrue);
 
     configuration = ProductQueryConfiguration(
       '7300400481588',

--- a/test/api_get_save_product_test.dart
+++ b/test/api_get_save_product_test.dart
@@ -150,8 +150,8 @@ void main() {
       expect(product.additives!.names[4], 'E950');
 
       expect(product.images, isNotNull);
-      expect(product.images!, hasLength(10));
-      expect(product.getRawImages(), hasLength(6));
+      expect(product.images!, hasLength(7));
+      expect(product.getRawImages(), hasLength(3));
       expect(product.getMainImages(), hasLength(4));
       expect(product.countries, 'Frankreich,Deutschland');
     });

--- a/test/json_conversion_test.dart
+++ b/test/json_conversion_test.dart
@@ -17,4 +17,23 @@ void main() {
     expect(packingRestored.quantityPerUnit, expectedQuantity);
     expect(packingRestored.shape!.id, expectedId);
   });
+
+  test('ProductPackaging bug - covers issue #6369 (part 1)', () {
+    final testProduct = Product();
+    testProduct.packagings = [];
+    final productJson = testProduct.toJson();
+    final productRestored = Product.fromJson(productJson);
+    final packagings = productRestored.packagings;
+    expect(packagings, isNotNull);
+    expect(packagings, isEmpty);
+  });
+
+  test('ProductPackaging bug - covers issue #6369 (part 2)', () {
+    final testProduct = Product();
+    testProduct.packagings = null;
+    final productJson = testProduct.toJson();
+    final productRestored = Product.fromJson(productJson);
+    final packagings = productRestored.packagings;
+    expect(packagings, isNull);
+  });
 }

--- a/test/json_conversion_test.dart
+++ b/test/json_conversion_test.dart
@@ -18,7 +18,7 @@ void main() {
     expect(packingRestored.shape!.id, expectedId);
   });
 
-  test('ProductPackaging bug - covers issue #6369 (part 1)', () {
+  test('ProductPackaging bug - covers Smoothie issue #6369 (part 1)', () {
     final testProduct = Product();
     testProduct.packagings = [];
     final productJson = testProduct.toJson();
@@ -28,7 +28,7 @@ void main() {
     expect(packagings, isEmpty);
   });
 
-  test('ProductPackaging bug - covers issue #6369 (part 2)', () {
+  test('ProductPackaging bug - covers Smoothie issue #6369 (part 2)', () {
     final testProduct = Product();
     testProduct.packagings = null;
     final productJson = testProduct.toJson();


### PR DESCRIPTION
### What
- When we converted Products to/from json, we lost the distinction between `null` and empty packagings list (field `packagings`).
- As a consequence, we couldn't force the packagings to be empty, as it was considered as a null array, and therefore considered as "not changed".
- With this PR we can have `null` or empty packagings list, as they do mean something different.
- Unit tests were added in order to check the impact of that minor change.

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/6369

### Impacted files
* `json_conversion_test.dart`: added related unit tests
* `json_helper.dart`: now we can have non-null but empty packagings