### PR TITLE
feat: added is_in_taxonomy field to ingredient

### DIFF
--- a/lib/src/model/ingredient.dart
+++ b/lib/src/model/ingredient.dart
@@ -17,6 +17,12 @@ class Ingredient extends JsonObject {
   @JsonKey()
   String? text;
 
+  @JsonKey(
+      name: 'is_in_taxonomy',
+      includeIfNull: false,
+      fromJson: JsonObject.parseBool)
+  bool? isInTaxonomy;
+
   @JsonKey(includeIfNull: false, fromJson: JsonObject.parseDouble)
   double? percent;
 
@@ -57,6 +63,7 @@ class Ingredient extends JsonObject {
       {this.rank,
       this.id,
       this.text,
+      this.isInTaxonomy,
       this.percent,
       this.percentEstimate,
       this.vegan,
@@ -76,6 +83,7 @@ class Ingredient extends JsonObject {
       '${id == null ? '' : 'id=$id'}'
       '${rank == null ? '' : ',rank=$rank'}'
       '${text == null ? '' : ',text=$text'}'
+      '${isInTaxonomy == null ? '' : ',isInTaxonomy=$isInTaxonomy'}'
       '${percent == null ? '' : ',percent=$percent'}'
       '${percentEstimate == null ? '' : ',percentEstimate=$percentEstimate'}'
       '${vegan == null ? '' : ',vegan=$vegan'}'

--- a/lib/src/model/ingredient.g.dart
+++ b/lib/src/model/ingredient.g.dart
@@ -10,6 +10,7 @@ Ingredient _$IngredientFromJson(Map<String, dynamic> json) => Ingredient(
       rank: JsonObject.parseInt(json['rank']),
       id: json['id'] as String?,
       text: json['text'] as String?,
+      isInTaxonomy: JsonObject.parseBool(json['is_in_taxonomy']),
       percent: JsonObject.parseDouble(json['percent']),
       percentEstimate: JsonObject.parseDouble(json['percent_estimate']),
       vegan: ingredientSpecialPropertyStatusFromJson(json['vegan']),
@@ -34,6 +35,7 @@ Map<String, dynamic> _$IngredientToJson(Ingredient instance) {
   writeNotNull('rank', instance.rank);
   writeNotNull('id', instance.id);
   val['text'] = instance.text;
+  writeNotNull('is_in_taxonomy', instance.isInTaxonomy);
   writeNotNull('percent', instance.percent);
   writeNotNull('percent_estimate', instance.percentEstimate);
   writeNotNull('vegan', ingredientSpecialPropertyStatusToJson(instance.vegan));

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -911,6 +911,7 @@ void main() {
       final Ingredient ingredient = result.product!.ingredients!.firstWhere(
         (ingredient) => ingredient.text == 'huile de palme',
       );
+      expect(ingredient.isInTaxonomy, true);
       expect(ingredient.vegan, IngredientSpecialPropertyStatus.POSITIVE);
       expect(ingredient.vegetarian, IngredientSpecialPropertyStatus.POSITIVE);
       expect(ingredient.fromPalmOil, IngredientSpecialPropertyStatus.POSITIVE);


### PR DESCRIPTION
### What
Add `is_in_taxonomy` to the Ingredient object.

[This flag was added Apr 19, 2024 to the server](https://github.com/openfoodfacts/openfoodfacts-server/commit/bb240bcf5e6b23f0ee232327f69f9c7f28bdc0a6) but not yet integrated here.

### Related to
https://github.com/openfoodfacts/openfoodfacts-dart/issues/1050
