### PR TITLE
feat: Bulgaria now in the Euro zone!

### DIFF
--- a/lib/src/prices/currency.dart
+++ b/lib/src/prices/currency.dart
@@ -95,7 +95,7 @@ enum Currency {
   BGM(noCountry: true),
 
   /// Bulgarian lev
-  BGN,
+  BGN(historicalCode: true),
   BGO(noCountry: true),
 
   /// Bahraini dinar

--- a/lib/src/utils/country_helper.dart
+++ b/lib/src/utils/country_helper.dart
@@ -99,7 +99,7 @@ enum OpenFoodFactsCountry implements OffTagged {
   BULGARIA(
     offTag: 'bg',
     iso3Code: 'BGR',
-    currency: Currency.BGN,
+    currency: Currency.EUR,
     wikiUrl: 'https://wiki.openfoodfacts.org/Local_Communities/BulgarianTeam',
   ),
 


### PR DESCRIPTION
### What
- Bulgaria is in the Euro zone since January 1st, 2026!