### PR TITLE
feat: flavor for product types

### DIFF
--- a/lib/src/model/product_type.dart
+++ b/lib/src/model/product_type.dart
@@ -8,23 +8,23 @@ import '../utils/server_type.dart';
 /// Somehow redundant with [ServerType] and [Flavor].
 enum ProductType implements OffTagged {
   @JsonValue('food')
-  food(offTag: 'food'),
-
+  food(offTag: 'food', flavor: Flavor.openFoodFacts),
   @JsonValue('beauty')
-  beauty(offTag: 'beauty'),
-
+  beauty(offTag: 'beauty', flavor: Flavor.openBeautyFacts),
   @JsonValue('petfood')
-  petFood(offTag: 'petfood'),
-
+  petFood(offTag: 'petfood', flavor: Flavor.openPetFoodFacts),
   @JsonValue('product')
-  product(offTag: 'product');
+  product(offTag: 'product', flavor: Flavor.openProductFacts);
 
   const ProductType({
     required this.offTag,
+    required this.flavor,
   });
 
   @override
   final String offTag;
+
+  final Flavor flavor;
 
   /// Returns the first [ProductType] that matches the [offTag].
   static ProductType? fromOffTag(final String? offTag) =>


### PR DESCRIPTION
### What
- New `flavor` field for `ProductType`
- Typical use case: nutri patrol, where from a product (with a product type) we have to pass the flavor as a parameter.

### Part of 
- https://github.com/openfoodfacts/smooth-app/pull/7120
