### PR TITLE
fix: error handling of API calls

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -157,6 +157,7 @@ export 'src/utils/autocompleter.dart';
 export 'src/utils/barcodes_validator.dart';
 export 'src/utils/country_helper.dart';
 export 'src/utils/http_helper.dart';
+export 'src/utils/http_status_exception.dart';
 export 'src/utils/image_helper.dart';
 export 'src/utils/invalid_barcodes.dart';
 export 'src/utils/json_helper.dart';

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -281,10 +281,7 @@ class OpenFoodAPIClient {
   }) async {
     final Response response = await configuration.getResponse(user, uriHelper);
     TooManyRequestsException.check(response);
-    if (response.statusCode == 404) {
-      return response.body;
-    }
-    _checkResponse(response);
+    _checkResponse(response, includeCodes: [404]);
     return response.body;
   }
 
@@ -1466,7 +1463,10 @@ class OpenFoodAPIClient {
     }
   }
 
-  static void _checkResponse(final Response response) {
-    HttpStatusException.check(response);
+  static void _checkResponse(
+    final Response response, {
+    List<int> includeCodes = const [],
+  }) {
+    HttpStatusException.check(response, includeCodes: includeCodes);
   }
 }

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -280,6 +280,7 @@ class OpenFoodAPIClient {
     final UriProductHelper uriHelper = uriHelperFoodProd,
   }) async {
     final Response response = await configuration.getResponse(user, uriHelper);
+    TooManyRequestsException.check(response);
     _checkResponse(response);
     return response.body;
   }
@@ -444,6 +445,7 @@ class OpenFoodAPIClient {
     final UriProductHelper uriHelper = uriHelperFoodProd,
   }) async {
     final Response response = await configuration.getResponse(user, uriHelper);
+    TooManyRequestsException.check(response);
     _checkResponse(response);
     final String jsonStr = _replaceQuotes(response.body);
     final SearchResult result = SearchResult.fromJson(
@@ -1462,7 +1464,6 @@ class OpenFoodAPIClient {
   }
 
   static void _checkResponse(final Response response) {
-    TooManyRequestsException.check(response);
     HttpStatusException.check(response);
   }
 }

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -49,6 +49,7 @@ import 'utils/tag_type.dart';
 import 'utils/taxonomy_query_configuration.dart';
 import 'utils/too_many_requests_exception.dart';
 import 'utils/uri_helper.dart';
+import 'utils/http_status_exception.dart';
 
 /// Client calls of the Open Food Facts API
 class OpenFoodAPIClient {
@@ -112,6 +113,7 @@ class OpenFoodAPIClient {
       uriHelper: uriHelper,
       addCredentialsToBody: true,
     );
+    _checkResponse(response);
     return Status.fromApiResponse(response.body);
   }
 
@@ -161,6 +163,7 @@ class OpenFoodAPIClient {
       user,
       uriHelper: uriHelper,
     );
+    _checkResponse(response);
     return ProductResultV3.fromJson(HttpHelper().jsonDecode(response.body));
   }
 
@@ -277,7 +280,7 @@ class OpenFoodAPIClient {
     final UriProductHelper uriHelper = uriHelperFoodProd,
   }) async {
     final Response response = await configuration.getResponse(user, uriHelper);
-    TooManyRequestsException.check(response);
+    _checkResponse(response);
     return response.body;
   }
 
@@ -441,7 +444,7 @@ class OpenFoodAPIClient {
     final UriProductHelper uriHelper = uriHelperFoodProd,
   }) async {
     final Response response = await configuration.getResponse(user, uriHelper);
-    TooManyRequestsException.check(response);
+    _checkResponse(response);
     final String jsonStr = _replaceQuotes(response.body);
     final SearchResult result = SearchResult.fromJson(
       HttpHelper().jsonDecode(jsonStr),
@@ -503,6 +506,8 @@ class OpenFoodAPIClient {
       uriHelper: uriHelper,
       addCredentialsToBody: false,
     );
+
+    _checkResponse(response);
 
     Map<String, dynamic> decodedJson =
         HttpHelper().jsonDecode(_replaceQuotes(response.body))
@@ -707,6 +712,7 @@ class OpenFoodAPIClient {
       uriHelper: uriHelper,
       addCredentialsToBody: false,
     );
+    _checkResponse(response);
     return OcrIngredientsResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes))
           as Map<String, dynamic>,
