### PR TITLE
feat: 1066 - new parameters for proof upload

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -106,6 +106,8 @@ export 'src/prices/get_locations_result.dart';
 
 // export 'src/prices/get_parameters_helper.dart'; // uncomment if really needed
 export 'src/prices/contribution_kind.dart';
+export 'src/prices/common_proof_parameters.dart';
+export 'src/prices/create_proof_parameters.dart';
 export 'src/prices/get_prices_order.dart';
 export 'src/prices/get_prices_parameters.dart';
 export 'src/prices/get_price_products_order.dart';

--- a/lib/src/open_prices_api_client.dart
+++ b/lib/src/open_prices_api_client.dart
@@ -515,18 +515,18 @@ class OpenPricesAPIClient {
 
 // TODO: deprecated from 2025-04-25 regarding single parameters; remove them when old enough
   static Future<MaybeError<Proof>> uploadProof({
-    @Deprecated('Use UploadProofParameters instead') final ProofType? proofType,
+    @Deprecated('Use CreateProofParameters instead') final ProofType? proofType,
     required final Uri imageUri,
     required final MediaType mediaType,
     final CreateProofParameters? createProofParameters,
-    @Deprecated('Use UploadProofParameters instead') final int? locationOSMId,
-    @Deprecated('Use UploadProofParameters instead')
+    @Deprecated('Use CreateProofParameters instead') final int? locationOSMId,
+    @Deprecated('Use CreateProofParameters instead')
     final LocationOSMType? locationOSMType,
-    @Deprecated('Use UploadProofParameters instead') final DateTime? date,
-    @Deprecated('Use UploadProofParameters instead') final Currency? currency,
-    @Deprecated('Use UploadProofParameters instead')
+    @Deprecated('Use CreateProofParameters instead') final DateTime? date,
+    @Deprecated('Use CreateProofParameters instead') final Currency? currency,
+    @Deprecated('Use CreateProofParameters instead')
     final int? receiptPriceCount,
-    @Deprecated('Use UploadProofParameters instead')
+    @Deprecated('Use CreateProofParameters instead')
     final num? receiptPriceTotal,
     required final String bearerToken,
     final UriProductHelper uriHelper = uriHelperFoodProd,

--- a/lib/src/prices/common_proof_parameters.dart
+++ b/lib/src/prices/common_proof_parameters.dart
@@ -1,0 +1,60 @@
+import '../interface/json_object.dart';
+import 'currency.dart';
+import 'get_parameters_helper.dart';
+import 'location_osm_type.dart';
+import 'proof_type.dart';
+
+/// Common parameters for the "upload and update proof" API queries.
+///
+/// cf. https://prices.openfoodfacts.org/api/docs
+abstract class CommonProofParameters extends JsonObject {
+  /// Proof type.
+  ProofType? get type;
+
+  /// Date when the product was bought.
+  DateTime? date;
+
+  /// Currency of the price.
+  Currency? currency;
+
+  /// ID of the location in OpenStreetMap.
+  int? locationOSMId;
+
+  /// Type of the OpenStreetMap location object.
+  LocationOSMType? locationOSMType;
+
+  /// Receipt's number of prices.
+  int? receiptPriceCount;
+
+  /// Receipt's total amount (user input).
+  num? receiptPriceTotal;
+
+  num? receiptOnlineDeliveryCosts;
+
+  bool? readyForPriceTagValidation;
+
+  bool? ownerConsumption;
+
+  String? ownerComment;
+
+  int? locationId;
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        if (type != null) 'type': type!.offTag,
+        if (date != null) 'date': GetParametersHelper.formatDate(date!),
+        if (currency != null) 'currency': currency!.name,
+        if (locationOSMId != null) 'location_osm_id': locationOSMId,
+        if (locationOSMType != null)
+          'location_osm_type': locationOSMType!.offTag,
+        if (receiptPriceCount != null) 'receipt_price_count': receiptPriceCount,
+        if (receiptPriceTotal != null) 'receipt_price_total': receiptPriceTotal,
+        if (receiptOnlineDeliveryCosts != null)
+          'receipt_online_delivery_costs': receiptOnlineDeliveryCosts,
+        if (readyForPriceTagValidation != null)
+          'ready_for_price_tag_validation': readyForPriceTagValidation,
+        if (ownerConsumption != null) 'owner_consumption': ownerConsumption,
+        if (ownerComment != null) 'owner_comment': ownerComment,
+        if (locationId != null) 'location_id': locationId,
+      };
+}

--- a/lib/src/prices/create_proof_parameters.dart
+++ b/lib/src/prices/create_proof_parameters.dart
@@ -1,0 +1,12 @@
+import 'common_proof_parameters.dart';
+import 'proof_type.dart';
+
+/// Parameters for the "upload proof" API query.
+///
+/// cf. https://prices.openfoodfacts.org/api/docs
+class CreateProofParameters extends CommonProofParameters {
+  CreateProofParameters(this.type);
+
+  @override
+  final ProofType type;
+}

--- a/lib/src/prices/proof.dart
+++ b/lib/src/prices/proof.dart
@@ -94,6 +94,18 @@ class Proof extends JsonObject {
   @JsonKey()
   Location? location;
 
+  @JsonKey(name: 'receipt_online_delivery_costs')
+  num? receiptOnlineDeliveryCosts;
+
+  @JsonKey(name: 'ready_for_price_tag_validation')
+  bool? readyForPriceTagValidation;
+
+  @JsonKey(name: 'owner_consumption')
+  bool? ownerConsumption;
+
+  @JsonKey(name: 'owner_comment')
+  String? ownerComment;
+
   Proof();
 
   factory Proof.fromJson(Map<String, dynamic> json) => _$ProofFromJson(json);

--- a/lib/src/prices/proof.g.dart
+++ b/lib/src/prices/proof.g.dart
@@ -26,7 +26,11 @@ Proof _$ProofFromJson(Map<String, dynamic> json) => Proof()
   ..updated = JsonHelper.nullableStringTimestampToDate(json['updated'])
   ..location = json['location'] == null
       ? null
-      : Location.fromJson(json['location'] as Map<String, dynamic>);
+      : Location.fromJson(json['location'] as Map<String, dynamic>)
+  ..receiptOnlineDeliveryCosts = json['receipt_online_delivery_costs'] as num?
+  ..readyForPriceTagValidation = json['ready_for_price_tag_validation'] as bool?
+  ..ownerConsumption = json['owner_consumption'] as bool?
+  ..ownerComment = json['owner_comment'] as String?;
 
 Map<String, dynamic> _$ProofToJson(Proof instance) => <String, dynamic>{
       'id': instance.id,
@@ -46,6 +50,10 @@ Map<String, dynamic> _$ProofToJson(Proof instance) => <String, dynamic>{
       'created': instance.created.toIso8601String(),
       'updated': instance.updated?.toIso8601String(),
       'location': instance.location,
+      'receipt_online_delivery_costs': instance.receiptOnlineDeliveryCosts,
+      'ready_for_price_tag_validation': instance.readyForPriceTagValidation,
+      'owner_consumption': instance.ownerConsumption,
+      'owner_comment': instance.ownerComment,
     };
 
 const _$ProofTypeEnumMap = {

--- a/lib/src/prices/update_proof_parameters.dart
+++ b/lib/src/prices/update_proof_parameters.dart
@@ -1,43 +1,10 @@
-import '../interface/json_object.dart';
-import 'currency.dart';
-import 'get_parameters_helper.dart';
-import 'location_osm_type.dart';
+import 'common_proof_parameters.dart';
 import 'proof_type.dart';
 
 /// Parameters for the "update proof" API query.
 ///
 /// cf. https://prices.openfoodfacts.org/api/docs
-class UpdateProofParameters extends JsonObject {
-  /// Proof type.
-  ProofType? type;
-
-  /// Date when the product was bought.
-  DateTime? date;
-
-  /// Currency of the price.
-  Currency? currency;
-
-  /// ID of the location in OpenStreetMap.
-  int? locationOSMId;
-
-  /// Type of the OpenStreetMap location object.
-  LocationOSMType? locationOSMType;
-
-  /// Receipt's number of prices.
-  int? receiptPriceCount;
-
-  /// Receipt's total amount (user input).
-  num? receiptPriceTotal;
-
+class UpdateProofParameters extends CommonProofParameters {
   @override
-  Map<String, dynamic> toJson() => <String, dynamic>{
-        if (type != null) 'type': type!.offTag,
-        if (date != null) 'date': GetParametersHelper.formatDate(date!),
-        if (currency != null) 'currency': currency!.name,
-        if (locationOSMId != null) 'location_osm_id': locationOSMId,
-        if (locationOSMType != null)
-          'location_osm_type': locationOSMType!.offTag,
-        if (receiptPriceCount != null) 'receipt_price_count': receiptPriceCount,
-        if (receiptPriceTotal != null) 'receipt_price_total': receiptPriceTotal,
-      };
+  ProofType? type;
 }

--- a/test/api_prices_test.dart
+++ b/test/api_prices_test.dart
@@ -6,10 +6,84 @@ import 'package:test/test.dart';
 import 'test_constants.dart';
 
 void main() {
+  const User user = TestConstants.TEST_USER;
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
   const int HTTP_OK = 200;
   const int pageNumber = 1;
   const int pageSize = 20;
+
+  // TODO(monsieurtanuki): more relevant image if possible
+  final Uri initialImageUri = Uri.file('test/test_assets/ingredients_en.jpg');
+  final MediaType initialMediaType =
+      HttpHelper().imagineMediaType(initialImageUri.path)!;
+
+  Future<String> getBearerToken({
+    required final UriProductHelper uriHelper,
+  }) async {
+    final MaybeError<String> token =
+        await OpenPricesAPIClient.getAuthenticationToken(
+      username: user.userId,
+      password: user.password,
+      uriHelper: uriHelper,
+    );
+    expect(token.isError, isFalse);
+    expect(token.value, isNotEmpty);
+    return token.value;
+  }
+
+  Future<void> closeSession({
+    required final String bearerToken,
+    required final UriProductHelper uriHelper,
+  }) async {
+    MaybeError<bool> deleting = await OpenPricesAPIClient.deleteUserSession(
+      uriHelper: uriHelper,
+      bearerToken: bearerToken,
+    );
+    expect(deleting.isError, isFalse);
+    expect(deleting.value, isTrue);
+
+    deleting = await OpenPricesAPIClient.deleteUserSession(
+      uriHelper: uriHelper,
+      bearerToken: bearerToken,
+    );
+    expect(deleting.isError, isTrue);
+    expect(deleting.statusCode, Session.invalidActionWithAuthStatusCode);
+    expect(
+        deleting.detailError, contains(Session.invalidActionWithAuthMessage));
+  }
+
+  Future<void> deleteProofAndCloseSession({
+    required final int proofId,
+    required final String bearerToken,
+    required final UriProductHelper uriHelper,
+  }) async {
+    // delete proof first time: success
+    MaybeError<bool> deletedProof = await OpenPricesAPIClient.deleteProof(
+      proofId: proofId,
+      bearerToken: bearerToken,
+      uriHelper: uriHelper,
+    );
+    expect(deletedProof.isError, isFalse);
+    expect(deletedProof.value, isTrue);
+
+    // delete proof second time: failure
+    deletedProof = await OpenPricesAPIClient.deleteProof(
+      proofId: proofId,
+      bearerToken: bearerToken,
+      uriHelper: uriHelper,
+    );
+    expect(deletedProof.isError, isTrue);
+    expect(deletedProof.statusCode, 404);
+    expect(
+      deletedProof.detailError,
+      'No Proof matches the given query.',
+    );
+
+    await closeSession(
+      bearerToken: bearerToken,
+      uriHelper: uriHelper,
+    );
+  }
 
   group('$OpenPricesAPIClient default', () {
     const UriProductHelper uriHelper = uriHelperFoodProd;
@@ -111,15 +185,7 @@ void main() {
     });
 
     test('existing user', () async {
-      final MaybeError<String> token =
-          await OpenPricesAPIClient.getAuthenticationToken(
-        username: user.userId,
-        password: user.password,
-        uriHelper: uriHelper,
-      );
-      expect(token.isError, isFalse);
-      expect(token.value, isNotEmpty);
-      final String bearerToken = token.value;
+      final String bearerToken = await getBearerToken(uriHelper: uriHelper);
 
       MaybeError<Session> session = await OpenPricesAPIClient.getUserSession(
         uriHelper: uriHelper,
@@ -128,21 +194,10 @@ void main() {
       expect(session.isError, isFalse);
       expect(session.value.userId, user.userId);
 
-      MaybeError<bool> deleting = await OpenPricesAPIClient.deleteUserSession(
-        uriHelper: uriHelper,
+      await closeSession(
         bearerToken: bearerToken,
-      );
-      expect(deleting.isError, isFalse);
-      expect(deleting.value, isTrue);
-
-      deleting = await OpenPricesAPIClient.deleteUserSession(
         uriHelper: uriHelper,
-        bearerToken: bearerToken,
       );
-      expect(deleting.isError, isTrue);
-      expect(deleting.statusCode, Session.invalidActionWithAuthStatusCode);
-      expect(
-          deleting.detailError, contains(Session.invalidActionWithAuthMessage));
 
       session = await OpenPricesAPIClient.getUserSession(
         uriHelper: uriHelper,
@@ -189,81 +244,27 @@ void main() {
       expect(addedPrice.detailError,
           contains(Session.invalidActionWithAuthMessage));
 
-      final ProofType uploadProofType = ProofType.receipt;
-      const Currency uploadCurrency = Currency.EUR;
-      final DateTime uploadDate = DateTime(2024, 1, 1);
+      final CreateProofParameters createProofParameters =
+          CreateProofParameters(ProofType.priceTag)
+            ..currency = Currency.EUR
+            ..ownerComment = 'just trying'
+            ..date = DateTime(2024, 1, 1);
 
-      final UpdateProofParameters updateProofParameters =
-          UpdateProofParameters()
-            ..type = ProofType.receipt
-            ..currency = Currency.USD
-            ..receiptPriceCount = 72
-            ..receiptPriceTotal = 1.75
-            ..date = DateTime(2024, 1, 2);
-
-      // TODO(monsieurtanuki): more relevant image if possible
-      final Uri initialImageUri =
-          Uri.file('test/test_assets/ingredients_en.jpg');
-      final MediaType initialMediaType =
-          HttpHelper().imagineMediaType(initialImageUri.path)!;
-
-      // authentication
-      final MaybeError<String> token =
-          await OpenPricesAPIClient.getAuthenticationToken(
-        username: user.userId,
-        password: user.password,
-        uriHelper: uriHelper,
-      );
-      expect(token.isError, isFalse);
-      expect(token.value, isNotEmpty);
-      final String bearerToken = token.value;
+      final String bearerToken = await getBearerToken(uriHelper: uriHelper);
 
       // successful proof upload with valid token
       final MaybeError<Proof> uploadProof =
           await OpenPricesAPIClient.uploadProof(
-        proofType: uploadProofType,
+        createProofParameters: createProofParameters,
         imageUri: initialImageUri,
         mediaType: initialMediaType,
-        currency: uploadCurrency,
-        date: uploadDate,
         bearerToken: bearerToken,
         uriHelper: uriHelper,
       );
       expect(uploadProof.isError, isFalse);
-      expect(uploadProof.value.type, uploadProofType);
-      expect(uploadProof.value.owner, user.userId);
       expect(uploadProof.value.id, isNotNull);
-      expect(uploadProof.value.priceCount, 0);
-      expect(uploadProof.value.mimetype, initialMediaType.toString());
-      expect(uploadProof.value.currency, uploadCurrency);
-      expect(uploadProof.value.date, uploadDate);
 
       final int proofId = uploadProof.value.id;
-
-      // successful proof update
-      MaybeError<bool> updateProof = await OpenPricesAPIClient.updateProof(
-        proofId,
-        parameters: updateProofParameters,
-        bearerToken: bearerToken,
-        uriHelper: uriHelper,
-      );
-      expect(updateProof.isError, isFalse);
-
-      final MaybeError<Proof> maybeProof = await OpenPricesAPIClient.getProof(
-        proofId,
-        uriHelper: uriHelper,
-        bearerToken: bearerToken,
-      );
-      expect(maybeProof.isError, isFalse);
-      expect(maybeProof.value.id, proofId);
-      expect(maybeProof.value.type, updateProofParameters.type);
-      expect(maybeProof.value.date, updateProofParameters.date);
-      expect(maybeProof.value.currency, updateProofParameters.currency);
-      expect(maybeProof.value.receiptPriceCount,
-          updateProofParameters.receiptPriceCount);
-      expect(maybeProof.value.receiptPriceTotal,
-          updateProofParameters.receiptPriceTotal);
-
       initialPrice.proofId = proofId;
 
       // failing price creation with valid token but invalid dates
@@ -275,8 +276,8 @@ void main() {
       expect(addedPrice.isError, isTrue);
 
       // successful price creation
-      initialPrice.date = updateProofParameters.date!;
-      initialPrice.currency = updateProofParameters.currency!;
+      initialPrice.date = createProofParameters.date!;
+      initialPrice.currency = createProofParameters.currency!;
       addedPrice = await OpenPricesAPIClient.createPrice(
         price: initialPrice,
         bearerToken: bearerToken,
@@ -344,36 +345,11 @@ void main() {
         'No Price matches the given query.',
       );
 
-      // delete proof first time: success
-      MaybeError<bool> deletedProof = await OpenPricesAPIClient.deleteProof(
+      await deleteProofAndCloseSession(
         proofId: proofId,
         bearerToken: bearerToken,
         uriHelper: uriHelper,
       );
-      expect(deletedProof.isError, isFalse);
-      expect(deletedProof.value, isTrue);
-
-      // delete proof second time: failure
-      deletedProof = await OpenPricesAPIClient.deleteProof(
-        proofId: proofId,
-        bearerToken: bearerToken,
-        uriHelper: uriHelper,
-      );
-      expect(deletedProof.isError, isTrue);
-      expect(deletedProof.statusCode, 404);
-      expect(
-        deletedProof.detailError,
-        'No Proof matches the given query.',
-      );
-
-      // close session
-      final MaybeError<bool> closedSession =
-          await OpenPricesAPIClient.deleteUserSession(
-        uriHelper: uriHelper,
-        bearerToken: bearerToken,
-      );
-      expect(closedSession.isError, isFalse);
-      expect(closedSession.value, isTrue);
     }, timeout: Timeout(Duration(seconds: 60)));
 
     test('get prices', () async {
@@ -838,7 +814,119 @@ void main() {
 
   group('$OpenPricesAPIClient Proofs', () {
     const UriProductHelper uriHelper = uriHelperFoodTest;
-    const User user = TestConstants.TEST_USER;
+
+    void checkProof(
+      final Proof proof,
+      final CommonProofParameters parameters,
+    ) {
+      expect(proof.type, parameters.type);
+      expect(proof.owner, user.userId);
+      expect(proof.id, isNotNull);
+      expect(proof.priceCount, 0);
+      expect(proof.mimetype, initialMediaType.toString());
+      expect(proof.currency, parameters.currency);
+      expect(proof.date, parameters.date);
+      expect(proof.locationOSMId, parameters.locationOSMId);
+      expect(proof.locationOSMType, parameters.locationOSMType);
+      expect(proof.locationId, parameters.locationId);
+      expect(proof.ownerComment, parameters.ownerComment);
+      if (proof.type == ProofType.receipt) {
+        expect(proof.receiptPriceCount, parameters.receiptPriceCount);
+        expect(proof.receiptPriceTotal, parameters.receiptPriceTotal);
+        expect(proof.receiptOnlineDeliveryCosts,
+            parameters.receiptOnlineDeliveryCosts);
+        expect(proof.ownerConsumption, parameters.ownerConsumption);
+      }
+      if (proof.type == ProofType.priceTag) {
+        expect(proof.readyForPriceTagValidation,
+            parameters.readyForPriceTagValidation);
+      }
+    }
+
+    Future<void> checkProofParameters(
+      final CreateProofParameters createProofParameters,
+      final UpdateProofParameters updateProofParameters,
+    ) async {
+      final String bearerToken = await getBearerToken(uriHelper: uriHelper);
+
+      // successful proof upload with valid token
+      final MaybeError<Proof> uploadProof =
+          await OpenPricesAPIClient.uploadProof(
+        createProofParameters: createProofParameters,
+        imageUri: initialImageUri,
+        mediaType: initialMediaType,
+        bearerToken: bearerToken,
+        uriHelper: uriHelper,
+      );
+      expect(uploadProof.isError, isFalse);
+      checkProof(uploadProof.value, createProofParameters);
+
+      final int proofId = uploadProof.value.id;
+
+      // successful proof update
+      MaybeError<bool> updateProof = await OpenPricesAPIClient.updateProof(
+        proofId,
+        parameters: updateProofParameters,
+        bearerToken: bearerToken,
+        uriHelper: uriHelper,
+      );
+      expect(updateProof.isError, isFalse);
+
+      final MaybeError<Proof> maybeProof = await OpenPricesAPIClient.getProof(
+        proofId,
+        uriHelper: uriHelper,
+        bearerToken: bearerToken,
+      );
+      expect(maybeProof.isError, isFalse);
+      expect(maybeProof.value.id, proofId);
+      checkProof(maybeProof.value, updateProofParameters);
+
+      await deleteProofAndCloseSession(
+        proofId: proofId,
+        bearerToken: bearerToken,
+        uriHelper: uriHelper,
+      );
+    }
+
+    test(
+      'upload and update PRICE TAG',
+      () async => checkProofParameters(
+        CreateProofParameters(ProofType.priceTag)
+          ..currency = Currency.EUR
+          ..ownerComment = 'just trying'
+          ..date = DateTime(2024, 1, 1)
+          ..readyForPriceTagValidation = true,
+        UpdateProofParameters()
+          ..type = ProofType.priceTag
+          ..currency = Currency.USD
+          ..ownerComment = 'nothing in the end'
+          ..date = DateTime(2024, 1, 2)
+          ..readyForPriceTagValidation = false,
+      ),
+    );
+
+    test(
+      'upload and update RECEIPT',
+      () async => checkProofParameters(
+        CreateProofParameters(ProofType.receipt)
+          ..currency = Currency.EUR
+          ..ownerComment = 'just trying'
+          ..date = DateTime(2024, 1, 1)
+          ..receiptPriceCount = 77
+          ..receiptPriceTotal = 1.75
+          ..receiptOnlineDeliveryCosts = 14
+          ..ownerConsumption = false,
+        UpdateProofParameters()
+          ..type = ProofType.receipt
+          ..currency = Currency.USD
+          ..ownerComment = 'nothing in the end'
+          ..date = DateTime(2024, 1, 2)
+          ..receiptPriceCount = 72
+          ..receiptPriceTotal = 1.75
+          ..receiptOnlineDeliveryCosts = 15
+          ..ownerConsumption = true,
+      ),
+    );
 
     test('image file media type', () async {
       final Map<String, MediaType> expectedMediaTypes = <String, MediaType>{
@@ -861,15 +949,7 @@ void main() {
 
       late GetProofsResult result;
 
-      final MaybeError<String> token =
-          await OpenPricesAPIClient.getAuthenticationToken(
-        username: user.userId,
-        password: user.password,
-        uriHelper: uriHelper,
-      );
-      expect(token.isError, isFalse);
-      expect(token.value, isNotEmpty);
-      final String bearerToken = token.value;
+      final String bearerToken = await getBearerToken(uriHelper: uriHelper);
 
       // oldest first
       GetProofsParameters parameters = GetProofsParameters()


### PR DESCRIPTION
### What
- Added 5 parameters for proof upload and update.
- Among them, `readyForPriceTagValidation` that is needed for bulk proof upload in Smoothie.
- Added 4 fields for proofs.
- Now sharing a common structure for proof upload and update parameters, offering more flexibility and code consistency.

### Fixes bug(s)
- Closes: #1066

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/6560

### Files
New files:
* `common_proof_parameters.dart`: Common parameters for the "upload and update proof" API queries, including 5 new fields.
* `create_proof_parameters.dart`: Parameters for the "upload proof" API query.

Impacted files:
* `api_prices_test.dart`: added more tests around proof upload and update; refactored accordingly
* `open_prices_api_client.dart`: changed the parameters of `uploadProof` for more flexibility
* `openfoodfacts.dart`: added the 2 new files
* `proof.dart`: added 4 missing fields
* `proof.g.dart`: generated
* `update_proof_parameters.dart`: moved code to `CommonProofParameters`