### PR TITLE
fix: 1038 - feedback for incorrect packaging numbers

### DIFF
--- a/lib/src/model/product_result_field.dart
+++ b/lib/src/model/product_result_field.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import '../interface/json_object.dart';
 
 part 'product_result_field.g.dart';
@@ -11,11 +12,27 @@ class ProductResultField extends JsonObject {
   @JsonKey(includeIfNull: false)
   String? id;
 
-  @JsonKey(includeIfNull: false)
+  /// Value sent by the user, here converted to String.
+  @JsonKey(
+    includeIfNull: false,
+    fromJson: JsonHelper.stringFromJSON,
+  )
   String? value;
 
-  @JsonKey(name: 'default_value', includeIfNull: false)
+  @JsonKey(
+    name: 'default_value',
+    includeIfNull: false,
+    fromJson: JsonHelper.stringFromJSON,
+  )
   String? defaultValue;
+
+  /// Value actually used by the server, here converted to String.
+  @JsonKey(
+    name: 'valued_converted',
+    includeIfNull: false,
+    fromJson: JsonHelper.stringFromJSON,
+  )
+  String? valuedConverted;
 
   factory ProductResultField.fromJson(Map<String, dynamic> json) =>
       _$ProductResultFieldFromJson(json);

--- a/lib/src/model/product_result_field.g.dart
+++ b/lib/src/model/product_result_field.g.dart
@@ -9,8 +9,9 @@ part of 'product_result_field.dart';
 ProductResultField _$ProductResultFieldFromJson(Map<String, dynamic> json) =>
     ProductResultField()
       ..id = json['id'] as String?
-      ..value = json['value'] as String?
-      ..defaultValue = json['default_value'] as String?;
+      ..value = JsonHelper.stringFromJSON(json['value'])
+      ..defaultValue = JsonHelper.stringFromJSON(json['default_value'])
+      ..valuedConverted = JsonHelper.stringFromJSON(json['valued_converted']);
 
 Map<String, dynamic> _$ProductResultFieldToJson(ProductResultField instance) {
   final val = <String, dynamic>{};
@@ -24,5 +25,6 @@ Map<String, dynamic> _$ProductResultFieldToJson(ProductResultField instance) {
   writeNotNull('id', instance.id);
   writeNotNull('value', instance.value);
   writeNotNull('default_value', instance.defaultValue);
+  writeNotNull('valued_converted', instance.valuedConverted);
   return val;
 }

--- a/lib/src/utils/json_helper.dart
+++ b/lib/src/utils/json_helper.dart
@@ -450,4 +450,7 @@ class JsonHelper {
     }
     return 0;
   }
+
+  /// Returns a String?, regardless of the input type.
+  static String? stringFromJSON(dynamic jsonValue) => jsonValue?.toString();
 }

--- a/test/api_save_product_v3_test.dart
+++ b/test/api_save_product_v3_test.dart
@@ -118,5 +118,72 @@ void main() {
         expect(readStatus.product!.packagingsComplete, value);
       }
     });
-  }, skip: 'Avoiding tests on TEST env');
+
+    test('reproducing issue 1038', () async {
+      // Check it's ok if we get numbers instead of String? as warning/error values.
+      const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
+      const int numberOfUnits = -12;
+      const double weightMeasured = -250;
+      final List<ProductPackaging> inputPackagings = [
+        ProductPackaging()
+          ..shape = (LocalizedTag()..lcName = 'bouteille')
+          ..material = (LocalizedTag()..lcName = 'verre')
+          ..recycling = (LocalizedTag()..lcName = 'bac de tri')
+          ..numberOfUnits = numberOfUnits
+          ..weightMeasured = weightMeasured,
+      ];
+      final ProductResultV3 status =
+          await OpenFoodAPIClient.temporarySaveProductV3(
+        TestConstants.TEST_USER,
+        barcode,
+        uriHelper: uriHelper,
+        country: country,
+        language: language,
+        packagings: inputPackagings,
+      );
+
+      expect(status.status, ProductResultV3.statusWarning);
+      expect(status.errors, isEmpty);
+      expect(status.result, isNull); // result is null for UPDATE queries
+      expect(status.barcode, barcode);
+      expect(status.product, isNotNull);
+
+      expect(status.product!.packagings, isNotNull);
+      final List<ProductPackaging> packagings = status.product!.packagings!;
+      expect(packagings, hasLength(1));
+      final ProductPackaging packaging = packagings.first;
+      // we send crap data, we get "corrected" results.
+      expect(packaging.numberOfUnits, isNull);
+      expect(packaging.weightMeasured, 0);
+
+      expect(status.warnings, isNotEmpty);
+      expect(status.warnings, hasLength(2));
+
+      for (final ProductResultFieldAnswer answer in status.warnings!) {
+        expect(answer.field, isNotNull);
+        expect(answer.impact, isNotNull);
+        expect(answer.message, isNotNull);
+        if (answer.field!.id == 'number_of_units') {
+          expect(answer.field!.value, numberOfUnits.toString());
+          expect(answer.impact!.id, 'field_ignored');
+          expect(answer.impact!.name, isNotNull);
+          expect(answer.impact!.lcName, isNotNull);
+          expect(answer.message!.id, 'invalid_type_must_be_integer');
+          expect(answer.message!.name, isNotNull);
+          expect(answer.message!.lcName, isNotNull);
+        } else if (answer.field!.id == 'weight_measured') {
+          expect(answer.field!.value, weightMeasured.toString());
+          expect(answer.field!.valuedConverted, 0.toString());
+          expect(answer.impact!.id, 'value_converted');
+          expect(answer.impact!.name, isNotNull);
+          expect(answer.impact!.lcName, isNotNull);
+          expect(answer.message!.id, 'invalid_type_must_be_number');
+          expect(answer.message!.name, isNotNull);
+          expect(answer.message!.lcName, isNotNull);
+        } else {
+          fail('Unexpected field id: ${answer.field!.id}');
+        }
+      }
+    });
+  });
 }


### PR DESCRIPTION
### What
- When we save packagings data, we use the v3 of the save product API.
- In this version, when there'a an error or a warning, we get a detailed feedback, including the input value.
- The problem was that if we sent incorrect numbers (e.g. negative weight), those numbers were sent back but we expected `String?`, which is an incorrect cast.
- The fix is to convert explicitly those feedback numbers to `String?`.

### Fixes bug(s)
- Closes: #1038

### Impacted files
* `api_save_product_v3_test.dart`: added a test specific to incorrect numbers sent by the user
* `json_helper.dart`: added a method for an explicit conversion to `String?`
* `product_result_field.dart`: explicit conversion to `String?` for some fields; added field `valuedConverted`
* `product_result_field.g.dart`: generated