### PR TITLE
fix: 1217 - clean error when incorrect credentials

### DIFF
--- a/lib/src/model/login_status.dart
+++ b/lib/src/model/login_status.dart
@@ -73,7 +73,7 @@ class LoginStatus {
       statusVerbose: json['status_verbose'] as String,
       userId: json['user_id'] as String?,
       cookie: headers?['set-cookie'],
-      userDetails: UserDetails.fromJson(json['user']),
+      userDetails: UserDetails.fromJson(json['user'] ?? {}),
     );
   }
 


### PR DESCRIPTION
### What
Now we have a "clean" error when logging in with incorrect credentials:
* status = 0
* statusVerbose = "user not signed-in"
 
Instead of a incomprehensible `type 'Null' is not a subtype of type 'Map<String, dynamic>'`.

The bug was introduced in #1186, package 3.30.0.

### Fixes bug(s)
- Fixes: #1217