@@ -750,6 +756,7 @@ class OpenFoodAPIClient {
       uriHelper: uriHelper,
       addCredentialsToBody: false,
     );
+    _checkResponse(response);
     return OcrPackagingResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes))
           as Map<String, dynamic>,
@@ -788,6 +795,7 @@ class OpenFoodAPIClient {
       user: user,
       uriHelper: uriHelper,
     );
+    _checkResponse(response);
     final Map<String, dynamic> map = HttpHelper().jsonDecode(response.body);
     final List<String> result = <String>[];
     if (map['suggestions'] != null) {
@@ -1189,9 +1197,7 @@ class OpenFoodAPIClient {
       uriHelper: uriHelper,
       addCredentialsToBody: false,
     );
-    if (response.statusCode != 200) {
-      throw Exception('Could not retrieve ordered nutrients!');
-    }
+    _checkResponse(response);
     return response.body;
   }
 
@@ -1289,11 +1295,7 @@ class OpenFoodAPIClient {
       uriHelper: uriHelper,
       addCredentialsToBody: true,
     );
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Bad response (${response.statusCode}): ${response.body}',
-      );
-    }
+    _checkResponse(response);
     final Map<String, dynamic> json =
         HttpHelper().jsonDecode(response.body) as Map<String, dynamic>;
     final String status = json['status'];
@@ -1341,11 +1343,7 @@ class OpenFoodAPIClient {
       uriHelper: uriHelper,
       addCredentialsToBody: true,
     );
-    if (response.statusCode != 200) {
-      throw Exception(
-        'Bad response (${response.statusCode}): ${response.body}',
-      );
-    }
+    _checkResponse(response);
     final Map<String, dynamic> json =
         HttpHelper().jsonDecode(response.body) as Map<String, dynamic>;
     final String status = json['status'];
@@ -1376,6 +1374,7 @@ class OpenFoodAPIClient {
       ),
       uriHelper: uriHelper,
     );
+    _checkResponse(response);
     final Map<OpenFoodFactsCountry, String> result =
         <OpenFoodFactsCountry, String>{};
     final Map<String, dynamic> map = HttpHelper().jsonDecode(response.body);
@@ -1460,5 +1459,10 @@ class OpenFoodAPIClient {
         response,
       );
     }
+  }
+
+  static void _checkResponse(final Response response) {
+    TooManyRequestsException.check(response);
+    HttpStatusException.check(response);
   }
 }

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -281,6 +281,9 @@ class OpenFoodAPIClient {
   }) async {
     final Response response = await configuration.getResponse(user, uriHelper);
     TooManyRequestsException.check(response);
+    if (response.statusCode == 404) {
+      return response.body;
+    }
     _checkResponse(response);
     return response.body;
   }

--- a/lib/src/open_food_search_api_client.dart
+++ b/lib/src/open_food_search_api_client.dart
@@ -10,7 +10,6 @@ import 'utils/open_food_api_configuration.dart';
 import 'search/autocomplete_search_result.dart';
 import 'search/fuzziness.dart';
 import 'search/taxonomy_name.dart';
-import 'utils/too_many_requests_exception.dart';
 import 'utils/uri_helper.dart';
 
 /// Client calls of the Open Food Facts Elastic Search API.
@@ -63,7 +62,6 @@ class OpenFoodSearchAPIClient {
       user: user,
       uriHelper: uriHelper,
     );
-    TooManyRequestsException.check(response);
     HttpStatusException.check(response);
     return AutocompleteSearchResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),

