### PR TITLE
fix: Exclude items from autosuggestions with dynamic limit adjustment (#889)

### DIFF
--- a/lib/src/open_food_search_api_client.dart
+++ b/lib/src/open_food_search_api_client.dart
@@ -32,6 +32,7 @@ class OpenFoodSearchAPIClient {
     final User? user,
     final int size = 10,
     final Fuzziness fuzziness = Fuzziness.none,
+    final List<String> excludedItems = const <String>[],
     final UriProductHelper uriHelper = uriHelperFoodProd,
   }) async {
     query = query.trim();
@@ -45,6 +46,9 @@ class OpenFoodSearchAPIClient {
     if (taxonomyTags.isEmpty) {
       throw Exception('Taxonomies cannot be empty!');
     }
+    // Ask the API for enough results to keep the requested page size
+    // even after excluded suggestions are removed locally.
+    final int adjustedSize = size + excludedItems.length;
     final Uri uri = uriHelper.getUri(
       path: '/autocomplete',
       forcedHost: _getHost(uriHelper),
@@ -52,7 +56,7 @@ class OpenFoodSearchAPIClient {
         'q': query,
         'taxonomy_names': taxonomyTags.join(','),
         'lang': language.offTag,
-        'size': size.toString(),
+        'size': adjustedSize.toString(),
         'fuzziness': fuzziness.offTag,
       },
     );
@@ -61,8 +65,19 @@ class OpenFoodSearchAPIClient {
       user: user,
       uriHelper: uriHelper,
     );
-    return AutocompleteSearchResult.fromJson(
+    final AutocompleteSearchResult result = AutocompleteSearchResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),
+    );
+    // Filter out excluded suggestions and clamp the list back to the
+    // originally requested size.
+    final filteredOptions = result.options
+        ?.where((final item) => !excludedItems.contains(item.text))
+        .take(size)
+        .toList();
+    return AutocompleteSearchResult(
+      took: result.took,
+      timedOut: result.timedOut,
+      options: filteredOptions,
     );
   }
 }


### PR DESCRIPTION
## Description

- This PR fixes issue #889 by implementing proper exclusion logic for autosuggestions.

## Problem
When requesting suggestions and excluding items, the app was returning fewer items than requested because it filtered AFTER asking the API for a fixed amount.

Example:
- Request: 10 suggestions
- Exclude: 3 items (apple, banana, mango)
- Old behavior: Asked API for 10 → filtered 3 → returned 7 items ❌
- New behavior: Asked API for 13 → filtered 3 → returns 10 items ✅

## Solution
Modified `autocomplete()` method in `lib/src/open_food_search_api_client.dart`:

1. Added optional `excludedItems` parameter with default empty list
2. Calculate adjusted size: `adjustedSize = size + excludedItems.length`
3. Request extra items from API using `adjustedSize`
4. Filter out excluded items from the response
5. Limit final result back to originally requested size with `.take(size)`
6. Preserve original response metadata

## Changes
- Modified: `lib/src/open_food_search_api_client.dart`
  - Added `excludedItems` parameter to `autocomplete()` method
  - Implemented dynamic size adjustment logic
  - Added filtering for excluded items
  - Added comments explaining the logic

## Backward Compatibility
 ##Fully backward compatible
- New parameter has default value (empty list)
- Behavior unchanged when `excludedItems` is not provided
- No breaking changes to API

## References
Fixes #889
References: PR #1027 (by @AffanShaikhsurab - incomplete implementation)