### PR TITLE
feat: 1160 - automatically excluding read-only pseudo nutrients

### DIFF
--- a/lib/src/model/ordered_nutrients.dart
+++ b/lib/src/model/ordered_nutrients.dart
@@ -17,8 +17,36 @@ class OrderedNutrients extends JsonObject {
 
   OrderedNutrients({required this.nutrients});
 
-  factory OrderedNutrients.fromJson(Map<String, dynamic> json) =>
-      _$OrderedNutrientsFromJson(json);
+  factory OrderedNutrients.fromJson(
+    Map<String, dynamic> json, {
+    final bool excludeReadOnly = true,
+  }) {
+    final OrderedNutrients result = _$OrderedNutrientsFromJson(json);
+    if (excludeReadOnly == false) {
+      return result;
+    }
+    _excludeReadOnly(result.nutrients);
+    return result;
+  }
+
+  // cf. https://github.com/openfoodfacts/openfoodfacts-dart/issues/1160
+  static void _excludeReadOnly(final List<OrderedNutrient>? orderedNutrients) {
+    if (orderedNutrients == null) {
+      return;
+    }
+    final List<int> remove = <int>[];
+    for (int i = 0; i < orderedNutrients.length; i++) {
+      final OrderedNutrient orderedNutrient = orderedNutrients[i];
+      if (orderedNutrient.id.startsWith('nutrition')) {
+        remove.add(i);
+      } else {
+        _excludeReadOnly(orderedNutrient.subNutrients);
+      }
+    }
+    for (int i = remove.length - 1; i >= 0; i--) {
+      orderedNutrients.removeAt(remove[i]);
+    }
+  }
 
   @override
   Map<String, dynamic> toJson() => _$OrderedNutrientsToJson(this);

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -1173,9 +1173,15 @@ class OpenFoodAPIClient {
   ///   print(orderedNutrients.nutrients[5].name);  // Fiber
   ///   print(orderedNutrients.nutrients[10].name); // Vitamin A
   /// ```
+  ///
+  /// By default, some read-only pseudo nutrients are automatically excluded,
+  /// like `nutrition-score-fr`, as they have negative added-value for the apps:
+  /// the users aren't going to set the values, and they can get the values
+  /// elsewhere.
   static Future<OrderedNutrients> getOrderedNutrients({
     required final OpenFoodFactsCountry country,
     required final OpenFoodFactsLanguage language,
+    final bool excludeReadOnly = true,
     final UriProductHelper uriHelper = uriHelperFoodProd,
   }) async =>
       OrderedNutrients.fromJson(
@@ -1186,6 +1192,7 @@ class OpenFoodAPIClient {
             uriHelper: uriHelper,
           ),
         ),
+        excludeReadOnly: excludeReadOnly,
       );
 
   /// Returns the nutrient hierarchy specific to a country, localized, as JSON

--- a/test/ordered_nutrient_test.dart
+++ b/test/ordered_nutrient_test.dart
@@ -146,5 +146,31 @@ void main() {
             reason: 'For country ${country.name}');
       }
     });
+
+    test('check excludeReadOnly', () async {
+      final List<bool> excludeReadOnlies = <bool>[true, false];
+      for (final bool excludeReadOnly in excludeReadOnlies) {
+        final OrderedNutrients orderedNutrients =
+            await OpenFoodAPIClient.getOrderedNutrients(
+          country: OpenFoodFactsCountry.FRANCE,
+          language: language,
+          excludeReadOnly: excludeReadOnly,
+        );
+        expect(
+          findOrderedNutrient(
+            orderedNutrients.nutrients,
+            'nutrition-score-fr',
+          ),
+          excludeReadOnly ? isNull : isNotNull,
+        );
+        expect(
+          findOrderedNutrient(
+            orderedNutrients.nutrients,
+            'nutrition-score-uk',
+          ),
+          excludeReadOnly ? isNull : isNotNull,
+        );
+      }
+    });
   });
 }


### PR DESCRIPTION
### What
- With the latest addition of nutrients (#1152), we included pseudo read-only nutrients, like `nutrition-score-fr`.
- Given that they make little sense if considered as real nutrients that users can edit, by default we remove them from the nutrient structure.

### Fixes bug(s)
- Closes: #1160

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/6990
- https://github.com/openfoodfacts/smooth-app/pull/7097

### Impacted files
* `open_food_api_client.dart`: added an `excludeReadOnly` parameter to method `getOrderedNutrients`
* `ordered_nutrient_test.dart`: added a test about excluding read-only pseudo nutrients
* `ordered_nutrients.dart`: added an `excludeReadOnly` parameter to factory `OrderedNutrients.fromJson`