--- a/lib/src/open_food_search_api_client.dart
+++ b/lib/src/open_food_search_api_client.dart
@@ -4,11 +4,13 @@ import 'package:http/http.dart';
 
 import 'model/user.dart';
 import 'utils/http_helper.dart';
+import 'utils/http_status_exception.dart';
 import 'utils/language_helper.dart';
 import 'utils/open_food_api_configuration.dart';
 import 'search/autocomplete_search_result.dart';
 import 'search/fuzziness.dart';
 import 'search/taxonomy_name.dart';
+import 'utils/too_many_requests_exception.dart';
 import 'utils/uri_helper.dart';
 
 /// Client calls of the Open Food Facts Elastic Search API.
@@ -61,6 +63,8 @@ class OpenFoodSearchAPIClient {
       user: user,
       uriHelper: uriHelper,
     );
+    TooManyRequestsException.check(response);
+    HttpStatusException.check(response);
     return AutocompleteSearchResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),
     );

--- a/lib/src/robot_off_api_client.dart
+++ b/lib/src/robot_off_api_client.dart
@@ -14,7 +14,6 @@ import 'utils/http_status_exception.dart';
 import 'utils/language_helper.dart';
 import 'utils/open_food_api_configuration.dart';
 import 'utils/server_type.dart';
-import 'utils/too_many_requests_exception.dart';
 import 'utils/uri_helper.dart';
 
 class RobotoffAPIClient {
@@ -249,7 +248,6 @@ class RobotoffAPIClient {
   }
 
   static void _checkResponse(final Response response) {
-    TooManyRequestsException.check(response);
     HttpStatusException.check(response);
   }
 }

--- a/lib/src/robot_off_api_client.dart
+++ b/lib/src/robot_off_api_client.dart
@@ -10,9 +10,11 @@ import 'model/status.dart';
 import 'model/user.dart';
 import 'utils/country_helper.dart';
 import 'utils/http_helper.dart';
+import 'utils/http_status_exception.dart';
 import 'utils/language_helper.dart';
 import 'utils/open_food_api_configuration.dart';
 import 'utils/server_type.dart';
+import 'utils/too_many_requests_exception.dart';
 import 'utils/uri_helper.dart';
 
 class RobotoffAPIClient {
@@ -44,6 +46,7 @@ class RobotoffAPIClient {
       insightUri,
       uriHelper: uriHelper,
     );
+    _checkResponse(response);
     var result = InsightsResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),
     );
@@ -69,6 +72,7 @@ class RobotoffAPIClient {
       insightsUri,
       uriHelper: uriHelper,
     );
+    _checkResponse(response);
 
     return InsightsResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),
@@ -104,6 +108,7 @@ class RobotoffAPIClient {
       user: user,
       uriHelper: uriHelper,
     );
+    _checkResponse(response);
     var result = RobotoffQuestionResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),
     );
@@ -165,6 +170,7 @@ class RobotoffAPIClient {
       uriHelper: uriHelper,
       addCredentialsToHeader: user != null,
     );
+    _checkResponse(response);
     return RobotoffQuestionResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),
     );
@@ -203,6 +209,7 @@ class RobotoffAPIClient {
       addCredentialsToBody: false,
       addCredentialsToHeader: user != null,
     );
+    _checkResponse(response);
     return Status.fromApiResponse(response.body);
   }
 
@@ -223,6 +230,7 @@ class RobotoffAPIClient {
     );
 
     final response = await HttpHelper().doGetRequest(uri, uriHelper: uriHelper);
+    _checkResponse(response);
 
     return RobotoffNutrientExtractionResult.fromJson(
       HttpHelper().jsonDecode(utf8.decode(response.bodyBytes)),
@@ -238,5 +246,10 @@ class RobotoffAPIClient {
       result.add(country.offTag);
     }
     return result.join(',');
+  }
+
+  static void _checkResponse(final Response response) {
+    TooManyRequestsException.check(response);
+    HttpStatusException.check(response);
   }
 }

