### PR TITLE
docs: Add Bite Diary (Android calorie tracker) to reusers

### DIFF
--- a/REUSERS.md
+++ b/REUSERS.md
@@ -15,5 +15,5 @@ We are very interested in learning what the Open Food Facts data is used for. It
 - **Glutten Scan**. [Android](https://play.google.com/store/apps/details?id=com.healthyfood.gluten_free_app) / [iOS](https://apps.apple.com/ch/app/gluten-scanner/id1540660083)
 - **Halal & Healthy**. [Android](https://play.google.com/store/apps/details?id=com.TagIn.Tech.handh) / [iOS](https://apps.apple.com/ch/app/halal-healthy/id1603051382)
 - **Fitness Tracker**. [Android](https://play.google.com/store/apps/details?id=dk.cepk.fitness_tracker)
+- **Bite Diary: Calorie Counter.** [Android](https://play.google.com/store/apps/details?id=com.tomic.calorie_counter)
 - [All public repositories using this package](https://github.com/openfoodfacts/openfoodfacts-dart/network/dependents)
-  


### PR DESCRIPTION
Bite Diary uses the openfoodfacts Dart SDK for barcode lookups and lets users push corrections back to OFF. Privacy-first, local-first Android app — all data stays on device.