### PR TITLE
fix: 1045 - OSM fields now nullable and discountType for Price

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -26,6 +26,7 @@ export 'src/model/nutrient_modifier.dart';
 export 'src/model/nutrient.dart';
 export 'src/model/nutrient_levels.dart';
 export 'src/model/nutriments.dart';
+
 // export 'src/model/product_list.dart'; // not needed
 export 'src/model/ocr_ingredients_result.dart';
 export 'src/model/ocr_packaging_result.dart';
@@ -97,10 +98,12 @@ export 'src/personalized_search/preference_importance.dart';
 export 'src/personalized_search/product_preferences_manager.dart';
 export 'src/personalized_search/product_preferences_selection.dart';
 export 'src/prices/currency.dart';
+export 'src/prices/discount_type.dart';
 export 'src/prices/flavor.dart';
 export 'src/prices/get_locations_order.dart';
 export 'src/prices/get_locations_parameters.dart';
 export 'src/prices/get_locations_result.dart';
+
 // export 'src/prices/get_parameters_helper.dart'; // uncomment if really needed
 export 'src/prices/get_prices_order.dart';
 export 'src/prices/get_prices_parameters.dart';

--- a/lib/src/open_prices_api_client.dart
+++ b/lib/src/open_prices_api_client.dart
@@ -90,6 +90,32 @@ class OpenPricesAPIClient {
     return MaybeError<GetPricesResult>.responseError(response);
   }
 