--- a/lib/src/utils/http_status_exception.dart
+++ b/lib/src/utils/http_status_exception.dart
@@ -1,0 +1,21 @@
+import 'package:http/http.dart';
+
+/// Generic exception for non-success HTTP responses.
+class HttpStatusException implements Exception {
+  const HttpStatusException({required this.statusCode, required this.body});
+
+  final int statusCode;
+  final String body;
+
+  static void check(final Response response) {
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw HttpStatusException(
+        statusCode: response.statusCode,
+        body: response.body,
+      );
+    }
+  }
+
+  @override
+  String toString() => 'HttpStatusException(statusCode: $statusCode)';
+}

--- a/lib/src/utils/http_status_exception.dart
+++ b/lib/src/utils/http_status_exception.dart
@@ -2,16 +2,16 @@ import 'package:http/http.dart';
 
 /// Generic exception for non-success HTTP responses.
 class HttpStatusException implements Exception {
-  const HttpStatusException({required this.statusCode, required this.body});
+  const HttpStatusException({required this.statusCode, required this.message});
 
   final int statusCode;
-  final String body;
+  final String message;
 
   static void check(final Response response) {
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw HttpStatusException(
         statusCode: response.statusCode,
-        body: response.body,
+        message: response.body,
       );
     }
   }

--- a/lib/src/utils/http_status_exception.dart
+++ b/lib/src/utils/http_status_exception.dart
@@ -7,8 +7,12 @@ class HttpStatusException implements Exception {
   final int statusCode;
   final String message;
 
-  static void check(final Response response) {
-    if (response.statusCode < 200 || response.statusCode >= 300) {
+  static void check(
+    final Response response, {
+    List<int> includeCodes = const [],
+  }) {
+    if ((response.statusCode < 200 || response.statusCode >= 300) &&
+        !includeCodes.contains(response.statusCode)) {
       throw HttpStatusException(
         statusCode: response.statusCode,
         message: response.body,

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -518,8 +518,10 @@ void main() {
           fields: [ProductField.ALL],
           version: version,
         );
-        ProductResultV3 result = await getProductV3InProd(configurations);
-        expect(result.product, isNull);
+        expect(
+          () async => getProductV3InProd(configurations),
+          throwsA(isA<HttpStatusException>()),
+        );
       });
 
       test('product ingredients', () async {

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -518,10 +518,8 @@ void main() {
           fields: [ProductField.ALL],
           version: version,
         );
-        expect(
-          () async => getProductV3InProd(configurations),
-          throwsA(isA<HttpStatusException>()),
-        );
+        ProductResultV3 result = await getProductV3InProd(configurations);
+        expect(result.product, isNull);
       });
 
       test('product ingredients', () async {

--- a/test/http_status_exception_test.dart
+++ b/test/http_status_exception_test.dart
@@ -1,0 +1,67 @@
+import 'package:test/test.dart';
+import 'package:http/http.dart';
+import 'package:openfoodfacts/src/utils/http_status_exception.dart';
+
+void main() {
+  test('200 response is accepted', () {
+    expect(
+      () => HttpStatusException.check(Response('{"status":1}', 200)),
+      returnsNormally,
+    );
+  });
+
+  test('299 response is accepted', () {
+    expect(
+      () => HttpStatusException.check(Response('{"status":1}', 299)),
+      returnsNormally,
+    );
+  });
+
+  test('504 Gateway Time-out with HTML body throws exception', () {
+    const body = '<html><title>504 Gateway Time-out</title></html>';
+    expect(
+      () => HttpStatusException.check(Response(body, 504)),
+      throwsA(
+        isA<HttpStatusException>()
+            .having((e) => e.statusCode, 'statusCode', 504)
+            .having((e) => e.body, 'body', body),
+      ),
+    );
+  });
+
+  test('500 throws exception with correct fields', () {
+    expect(
+      () => HttpStatusException.check(Response('Internal Server Error', 500)),
+      throwsA(
+        isA<HttpStatusException>()
+            .having((e) => e.statusCode, 'statusCode', 500)
+            .having((e) => e.body, 'body', 'Internal Server Error'),
+      ),
+    );
+  });
+
+  test('404 throws exception', () {
+    expect(
+      () => HttpStatusException.check(Response('Not Found', 404)),
+      throwsA(isA<HttpStatusException>()),
+    );
+  });
+
+  test('301 redirect throws exception', () {
+    expect(
+      () => HttpStatusException.check(Response('', 301)),
+      throwsA(
+        isA<HttpStatusException>().having(
+          (e) => e.statusCode,
+          'statusCode',
+          301,
+        ),
+      ),
+    );
+  });
+
+  test('toString contains status code', () {
+    const exception = HttpStatusException(statusCode: 504, body: 'timeout');
+    expect(exception.toString(), contains('504'));
+  });
+}

--- a/test/http_status_exception_test.dart
+++ b/test/http_status_exception_test.dart
@@ -24,7 +24,7 @@ void main() {
       throwsA(
         isA<HttpStatusException>()
             .having((e) => e.statusCode, 'statusCode', 504)
-            .having((e) => e.body, 'body', body),
+            .having((e) => e.message, 'message', body),
       ),
     );
   });
@@ -35,7 +35,7 @@ void main() {
       throwsA(
         isA<HttpStatusException>()
             .having((e) => e.statusCode, 'statusCode', 500)
-            .having((e) => e.body, 'body', 'Internal Server Error'),
+            .having((e) => e.message, 'message', 'Internal Server Error'),
       ),
     );
   });
@@ -61,7 +61,7 @@ void main() {
   });
 
   test('toString contains status code', () {
-    const exception = HttpStatusException(statusCode: 504, body: 'timeout');
+    const exception = HttpStatusException(statusCode: 504, message: 'timeout');
     expect(exception.toString(), contains('504'));
   });
 }


