### PR TITLE
fix: 1099 - additional test for "folksonomy get product tag": "not found"

### DIFF
--- a/lib/src/folksonomy.dart
+++ b/lib/src/folksonomy.dart
@@ -190,7 +190,7 @@ class FolksonomyAPIClient {
       response,
       authorizedStatus: <int>[200, 404],
     );
-    if (response.body == 'null') {
+    if (response.body == 'null' || response.body == '[]') {
       // not found
       return null;
     }


### PR DESCRIPTION
### What
- Now a "not found" response for "folksonomy get product tag" may be "[]" (and not only "null").

### Fixes bug(s)
- Fixes: #1099