### PR TITLE
feat: 905 - new nutrient units "% DV" and "IU"

### DIFF
--- a/lib/src/model/nutrient.dart
+++ b/lib/src/model/nutrient.dart
@@ -5,37 +5,52 @@ import '../utils/unit_helper.dart';
 /// Nutrient
 enum Nutrient implements OffTagged {
   /// Salt
-  salt(typicalUnit: Unit.G, offTag: 'salt'),
+  salt(typicalUnit: Unit.G, offTag: 'salt', acceptsPercentDV: false),
 
   /// Sodium
-  sodium(typicalUnit: Unit.G, offTag: 'sodium'),
+  sodium(typicalUnit: Unit.G, offTag: 'sodium', acceptsPercentDV: false),
 
   /// Fibers
-  fiber(typicalUnit: Unit.G, offTag: 'fiber'),
+  fiber(typicalUnit: Unit.G, offTag: 'fiber', acceptsPercentDV: false),
 
   /// Sugars
-  sugars(typicalUnit: Unit.G, offTag: 'sugars'),
+  sugars(typicalUnit: Unit.G, offTag: 'sugars', acceptsPercentDV: false),
 
   /// Added Sugars
   addedSugars(typicalUnit: Unit.G, offTag: 'added-sugars'),
 
   /// Fats
-  fat(typicalUnit: Unit.G, offTag: 'fat'),
+  fat(typicalUnit: Unit.G, offTag: 'fat', acceptsPercentDV: false),
 
   /// Saturated Fats
-  saturatedFat(typicalUnit: Unit.G, offTag: 'saturated-fat'),
+  saturatedFat(
+      typicalUnit: Unit.G, offTag: 'saturated-fat', acceptsPercentDV: false),
 
   /// Proteins
-  proteins(typicalUnit: Unit.G, offTag: 'proteins'),
+  proteins(typicalUnit: Unit.G, offTag: 'proteins', acceptsPercentDV: false),
 
   /// Energy in kcal
-  energyKCal(typicalUnit: Unit.KCAL, offTag: 'energy-kcal'),
+  energyKCal(
+    typicalUnit: Unit.KCAL,
+    offTag: 'energy-kcal',
+    acceptsWeight: false,
+    acceptsPercentDV: false,
+  ),
 
   /// Energy in kj
-  energyKJ(typicalUnit: Unit.KJ, offTag: 'energy-kj'),
+  energyKJ(
+    typicalUnit: Unit.KJ,
+    offTag: 'energy-kj',
+    acceptsWeight: false,
+    acceptsPercentDV: false,
+  ),
 
   /// Carbohydrates
-  carbohydrates(typicalUnit: Unit.G, offTag: 'carbohydrates'),
+  carbohydrates(
+    typicalUnit: Unit.G,
+    offTag: 'carbohydrates',
+    acceptsPercentDV: false,
+  ),
 
   /// Caffeine
   caffeine(typicalUnit: Unit.G, offTag: 'caffeine'),
@@ -47,7 +62,7 @@ enum Nutrient implements OffTagged {
   iron(typicalUnit: Unit.MILLI_G, offTag: 'iron'),
 
   /// Vitamin C
-  vitaminC(typicalUnit: Unit.MILLI_G, offTag: 'vitamin-c'),
+  vitaminC(typicalUnit: Unit.MILLI_G, offTag: 'vitamin-c', acceptsIU: true),
 
   /// Magnesium
   magnesium(typicalUnit: Unit.MILLI_G, offTag: 'magnesium'),
@@ -68,13 +83,13 @@ enum Nutrient implements OffTagged {
   selenium(typicalUnit: Unit.MICRO_G, offTag: 'selenium'),
 
   /// Vitamin A
-  vitaminA(typicalUnit: Unit.MICRO_G, offTag: 'vitamin-a'),
+  vitaminA(typicalUnit: Unit.MICRO_G, offTag: 'vitamin-a', acceptsIU: true),
 
   /// Vitamin E
-  vitaminE(typicalUnit: Unit.MILLI_G, offTag: 'vitamin-e'),
+  vitaminE(typicalUnit: Unit.MILLI_G, offTag: 'vitamin-e', acceptsIU: true),
 
   /// Vitamin D
-  vitaminD(typicalUnit: Unit.MICRO_G, offTag: 'vitamin-d'),
+  vitaminD(typicalUnit: Unit.MICRO_G, offTag: 'vitamin-d', acceptsIU: true),
 
   /// Vitamin B1
   vitaminB1(typicalUnit: Unit.MILLI_G, offTag: 'vitamin-b1'),
@@ -146,7 +161,12 @@ enum Nutrient implements OffTagged {
   polyunsaturatedFat(typicalUnit: Unit.G, offTag: 'polyunsaturated-fat'),
 
   /// Alcohol
-  alcohol(typicalUnit: Unit.PERCENT, offTag: 'alcohol'),
+  alcohol(
+    typicalUnit: Unit.PERCENT,
+    offTag: 'alcohol',
+    acceptsWeight: false,
+    acceptsPercentDV: false,
+  ),
 
   /// Pantothenic Acid
   pantothenicAcid(typicalUnit: Unit.MILLI_G, offTag: 'pantothenic-acid'),
@@ -239,10 +259,22 @@ enum Nutrient implements OffTagged {
   const Nutrient({
     required this.typicalUnit,
     required this.offTag,
+    this.acceptsWeight = true,
+    this.acceptsPercentDV = true,
+    this.acceptsIU = false,
   });
 
   /// Typical unit. An educated guess only: may differ according to countries.
   final Unit typicalUnit;
+
+  /// Can this nutrient typically be valued in weight? (g, mg, mcg)
+  final bool acceptsWeight;
+
+  /// Can this nutrient typically be valued in "% DV"?
+  final bool acceptsPercentDV;
+
+  /// Can this nutrient typically be valued in "IU"?
+  final bool acceptsIU;
 
   @override
   final String offTag;

--- a/lib/src/utils/unit_helper.dart
+++ b/lib/src/utils/unit_helper.dart
@@ -1,55 +1,55 @@
+import '../model/off_tagged.dart';
+
 /// Unit of measurement for nutrients
-enum Unit { KCAL, KJ, G, MILLI_G, MICRO_G, MILLI_L, L, PERCENT, UNKNOWN }
+enum Unit implements OffTagged {
+  KCAL('kcal'),
+  KJ('kj'),
+  G('g'),
+  MILLI_G('mg'),
+  MICRO_G('mcg'),
+  MILLI_L('ml'),
+  L('liter'),
+  PERCENT('percent'),
+  // actually we don't expect a specific offTag for "unknown".
+  UNKNOWN('unknown'),
+  PERCENT_DV('% DV'),
+  IU('IU');
+
+  const Unit(this.offTag);
+
+  @override
+  final String offTag;
+}
 
 /// Helper class for conversions to/from [Unit]
 class UnitHelper {
-  /// Maps a unit spelling to a [Unit]
-  static const Map<String, Unit> _UNITS = {
-    'kcal': Unit.KCAL,
+  /// Maps alternate unit spellings to a [Unit]
+  static const Map<String, Unit> _ALTERNATE_UNITS = {
     'kCal': Unit.KCAL,
     'KCal': Unit.KCAL,
-    'kj': Unit.KJ,
     'Kj': Unit.KJ,
     'kJ': Unit.KJ,
     'KJ': Unit.KJ,
-    'g': Unit.G,
     'G': Unit.G,
-    'mg': Unit.MILLI_G,
     'milli-gram': Unit.MILLI_G,
     'mG': Unit.MILLI_G,
-    'mcg': Unit.MICRO_G,
     'µg': Unit.MICRO_G,
     '&#181;g': Unit.MICRO_G,
     '&micro;g': Unit.MICRO_G,
     '&#xb5;g': Unit.MICRO_G,
-    'ml': Unit.MILLI_L,
     'mL': Unit.MILLI_L,
     'Ml': Unit.MILLI_L,
     'ML': Unit.MILLI_L,
     'milli-liter': Unit.MILLI_L,
-    'liter': Unit.L,
     'L': Unit.L,
     'l': Unit.L,
     '%': Unit.PERCENT,
     'per cent': Unit.PERCENT,
-    'percent': Unit.PERCENT,
     'μg': Unit.MICRO_G,
   };
 
-  /// Maps a [Unit] to a unit spelling recognised by the write API
-  static const _POSSIBLE_SPELLINGS = {
-    Unit.KCAL: 'kcal',
-    Unit.KJ: 'kj',
-    Unit.G: 'g',
-    Unit.MILLI_G: 'mg',
-    Unit.MICRO_G: 'mcg',
-    Unit.MILLI_L: 'ml',
-    Unit.L: 'liter',
-    Unit.PERCENT: 'percent',
-  };
-
   /// Returns a unit spelling corresponding to the type of [unit]
-  static String? unitToString(Unit? unit) => _POSSIBLE_SPELLINGS[unit];
+  static String? unitToString(Unit? unit) => unit?.offTag;
 
   /// Returns the [Unit] described by [s]
   static Unit? stringToUnit(String? s) {
@@ -65,6 +65,8 @@ class UnitHelper {
       return Unit.UNKNOWN;
     }
 
-    return _UNITS[s] ?? Unit.UNKNOWN;
+    return OffTagged.fromOffTag(s, Unit.values) as Unit? ??
+        _ALTERNATE_UNITS[s] ??
+        Unit.UNKNOWN;
   }
 }


### PR DESCRIPTION
### What
- New nutrient units - "% DV" and "IU"

### Fixes bug(s)
- Closes: #905

### Impacted files
* `nutrient.dart`: new fields "acceptsWeight", "acceptsPercentDV", "acceptsIU"
* `unit_helper.dart`: added "% DV" and "IU"; refactored as `OffTagged`

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/7005