### PR TITLE
feat: 1055 - API versions as decimal, Product.schemaVersion

### DIFF
--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -96,6 +96,10 @@ class Product extends JsonObject {
   @JsonKey(name: 'product_type')
   ProductType? productType;
 
+  /// Server schema version (e.g. "999" for API V3).
+  @JsonKey(name: 'schema_version')
+  int? schemaVersion;
+
   /// Product name, either set directly or taken from one of the localizations.
   ///
   /// Rather use [productNameInLanguages] instead.

--- a/lib/src/model/product.g.dart
+++ b/lib/src/model/product.g.dart
@@ -103,6 +103,7 @@ Product _$ProductFromJson(Map<String, dynamic> json) => Product(
     )
       ..productType =
           $enumDecodeNullable(_$ProductTypeEnumMap, json['product_type'])
+      ..schemaVersion = (json['schema_version'] as num?)?.toInt()
       ..conservationConditionsInLanguages = LanguageHelper.fromJsonStringMap(
           json['conservation_conditions_in_languages'])
       ..customerServiceInLanguages = LanguageHelper.fromJsonStringMap(
@@ -205,6 +206,7 @@ Map<String, dynamic> _$ProductToJson(Product instance) => <String, dynamic>{
       'code': instance.barcode,
       if (_$ProductTypeEnumMap[instance.productType] case final value?)
         'product_type': value,
+      if (instance.schemaVersion case final value?) 'schema_version': value,
       if (instance.productName case final value?) 'product_name': value,
       if (LanguageHelper.toJsonStringMap(instance.productNameInLanguages)
           case final value?)

--- a/lib/src/utils/product_fields.dart
+++ b/lib/src/utils/product_fields.dart
@@ -5,6 +5,7 @@ import 'language_helper.dart';
 enum ProductField implements OffTagged {
   BARCODE(offTag: 'code'),
   PRODUCT_TYPE(offTag: 'product_type'),
+  SCHEMA_VERSION(offTag: 'schema_version'),
   NAME(
     offTag: 'product_name',
     inLanguagesProductField: ProductField.NAME_IN_LANGUAGES,

--- a/lib/src/utils/product_query_configurations.dart
+++ b/lib/src/utils/product_query_configurations.dart
@@ -8,10 +8,10 @@ import 'uri_helper.dart';
 
 /// Api version for product queries (minimum forced version number: 2).
 class ProductQueryVersion {
-  const ProductQueryVersion(final int version)
+  const ProductQueryVersion(final num version)
       : version = version < 2 ? 2 : version;
 
-  final int version;
+  final num version;
 
   static const ProductQueryVersion v3 = ProductQueryVersion(3);
 

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -1466,4 +1466,30 @@ void main() {
       expect(productResult.product!.dataQualityWarningsTags, isNull);
     });
   });
+
+  group('$OpenFoodAPIClient different API versions', () {
+    const String barcode = '3661344723290';
+    const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
+    const OpenFoodFactsCountry country = OpenFoodFactsCountry.FRANCE;
+
+    test('get schema versions', () async {
+      final Map<num, int> schemaVersions = <num, int>{
+        3: 999,
+        3.1: 1000,
+        3.2: 1001,
+      };
+      for (final MapEntry<num, int> version in schemaVersions.entries) {
+        final ProductResultV3 productResult = await getProductV3InProd(
+          ProductQueryConfiguration(barcode,
+              language: language,
+              country: country,
+              version: ProductQueryVersion(version.key),
+              fields: [
+                ProductField.SCHEMA_VERSION,
+              ]),
+        );
+        expect(productResult.product!.schemaVersion, version.value);
+      }
+    });
+  });
 }


### PR DESCRIPTION
### What
- Now we can use decimal API versions - e.g. `3.2` - instead of just `int`
- New related product field `schemaVersion`

### Part of 
- #1055

### Impacted files
* `api_get_product_test.dart`: added a test about API versions matching schema versions
* `product.dart`: new field `schemaVersion`
* `product.g.dart`: generated
* `product_fields.dart`: new product field `SCHEMA_VERSION`
* `product_query_configurations.dart`: now the version number can be decimal