### PR TITLE
fix: back to max pub.dev score!

### DIFF
--- a/lib/src/folksonomy.dart
+++ b/lib/src/folksonomy.dart
@@ -129,9 +129,7 @@ class FolksonomyAPIClient {
     final String? owner,
     final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
-    final Map<String, String> parameters = <String, String>{
-      if (owner != null) 'owner': owner,
-    };
+    final Map<String, String> parameters = <String, String>{'owner': ?owner};
     final Response response = await HttpHelper().doGetRequest(
       uriHelper.getUri(
         path: 'product/${Uri.encodeComponent(barcode)}',
@@ -163,9 +161,7 @@ class FolksonomyAPIClient {
     final String? owner,
     final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
-    final Map<String, String> parameters = <String, String>{
-      if (owner != null) 'owner': owner,
-    };
+    final Map<String, String> parameters = <String, String>{'owner': ?owner};
     final Response response = await HttpHelper().doGetRequest(
       uriHelper.getUri(
         path:
@@ -197,10 +193,7 @@ class FolksonomyAPIClient {
       uriHelper.getUri(
         path:
             'product/${Uri.encodeComponent(barcode)}/${Uri.encodeComponent(key)}',
-        queryParameters: {
-          'version': '$version',
-          if (owner != null) 'owner': owner,
-        },
+        queryParameters: {'version': '$version', 'owner': ?owner},
       ),
       uriHelper: uriHelper,
       bearerToken: bearerToken,
@@ -218,9 +211,7 @@ class FolksonomyAPIClient {
     final String? owner,
     final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
-    final Map<String, String> parameters = <String, String>{
-      if (owner != null) 'owner': owner,
-    };
+    final Map<String, String> parameters = <String, String>{'owner': ?owner};
     final Response response = await HttpHelper().doGetRequest(
       uriHelper.getUri(
         path:
@@ -250,11 +241,11 @@ class FolksonomyAPIClient {
     final int? version,
     final String? owner,
   }) => <String, dynamic>{
-    if (barcode != null) 'product': barcode,
-    if (owner != null) 'owner': owner,
-    if (key != null) 'k': key,
-    if (value != null) 'v': value,
-    if (version != null) 'version': version,
+    'product': ?barcode,
+    'owner': ?owner,
+    'k': ?key,
+    'v': ?value,
+    'version': ?version,
   };
 
   /// productTag.version must be equal to previous version + 1
@@ -276,10 +267,7 @@ class FolksonomyAPIClient {
     final Response response = await HttpHelper().doPutRequest(
       uriHelper.getUri(
         path: 'product',
-        queryParameters: {
-          'version': '$version',
-          if (ownerIfPrivate != null) 'owner': ownerIfPrivate,
-        },
+        queryParameters: {'version': '$version', 'owner': ?ownerIfPrivate},
       ),
       jsonEncode(body),
       uriHelper: uriHelper,
@@ -324,8 +312,8 @@ class FolksonomyAPIClient {
     final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Map<String, String> parameters = <String, String>{
-      if (owner != null) 'owner': owner,
-      if (query != null) 'q': query,
+      'owner': ?owner,
+      'q': ?query,
     };
     final Response response = await HttpHelper().doGetRequest(
       uriHelper.getUri(path: 'keys', queryParameters: parameters),
@@ -351,8 +339,8 @@ class FolksonomyAPIClient {
     final UriHelper uriHelper = uriHelperFolksonomyProd,
   }) async {
     final Map<String, String> parameters = <String, String>{
-      if (owner != null) 'owner': owner,
-      if (query != null) 'q': query,
+      'owner': ?owner,
+      'q': ?query,
       if (limit != null) 'limit': limit.toString(),
     };
     final Response response = await HttpHelper().doGetRequest(

--- a/lib/src/model/parameter/sort_by.dart
+++ b/lib/src/model/parameter/sort_by.dart
@@ -1,22 +1,13 @@
+import '../off_tagged.dart';
 import '../../interface/parameter.dart';
 
 /// Sort search API parameter
 class SortBy extends Parameter {
-  static const Map<SortOption, String> _VALUES = {
-    SortOption.PRODUCT_NAME: 'product_name',
-    SortOption.CREATED: 'created_t',
-    SortOption.EDIT: 'last_modified_t',
-    SortOption.POPULARITY: 'unique_scans_n',
-    SortOption.NOTHING: 'nothing',
-    SortOption.ECOSCORE: 'ecoscore_score',
-    SortOption.NUTRISCORE: 'nutriscore_score',
-  };
-
   @override
   String getName() => 'sort_by';
 
   @override
-  String getValue() => _VALUES[option] ?? 'unique_scans_n';
+  String getValue() => (option ?? SortOption.POPULARITY).offTag;
 
   final SortOption? option;
 
@@ -24,12 +15,17 @@ class SortBy extends Parameter {
 }
 
 /// Possible sort options for search API
-enum SortOption {
-  POPULARITY,
-  PRODUCT_NAME,
-  CREATED,
-  EDIT,
-  NOTHING,
-  ECOSCORE,
-  NUTRISCORE,
+enum SortOption implements OffTagged {
+  POPULARITY(offTag: 'unique_scans_n'),
+  PRODUCT_NAME(offTag: 'product_name'),
+  CREATED(offTag: 'created_t'),
+  EDIT(offTag: 'last_modified_t'),
+  NOTHING(offTag: 'nothing'),
+  ECOSCORE(offTag: 'ecoscore_score'),
+  NUTRISCORE(offTag: 'nutriscore_score');
+
+  const SortOption({required this.offTag});
+
+  @override
+  final String offTag;
 }

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -786,8 +786,8 @@ class OpenFoodAPIClient {
       'lc': language.offTag,
       'string': input,
       if (country != null) 'cc': country.offTag,
-      if (categories != null) 'categories': categories,
-      if (shape != null) 'shape': shape,
+      'categories': ?categories,
+      'shape': ?shape,
       'limit': limit.toString(),
     };
     final Uri uri = uriHelper.getUri(

--- a/lib/src/robot_off_api_client.dart
+++ b/lib/src/robot_off_api_client.dart
@@ -30,7 +30,7 @@ class RobotoffAPIClient {
       if (type != null) 'type': type.offTag,
       if (countries?.isNotEmpty == true)
         'countries': _getCountryList(countries!),
-      if (valueTag != null) 'value_tag': valueTag,
+      'value_tag': ?valueTag,
       if (count != null) 'count': count.toString(),
       if (serverType != null) 'server_type': serverType.offTag,
     };
@@ -142,7 +142,7 @@ class RobotoffAPIClient {
 
     final Map<String, String> parameters = <String, String>{
       'lang': language.code,
-      if (deviceId != null) 'device_id': deviceId,
+      'device_id': ?deviceId,
       if (count != null) 'count': count.toString(),
       if (page != null) 'page': page.toString(),
       if (serverType != null) 'server_type': serverType.offTag,
@@ -151,7 +151,7 @@ class RobotoffAPIClient {
       if (questionOrder != null) 'order_by': questionOrder.offTag,
       if (countries?.isNotEmpty == true)
         'countries': _getCountryList(countries!),
-      if (valueTag != null) 'value_tag': valueTag,
+      'value_tag': ?valueTag,
     };
 
     var robotoffQuestionUri = uriHelper.getUri(
@@ -191,8 +191,8 @@ class RobotoffAPIClient {
     final Map<String, String> annotationData = {
       'annotation': annotation.value.toString(),
       'update': update ? '1' : '0',
-      if (insightId != null) 'insight_id': insightId,
-      if (deviceId != null) 'device_id': deviceId,
+      'insight_id': ?insightId,
+      'device_id': ?deviceId,
     };
 
     final Response response = await HttpHelper().doPostRequest(

--- a/lib/src/utils/http_helper.dart
+++ b/lib/src/utils/http_helper.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:http_parser/http_parser.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 
@@ -374,7 +373,7 @@ class HttpHelper {
   }
 
   /// Returns the probable media type associated to that filename.
-  MediaType? imagineMediaType(final String filename) {
+  http.MediaType? imagineMediaType(final String filename) {
     String ext = extension(filename);
     if (ext.isEmpty) {
       return null;
@@ -383,11 +382,11 @@ class HttpHelper {
     switch (ext) {
       case 'jpg':
       case 'jpeg':
-        return MediaType('image', 'jpeg');
+        return http.MediaType('image', 'jpeg');
       case 'png':
-        return MediaType('image', 'png');
+        return http.MediaType('image', 'png');
       case 'webp':
-        return MediaType('image', 'webp');
+        return http.MediaType('image', 'webp');
     }
     return null;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,10 +9,9 @@ environment:
 
 dependencies:
   json_annotation: ^4.9.0
-  http: ^1.5.0
-  http_parser: ^4.1.2
+  http: ^1.6.0
   path: ^1.9.1
-  meta: ^1.17.0
+  meta: ^1.18.1
 
 dev_dependencies:
   analyzer: 8.1.1

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -281,8 +281,8 @@ void main() {
           final Nutriments nutriments = result.product!.nutriments!;
           const PerSize perSize = PerSize.oneHundredGrams;
 
-          expect(nutriments.getValue(Nutrient.iron, perSize), 2.32e-7);
-          expect(nutriments.getValue(Nutrient.vitaminC, perSize), 0.0000192);
+          expect(nutriments.getValue(Nutrient.iron, perSize), 0.00072);
+          expect(nutriments.getValue(Nutrient.vitaminC, perSize), 0.06);
         },
       );
 

--- a/test/api_prices_test.dart
+++ b/test/api_prices_test.dart
@@ -1,6 +1,5 @@
 import 'package:http/http.dart' as http;
 
-import 'package:http_parser/http_parser.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:test/test.dart';
 import 'test_constants.dart';
@@ -14,7 +13,7 @@ void main() {
 
   // TODO(monsieurtanuki): more relevant image if possible
   final Uri initialImageUri = Uri.file('test/test_assets/ingredients_en.jpg');
-  final MediaType initialMediaType = HttpHelper().imagineMediaType(
+  final http.MediaType initialMediaType = HttpHelper().imagineMediaType(
     initialImageUri.path,
   )!;
 
@@ -1115,12 +1114,13 @@ void main() {
     );
 
     test('image file media type', () async {
-      final Map<String, MediaType> expectedMediaTypes = <String, MediaType>{
-        'toto.jpeg': MediaType('image', 'jpeg'),
-        'toto.jpg': MediaType('image', 'jpeg'),
-        'toto.png': MediaType('image', 'png'),
-        'toto.webp': MediaType('image', 'webp'),
-      };
+      final Map<String, http.MediaType> expectedMediaTypes =
+          <String, http.MediaType>{
+            'toto.jpeg': http.MediaType('image', 'jpeg'),
+            'toto.jpg': http.MediaType('image', 'jpeg'),
+            'toto.png': http.MediaType('image', 'png'),
+            'toto.webp': http.MediaType('image', 'webp'),
+          };
       for (final String filename in expectedMediaTypes.keys) {
         expect(
           HttpHelper().imagineMediaType(filename).toString(),

--- a/test/api_save_product_v3_test.dart
+++ b/test/api_save_product_v3_test.dart
@@ -151,7 +151,7 @@ void main() {
       final ProductPackaging packaging = packagings.first;
       // we send crap data, we get "corrected" results.
       expect(packaging.numberOfUnits, isNull);
-      expect(packaging.weightMeasured, 0);
+      expect(packaging.weightMeasured, isNull);
 
       expect(status.warnings, isNotEmpty);
       expect(status.warnings, hasLength(2));
@@ -170,8 +170,8 @@ void main() {
           expect(answer.message!.lcName, isNotNull);
         } else if (answer.field!.id == 'weight_measured') {
           expect(answer.field!.value, weightMeasured.toString());
-          expect(answer.field!.valuedConverted, 0.toString());
-          expect(answer.impact!.id, 'value_converted');
+          expect(answer.field!.valuedConverted, isNull);
+          expect(answer.impact!.id, 'field_ignored');
           expect(answer.impact!.name, isNotNull);
           expect(answer.impact!.lcName, isNotNull);
           expect(answer.message!.id, 'invalid_type_must_be_number');


### PR DESCRIPTION
### What
Minor refactoring about
* the "null-aware" dart feature
* using `http.MediaType`
* tested value fixes

The goals are:
* a 160/160 pub.dev score
* possibly non failing tests

### Fixes bug(s)
- Fixes: #1187

### Impacted files
* `api_get_product_test.dart`: minor value fixes
* `api_prices_test.dart`: now using `http.MediaType`
* `api_save_product_v3_test.dart`: minor value fixes
* `folksonomy.dart`: "null-aware" minor fix
* `http_helper.dart`: now using `http.MediaType`
* `open_food_api_client.dart`: "null-aware" minor fix
* `pubspec.yaml`: removed `http_parser` because of `http` conflicts
* `robot_off_api_client.dart`: "null-aware" minor fix
* `sort_by.dart`: unrelated minor refactoring