### PR TITLE
feat: add percentage type and name field to TitleElement

### DIFF
--- a/lib/src/model/knowledge_panel.dart
+++ b/lib/src/model/knowledge_panel.dart
@@ -59,6 +59,8 @@ enum TitleElementType {
   // Title Element depicts a grade like 'Eco-Score' or 'Nutri-Score'.
   @JsonValue('grade')
   GRADE,
+  @JsonValue('percentage')
+  PERCENTAGE,
   UNKNOWN,
 }
 
@@ -133,6 +135,9 @@ class TitleElement extends JsonObject {
   /// Title string of the panel. Example - 'Eco-Score D'.
   final String title;
 
+  /// A short name of this panel, not including any actual values.
+  final String? name;
+
   /// Subtitle of the panel. Example - 'High environmental impact'.
   final String? subtitle;
 
@@ -159,6 +164,7 @@ class TitleElement extends JsonObject {
 
   const TitleElement({
     required this.title,
+    this.name,
     this.subtitle,
     this.grade,
     this.type,

--- a/lib/src/model/knowledge_panel.g.dart
+++ b/lib/src/model/knowledge_panel.g.dart
@@ -64,6 +64,7 @@ const _$KnowledgePanelSizeEnumMap = {
 
 TitleElement _$TitleElementFromJson(Map<String, dynamic> json) => TitleElement(
       title: json['title'] as String,
+      name: json['name'] as String?,
       subtitle: json['subtitle'] as String?,
       grade: $enumDecodeNullable(_$GradeEnumMap, json['grade'],
           unknownValue: Grade.UNKNOWN),
@@ -77,6 +78,7 @@ TitleElement _$TitleElementFromJson(Map<String, dynamic> json) => TitleElement(
 Map<String, dynamic> _$TitleElementToJson(TitleElement instance) =>
     <String, dynamic>{
       'title': instance.title,
+      'name': instance.name,
       'subtitle': instance.subtitle,
       'grade': _$GradeEnumMap[instance.grade],
       'type': _$TitleElementTypeEnumMap[instance.type],
@@ -95,5 +97,6 @@ const _$GradeEnumMap = {
 
 const _$TitleElementTypeEnumMap = {
   TitleElementType.GRADE: 'grade',
+  TitleElementType.PERCENTAGE: 'percentage',
   TitleElementType.UNKNOWN: 'UNKNOWN',
 };


### PR DESCRIPTION
### What
Some fields for #9683 have been missing from `TitleElement` in `KnowledgePanels`
This PR adds the `name` field and the value `PERCENTAGE` to `TitleElementType`