+  /// Gets a price.
+  static Future<MaybeError<Price>> getPrice(
+    final int priceId, {
+    final UriProductHelper uriHelper = uriHelperFoodProd,
+  }) async {
+    final Uri uri = getUri(
+      path: '/api/v1/prices/$priceId',
+      uriHelper: uriHelper,
+    );
+    final Response response = await HttpHelper().doGetRequest(
+      uri,
+      uriHelper: uriHelper,
+    );
+    if (response.statusCode == 200) {
+      try {
+        final dynamic decodedResponse = HttpHelper().jsonDecodeUtf8(response);
+        return MaybeError<Price>.value(
+          Price.fromJson(decodedResponse),
+        );
+      } catch (e) {
+        //
+      }
+    }
+    return MaybeError<Price>.responseError(response);
+  }
+
   static Future<MaybeError<Location>> getOSMLocation({
     required final int locationOSMId,
     required final LocationOSMType locationOSMType,
@@ -367,6 +393,9 @@ class OpenPricesAPIClient {
       uriHelper: uriHelper,
     );
     final Map<String, dynamic> body = <String, dynamic>{
+      'price': price.price,
+      'currency': price.currency.name,
+      'date': GetParametersHelper.formatDate(price.date),
       if (price.productCode != null) 'product_code': price.productCode,
       if (price.productName != null) 'product_name': price.productName,
       if (price.categoryTag != null) 'category_tag': price.categoryTag,
@@ -378,11 +407,11 @@ class OpenPricesAPIClient {
         'price_without_discount': price.priceWithoutDiscount,
       if (price.priceIsDiscounted != null)
         'price_is_discounted': price.priceIsDiscounted,
-      'price': price.price,
-      'currency': price.currency.name,
-      'location_osm_id': price.locationOSMId,
-      'location_osm_type': price.locationOSMType.offTag,
-      'date': GetParametersHelper.formatDate(price.date),
+      if (price.discountType != null)
+        'discount_type': price.discountType!.offTag,
+      if (price.locationOSMId != null) 'location_osm_id': price.locationOSMId,
+      if (price.locationOSMType != null)
+        'location_osm_type': price.locationOSMType!.offTag,
       if (price.receiptQuantity != null)
         'receipt_quantity': price.receiptQuantity,
     };

--- a/lib/src/prices/discount_type.dart
+++ b/lib/src/prices/discount_type.dart
@@ -1,0 +1,35 @@
+import 'package:json_annotation/json_annotation.dart';
+import '../model/off_tagged.dart';
+
+/// Discount Type, for Prices.
+///
+/// cf. DiscountTypeEnum in https://prices.openfoodfacts.org/api/docs
+enum DiscountType implements OffTagged {
+  @JsonValue('QUANTITY')
+  quantity(offTag: 'QUANTITY'),
+  @JsonValue('SALE')
+  sale(offTag: 'SALE'),
+  @JsonValue('SEASONAL')
+  seasonal(offTag: 'SEASONAL'),
+  @JsonValue('LOYALTY_PROGRAM')
+  loyaltyProgram(offTag: 'LOYALTY_PROGRAM'),
+  @JsonValue('EXPIRES_SOON')
+  expiresSoon(offTag: 'EXPIRES_SOON'),
+  @JsonValue('PICK_IT_YOURSELF')
+  pickItYourself(offTag: 'PICK_IT_YOURSELF'),
+  @JsonValue('SECOND_HAND')
+  secondHand(offTag: 'SECOND_HAND'),
+  @JsonValue('OTHER')
+  other(offTag: 'OTHER');
+
+  const DiscountType({
+    required this.offTag,
+  });
+
+  @override
+  final String offTag;
+
+  /// Returns the first [DiscountType] that matches the [offTag].
+  static DiscountType? fromOffTag(final String? offTag) =>
+      OffTagged.fromOffTag(offTag, DiscountType.values) as DiscountType?;
+}

--- a/lib/src/prices/price.dart
+++ b/lib/src/prices/price.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 
 import 'currency.dart';
+import 'discount_type.dart';
 import 'location.dart';
 import 'location_osm_type.dart';
 import 'price_per.dart';
@@ -70,6 +71,9 @@ class Price extends JsonObject {
   @JsonKey(name: 'price_without_discount')
   num? priceWithoutDiscount;
 
+  @JsonKey(name: 'discount_type')
+  DiscountType? discountType;
+
   /// Price per unit, kilogram, ..?
   ///
   /// if the price is about a barcode-less product (if category_tag is
@@ -85,7 +89,7 @@ class Price extends JsonObject {
 
   /// ID of the location in OpenStreetMap: the store where the product was bought.
   @JsonKey(name: 'location_osm_id')
-  late int locationOSMId;
+  int? locationOSMId;
 
   /// Type of the OpenStreetMap location object.
   ///
@@ -93,7 +97,7 @@ class Price extends JsonObject {
   /// It is necessary to be able to fetch the correct information about the
   /// store using the ID.
   @JsonKey(name: 'location_osm_type')
-  late LocationOSMType locationOSMType;
+  LocationOSMType? locationOSMType;
 
   /// Date when the product was bought.
   @JsonKey(fromJson: JsonHelper.stringTimestampToDate)

--- a/lib/src/prices/price.g.dart
+++ b/lib/src/prices/price.g.dart
@@ -17,11 +17,13 @@ Price _$PriceFromJson(Map<String, dynamic> json) => Price()
   ..price = json['price'] as num
   ..priceIsDiscounted = json['price_is_discounted'] as bool?
   ..priceWithoutDiscount = json['price_without_discount'] as num?
+  ..discountType =
+      $enumDecodeNullable(_$DiscountTypeEnumMap, json['discount_type'])
   ..pricePer = $enumDecodeNullable(_$PricePerEnumMap, json['price_per'])
   ..currency = $enumDecode(_$CurrencyEnumMap, json['currency'])
-  ..locationOSMId = (json['location_osm_id'] as num).toInt()
+  ..locationOSMId = (json['location_osm_id'] as num?)?.toInt()
   ..locationOSMType =
-      $enumDecode(_$LocationOSMTypeEnumMap, json['location_osm_type'])
+      $enumDecodeNullable(_$LocationOSMTypeEnumMap, json['location_osm_type'])
   ..date = JsonHelper.stringTimestampToDate(json['date'])
   ..proofId = (json['proof_id'] as num?)?.toInt()
   ..id = (json['id'] as num).toInt()
@@ -51,10 +53,11 @@ Map<String, dynamic> _$PriceToJson(Price instance) => <String, dynamic>{
       'price': instance.price,
       'price_is_discounted': instance.priceIsDiscounted,
       'price_without_discount': instance.priceWithoutDiscount,
+      'discount_type': _$DiscountTypeEnumMap[instance.discountType],
       'price_per': _$PricePerEnumMap[instance.pricePer],
       'currency': _$CurrencyEnumMap[instance.currency]!,
       'location_osm_id': instance.locationOSMId,
-      'location_osm_type': _$LocationOSMTypeEnumMap[instance.locationOSMType]!,
+      'location_osm_type': _$LocationOSMTypeEnumMap[instance.locationOSMType],
       'date': instance.date.toIso8601String(),
       'proof_id': instance.proofId,
       'id': instance.id,
@@ -69,6 +72,17 @@ Map<String, dynamic> _$PriceToJson(Price instance) => <String, dynamic>{
       'created': instance.created.toIso8601String(),
       'updated': instance.updated?.toIso8601String(),
     };
+
+const _$DiscountTypeEnumMap = {
+  DiscountType.quantity: 'QUANTITY',
+  DiscountType.sale: 'SALE',
+  DiscountType.seasonal: 'SEASONAL',
+  DiscountType.loyaltyProgram: 'LOYALTY_PROGRAM',
+  DiscountType.expiresSoon: 'EXPIRES_SOON',
+  DiscountType.pickItYourself: 'PICK_IT_YOURSELF',
+  DiscountType.secondHand: 'SECOND_HAND',
+  DiscountType.other: 'OTHER',
+};
 
 const _$PricePerEnumMap = {
   PricePer.unit: 'UNIT',

--- a/lib/src/prices/update_price_parameters.dart
+++ b/lib/src/prices/update_price_parameters.dart
@@ -1,5 +1,6 @@
 import '../interface/json_object.dart';
 import 'currency.dart';
+import 'discount_type.dart';
 import 'get_parameters_helper.dart';
 import 'price_per.dart';
 
@@ -16,6 +17,9 @@ class UpdatePriceParameters extends JsonObject {
   /// Price of the product, without discount, taxes included.
   num? priceWithoutDiscount;
 
+  /// Discount Type.
+  DiscountType? discountType;
+
   /// Price per unit, kilogram, ..?
   PricePer? pricePer;
 
@@ -31,9 +35,15 @@ class UpdatePriceParameters extends JsonObject {
   @override
   Map<String, dynamic> toJson() => <String, dynamic>{
         if (pricePer != null) 'price_per': pricePer!.offTag,
-        if (priceWithoutDiscount != null)
-          'price_without_discount': priceWithoutDiscount,
         if (priceIsDiscounted != null) 'price_is_discounted': priceIsDiscounted,
+        if (priceIsDiscounted == false)
+          'discount_type': null
+        else if (discountType != null)
+          'discount_type': discountType!.offTag,
+        if (priceIsDiscounted == false)
+          'price_without_discount': null
+        else if (priceWithoutDiscount != null)
+          'price_without_discount': priceWithoutDiscount,
         if (price != null) 'price': price,
         if (currency != null) 'currency': currency!.name,
         if (date != null) 'date': GetParametersHelper.formatDate(date!),


### PR DESCRIPTION
### What
- OSM fields are now considered as nullable for Price as we can have online shops. Expecting non-nullable values caused crashes.
- _En passant_, added Price field `discountType`.

### Fixes bug(s)
- Fixes: #1045

### Files
New file:
* `discount_type.dart`: Discount Type, for Prices.

Impacted files:
* `api_prices_test.dart`: added specific test for issue 1045; new test for `getPrice`
* `open_prices_api_client.dart`: new `getPrice` method; added `discountType` to `createPrice` method
* `openfoodfacts.dart`: added new file `discount_type.dart`
* `price.dart`: fixed OSM related fields as nullable; added `discountType` field
* `price.g.dart`: generated
* `update_price_parameters.dart`: added `discountType` field and related business rules