### PR TITLE
fix: 1239 - throws attempts to set/crop image as OTHER

### DIFF
--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -1281,6 +1281,9 @@ class OpenFoodAPIClient {
     required final User user,
     required final UriProductHelper uriHelper,
   }) async {
+    if (imageField == ImageField.OTHER) {
+      throw Exception('You cannot set or crop an image as OTHER');
+    }
     final String id = '${imageField.offTag}_${language.offTag}';
     final Map<String, String> queryParameters = <String, String>{
       'code': barcode,


### PR DESCRIPTION
### What
The server doesn't accept setting or cropping an existing image as OTHER.
Now, we throw an exception when the method is called with OTHER.

### Fixes bug(s)
- Fixes: #1239

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/7363
- https://github.com/openfoodfacts/openfoodfacts-server/pull/13630