### PR DESCRIPTION
# Fix handling of HTTP responses before JSON parsing

## Summary

This PR improves error handling for API calls by validating HTTP responses before attempting to parse the response body as JSON.

Previously, some non-success responses (for example, `504 Gateway Time-out`) could return an HTML error page. The client would still attempt to call `jsonDecode()`, resulting in errors such as:

```text
Exception: JSON expected, html found
```

Instead, the client should detect non-success HTTP responses and throw a dedicated exception before JSON parsing is attempted.

## Changes

- Add a new `HttpStatusException` that includes:
  - HTTP status code
  - Error message
- Introduce a shared response validation method in the API client.
- Preserve existing special-case handling for `TooManyRequestsException`.
- Throw `HttpStatusException` for non-2xx responses before calling `jsonDecode()`.
- Add regression tests covering HTML error responses such as `504 Gateway Time-out`.

## Before

```text
HTTP 504 response
    ↓
jsonDecode(response.body)
    ↓
Exception: JSON expected, html found
```

## After

```text
HTTP 504 response
    ↓
Response validation
    ↓
HttpStatusException(statusCode: 504)
```

## Behavior

### Success responses (2xx)

No behavior change.

### Too many requests (429)

Existing `TooManyRequestsException` handling is preserved.

### Other non-success responses

The client now throws `HttpStatusException` instead of attempting to parse a non-JSON response body.

## Motivation

This change prevents confusing JSON parsing failures when the server returns HTML error pages and provides consumers of the SDK with a structured exception that can be handled appropriately based on the HTTP status code.

## Testing

Added regression tests to verify that:

- 2xx responses continue to behave as before.
- Existing `TooManyRequestsException` behavior remains unchanged.
- HTML error responses such as `504 Gateway Time-out` result in `HttpStatusException` rather than a JSON parsing exception.

## Related Issue

Fixes #1069