### PR TITLE
feat: 1238 - support of API 3.1

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,7 +10,7 @@ Future<Product?> getProduct() async {
     barcode,
     language: OpenFoodFactsLanguage.GERMAN,
     fields: [ProductField.ALL],
-    version: ProductQueryVersion.v3,
+    version: ProductQueryVersion.latestVersion,
   );
   final ProductResultV3 result =
       await OpenFoodAPIClient.getProductV3(configuration);
@@ -129,7 +129,7 @@ void saveAndExtractIngredient() async {
     fields: [
       ProductField.INGREDIENTS_TEXT,
     ],
-    version: ProductQueryVersion.v3,
+    version: ProductQueryVersion.latestVersion,
   );
   final ProductResultV3 productResult = await OpenFoodAPIClient.getProductV3(
     configurations,

--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -169,6 +169,7 @@ export 'src/utils/pnns_groups.dart';
 export 'src/utils/product_fields.dart';
 export 'src/utils/product_helper.dart';
 export 'src/utils/product_query_configurations.dart';
+export 'src/utils/product_query_version.dart';
 export 'src/utils/product_search_query_configuration.dart';
 export 'src/utils/server_type.dart';
 export 'src/utils/tag_type.dart';

--- a/lib/src/model/nutrient.dart
+++ b/lib/src/model/nutrient.dart
@@ -84,6 +84,16 @@ enum Nutrient implements OffTagged {
   /// Vitamin D
   vitaminD(typicalUnit: Unit.MICRO_G, offTag: 'vitamin-d', acceptsIU: true),
 
+  /// Vitamin D2
+  vitaminD2(
+    typicalUnit: Unit.MICRO_G,
+    offTag: 'vitamin-d2',
+    acceptsPercentDV: false,
+  ),
+
+  /// Vitamin D3
+  vitaminD3(typicalUnit: Unit.MICRO_G, offTag: 'vitamin-d3', acceptsIU: true),
+
   /// Vitamin B1
   vitaminB1(typicalUnit: Unit.MILLI_G, offTag: 'vitamin-b1'),
 

--- a/lib/src/model/parameter/sort_by.dart
+++ b/lib/src/model/parameter/sort_by.dart
@@ -21,7 +21,7 @@ enum SortOption implements OffTagged {
   CREATED(offTag: 'created_t'),
   EDIT(offTag: 'last_modified_t'),
   NOTHING(offTag: 'nothing'),
-  ECOSCORE(offTag: 'ecoscore_score'),
+  ECOSCORE(offTag: 'environmental_score_score'),
   NUTRISCORE(offTag: 'nutriscore_score');
 
   const SortOption({required this.offTag});

--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -591,12 +591,93 @@ class Product extends JsonObject {
   @JsonKey(name: 'editors_tags')
   List<String>? editors;
 
+  /// Read-only.
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreGrade and API V3.1+ instead')
   @JsonKey(name: 'ecoscore_grade')
-  String? ecoscoreGrade;
+  String? ecoscoreGradeV3;
+
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreGrade and API V3.1+ instead')
+  @JsonKey(ignore: true)
+  String? get ecoscoreGrade => ecoscoreGradeV3;
+
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreGrade and API V3.1+ instead')
+  set ecoscoreGrade(String? value) => ecoscoreGradeV3 = value;
+
+  /// Read-only.
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreScore and API V3.1+ instead')
   @JsonKey(name: 'ecoscore_score', fromJson: JsonObject.parseDouble)
-  double? ecoscoreScore;
+  double? ecoscoreScoreV3;
+
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreScore and API V3.1+ instead')
+  @JsonKey(ignore: true)
+  double? get ecoscoreScore => ecoscoreScoreV3;
+
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreScore and API V3.1+ instead')
+  set ecoscoreScore(double? value) => ecoscoreScoreV3 = value;
+
+  /// Read-only.
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreData and API V3.1+ instead')
   @JsonKey(name: 'ecoscore_data', toJson: EcoscoreData.toJsonHelper)
-  EcoscoreData? ecoscoreData;
+  EcoscoreData? ecoscoreDataV3;
+
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreData and API V3.1+ instead')
+  @JsonKey(ignore: true)
+  EcoscoreData? get ecoscoreData => ecoscoreDataV3;
+
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreData and API V3.1+ instead')
+  set ecoscoreData(EcoscoreData? value) => ecoscoreDataV3 = value;
+
+  /// Read-only.
+  @JsonKey(name: 'environmental_score_grade')
+  String? environmentalScoreGrade;
+
+  /// Read-only.
+  @JsonKey(name: 'environmental_score_score', fromJson: JsonObject.parseDouble)
+  double? environmentalScoreScore;
+
+  /// Read-only.
+  @JsonKey(name: 'environmental_score_data', toJson: EcoscoreData.toJsonHelper)
+  EcoscoreData? environmentalScoreData;
+
+  bool? get _atLeastV3_1 {
+    if (schemaVersion == null) {
+      return null;
+    }
+    return schemaVersion! >= 1000;
+  }
+
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreGrade and API V3.1+ instead')
+  String? getEnvironmentalGrade() => switch (_atLeastV3_1) {
+    true => environmentalScoreGrade,
+    false => ecoscoreGrade,
+    null => environmentalScoreGrade ?? ecoscoreGrade,
+  };
+
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreScore and API V3.1+ instead')
+  double? getEnvironmentalScore() => switch (_atLeastV3_1) {
+    true => environmentalScoreScore,
+    false => ecoscoreScore,
+    null => environmentalScoreScore ?? ecoscoreScore,
+  };
+
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Use environmentalScoreData and API V3.1+ instead')
+  EcoscoreData? getEnvironmentalData() => switch (_atLeastV3_1) {
+    true => environmentalScoreData,
+    false => ecoscoreData,
+    null => environmentalScoreData ?? ecoscoreData,
+  };
 
   @JsonKey(
     name: 'knowledge_panels',
@@ -712,9 +793,6 @@ class Product extends JsonObject {
     this.stores,
     this.attributeGroups,
     this.lastModified,
-    this.ecoscoreGrade,
-    this.ecoscoreScore,
-    this.ecoscoreData,
     Nutriments? nutriments,
     bool? noNutritionData,
   }) : _nutriments = nutriments,

--- a/lib/src/model/product.g.dart
+++ b/lib/src/model/product.g.dart
@@ -104,13 +104,6 @@ Product _$ProductFromJson(Map<String, dynamic> json) =>
             ?.map(AttributeGroup.fromJson)
             .toList(),
         lastModified: JsonHelper.timestampToDate(json['last_modified_t']),
-        ecoscoreGrade: json['ecoscore_grade'] as String?,
-        ecoscoreScore: JsonObject.parseDouble(json['ecoscore_score']),
-        ecoscoreData: json['ecoscore_data'] == null
-            ? null
-            : EcoscoreData.fromJson(
-                json['ecoscore_data'] as Map<String, dynamic>,
-              ),
         nutriments: json['nutriments'] == null
             ? null
             : Nutriments.fromJson(json['nutriments'] as Map<String, dynamic>),
@@ -196,6 +189,20 @@ Product _$ProductFromJson(Map<String, dynamic> json) =>
       ..editors = (json['editors_tags'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList()
+      ..ecoscoreGradeV3 = json['ecoscore_grade'] as String?
+      ..ecoscoreScoreV3 = JsonObject.parseDouble(json['ecoscore_score'])
+      ..ecoscoreDataV3 = json['ecoscore_data'] == null
+          ? null
+          : EcoscoreData.fromJson(json['ecoscore_data'] as Map<String, dynamic>)
+      ..environmentalScoreGrade = json['environmental_score_grade'] as String?
+      ..environmentalScoreScore = JsonObject.parseDouble(
+        json['environmental_score_score'],
+      )
+      ..environmentalScoreData = json['environmental_score_data'] == null
+          ? null
+          : EcoscoreData.fromJson(
+              json['environmental_score_data'] as Map<String, dynamic>,
+            )
       ..knowledgePanels = KnowledgePanels.fromJsonHelper(
         json['knowledge_panels'] as Map?,
       )
@@ -359,9 +366,14 @@ Map<String, dynamic> _$ProductToJson(Product instance) => <String, dynamic>{
   'created_t': ?JsonHelper.dateToTimestamp(instance.created),
   'creator': ?instance.creator,
   'editors_tags': ?instance.editors,
-  'ecoscore_grade': ?instance.ecoscoreGrade,
-  'ecoscore_score': ?instance.ecoscoreScore,
-  'ecoscore_data': ?EcoscoreData.toJsonHelper(instance.ecoscoreData),
+  'ecoscore_grade': ?instance.ecoscoreGradeV3,
+  'ecoscore_score': ?instance.ecoscoreScoreV3,
+  'ecoscore_data': ?EcoscoreData.toJsonHelper(instance.ecoscoreDataV3),
+  'environmental_score_grade': ?instance.environmentalScoreGrade,
+  'environmental_score_score': ?instance.environmentalScoreScore,
+  'environmental_score_data': ?EcoscoreData.toJsonHelper(
+    instance.environmentalScoreData,
+  ),
   'knowledge_panels': ?KnowledgePanels.toJsonHelper(instance.knowledgePanels),
   'emb_codes': ?instance.embCodes,
   'manufacturing_places': ?instance.manufacturingPlaces,

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -44,6 +44,7 @@ import 'utils/open_food_api_configuration.dart';
 import 'utils/product_fields.dart';
 import 'utils/product_helper.dart';
 import 'utils/product_query_configurations.dart';
+import 'utils/product_query_version.dart';
 import 'utils/product_search_query_configuration.dart';
 import 'utils/tag_type.dart';
 import 'utils/taxonomy_query_configuration.dart';
@@ -254,9 +255,6 @@ class OpenFoodAPIClient {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
   }) async {
-    if (!configuration.matchesV3()) {
-      Exception("The configuration must match V3!");
-    }
     final String productString = await getProductString(
       configuration,
       user: user,

--- a/lib/src/utils/abstract_query_configuration.dart
+++ b/lib/src/utils/abstract_query_configuration.dart
@@ -9,6 +9,7 @@ import 'http_helper.dart';
 import 'language_helper.dart';
 import 'open_food_api_configuration.dart';
 import 'product_fields.dart';
+import 'product_query_version.dart';
 import 'uri_helper.dart';
 
 /// Abstract Query Configuration, that helps build API URI
@@ -69,6 +70,9 @@ abstract class AbstractQueryConfiguration {
   /// If true, the knowledge panels will be simplified.
   final bool? activateKnowledgePanelsSimplified;
 
+  /// The API version
+  final ProductQueryVersion version;
+
   AbstractQueryConfiguration({
     this.language,
     this.languages,
@@ -76,6 +80,7 @@ abstract class AbstractQueryConfiguration {
     this.fields,
     this.additionalParameters = const [],
     this.activateKnowledgePanelsSimplified,
+    required this.version,
   }) {
     fields ??= [ProductField.ALL];
     if (languages != null) {

--- a/lib/src/utils/product_fields.dart
+++ b/lib/src/utils/product_fields.dart
@@ -186,9 +186,21 @@ enum ProductField implements OffTagged {
   CREATED(offTag: 'created_t'),
   CREATOR(offTag: 'creator'),
   EDITORS(offTag: 'editors_tags'),
-  ECOSCORE_GRADE(offTag: 'ecoscore_grade'),
-  ECOSCORE_SCORE(offTag: 'ecoscore_score'),
-  ECOSCORE_DATA(offTag: 'ecoscore_data'),
+  ECOSCORE_GRADE(
+    offTag: 'ecoscore_grade',
+    // since API 3.1
+    alternateOffTags: ['environmental_score_grade'],
+  ),
+  ECOSCORE_SCORE(
+    offTag: 'ecoscore_score',
+    // since API 3.1
+    alternateOffTags: ['environmental_score_score'],
+  ),
+  ECOSCORE_DATA(
+    offTag: 'ecoscore_data',
+    // since API 3.1
+    alternateOffTags: ['environmental_score_data'],
+  ),
   KNOWLEDGE_PANELS(offTag: 'knowledge_panels'),
   EMB_CODES(offTag: 'emb_codes'),
   MANUFACTURING_PLACES(offTag: 'manufacturing_places'),
@@ -214,6 +226,7 @@ enum ProductField implements OffTagged {
     final ProductField? inLanguagesProductField,
     this.isInLanguages = false,
     this.isAllLanguages = false,
+    this.alternateOffTags,
   }) : _inLanguagesProductField = inLanguagesProductField;
 
   @override
@@ -230,6 +243,8 @@ enum ProductField implements OffTagged {
   /// Returns the corresponding "in languages" field, if relevant.
   ProductField? get inLanguages =>
       isInLanguages ? this : _inLanguagesProductField;
+
+  final List<String>? alternateOffTags;
 
   static List<ProductField> _inLanguagesList = <ProductField>[];
   static List<ProductField> _allLanguagesList = <ProductField>[];
@@ -279,6 +294,9 @@ List<String> convertFieldsToStrings(
       }
     } else {
       fieldsStrings.add(field.offTag);
+      if (field.alternateOffTags != null) {
+        fieldsStrings.addAll(field.alternateOffTags!);
+      }
     }
   }
 

--- a/lib/src/utils/product_query_configurations.dart
+++ b/lib/src/utils/product_query_configurations.dart
@@ -1,5 +1,4 @@
 import 'package:http/http.dart';
-import 'package:meta/meta.dart';
 
 import '../model/parameter/ingredients_unwanted_parameter.dart';
 import '../model/product_type_filter.dart';
@@ -8,32 +7,10 @@ import 'abstract_query_configuration.dart';
 import 'http_helper.dart';
 import 'uri_helper.dart';
 
-/// Api version for product queries (minimum forced version number: 2).
-class ProductQueryVersion {
-  const ProductQueryVersion(final num version)
-    : version = version < 2 ? 2 : version;
-
-  final num version;
-
-  static const ProductQueryVersion v3 = ProductQueryVersion(3);
-
-  String getPath(final String barcode) =>
-      '/api/v$version/product/${Uri.encodeComponent(barcode)}/';
-
-  bool matchesV3() => version >= 3;
-
-  /// Useful for testing new API versions.
-  @visibleForTesting
-  static const ProductQueryVersion testVersion = ProductQueryVersion(3);
-}
-
 /// Query Configuration for single barcode
 class ProductQueryConfiguration extends AbstractQueryConfiguration {
   /// The barcode from the desired product
   final String barcode;
-
-  /// The API version
-  final ProductQueryVersion version;
 
   /// Filter on a specific server.
   final ProductTypeFilter? productTypeFilter;
@@ -45,7 +22,7 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
   /// parameter's description.
   ProductQueryConfiguration(
     this.barcode, {
-    required this.version,
+    required super.version,
     super.language,
     super.languages,
     super.country,
@@ -68,7 +45,9 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
   }
 
   /// If the provided [ProductQueryVersion] matches the API V3 requirements
-  bool matchesV3() => version.matchesV3();
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Minimum version is now 3')
+  bool matchesV3() => true;
 
   @override
   String getUriPath() => version.getPath(barcode);
@@ -78,23 +57,11 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
     final User? user,
     final UriProductHelper uriHelper,
   ) async {
-    if (matchesV3()) {
-      return HttpHelper().doGetRequest(
-        uriHelper.getUri(
-          path: getUriPath(),
-          queryParameters: getParametersMap(),
-        ),
-        user: user,
-        uriHelper: uriHelper,
-        addCookiesToHeader: true,
-      );
-    }
-    return HttpHelper().doPostRequest(
-      uriHelper.getPostUri(path: getUriPath()),
-      getParametersMap(),
-      user,
+    return HttpHelper().doGetRequest(
+      uriHelper.getUri(path: getUriPath(), queryParameters: getParametersMap()),
+      user: user,
       uriHelper: uriHelper,
-      addCredentialsToBody: false,
+      addCookiesToHeader: true,
     );
   }
 }

--- a/lib/src/utils/product_query_version.dart
+++ b/lib/src/utils/product_query_version.dart
@@ -1,0 +1,35 @@
+import 'package:meta/meta.dart';
+
+/// Api version for product queries (minimum forced version number: 3).
+///
+/// cf. https://openfoodfacts.github.io/openfoodfacts-server/api/ref-api-and-product-schema-change-log/
+class ProductQueryVersion {
+  const ProductQueryVersion(final num version)
+    : version = version < 3 ? 3 : version;
+
+  final num version;
+
+  // TODO: deprecated from 2026-06-25; remove when old enough
+  @Deprecated('Use ProductQueryVersion.latestVersion instead')
+  static const ProductQueryVersion v3 = ProductQueryVersion(3);
+
+  static const ProductQueryVersion v3_1 = ProductQueryVersion(3.1);
+
+  static const ProductQueryVersion latestVersion = v3_1;
+
+  String getPath(final String barcode) =>
+      '/api/v$version/product/${Uri.encodeComponent(barcode)}/';
+
+  // TODO: deprecated from 2026-07-09; remove when old enough
+  @Deprecated('Minimum version is now 3')
+  bool matchesV3() => true;
+
+  /// Useful for testing new API versions.
+  @visibleForTesting
+  static const ProductQueryVersion testVersion = latestVersion;
+
+  int? get schemaVersion => switch (version) {
+    3.1 => 1000,
+    _ => null,
+  };
+}

--- a/lib/src/utils/product_search_query_configuration.dart
+++ b/lib/src/utils/product_search_query_configuration.dart
@@ -1,6 +1,5 @@
 import 'abstract_query_configuration.dart';
 import 'product_fields.dart';
-import 'product_query_configurations.dart';
 import '../interface/parameter.dart';
 
 /// Query Configuration for search parameters
@@ -14,10 +13,8 @@ class ProductSearchQueryConfiguration extends AbstractQueryConfiguration {
     super.fields,
     super.activateKnowledgePanelsSimplified,
     required List<Parameter> parametersList,
-    required this.version,
+    required super.version,
   }) : super(additionalParameters: parametersList);
-
-  final ProductQueryVersion version;
 
   List<String> getFieldsKeys() {
     List<String> result = [];

--- a/lib/src/utils/tsv_helper.dart
+++ b/lib/src/utils/tsv_helper.dart
@@ -43,8 +43,8 @@ class TsvHelper {
       quantity: quantity,
       brands: brands,
       nutriscore: nutriscore,
-      ecoscoreGrade: ecoscoreGrade,
     );
+    product.ecoscoreGrade = ecoscoreGrade;
     product.novaGroup = novaGroup;
 
     return product;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,20 +5,20 @@ version: 3.30.2
 homepage: https://github.com/openfoodfacts/openfoodfacts-dart
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
+  sdk: '>=3.11.0 <4.0.0'
 
 dependencies:
-  json_annotation: ^4.9.0
+  json_annotation: ^4.12.0
   http: ^1.6.0
   path: ^1.9.1
   meta: ^1.17.0
 
 dev_dependencies:
-  analyzer: 8.1.1
+  analyzer: 13.3.0
   build_runner: 2.15.1
-  json_serializable: 6.11.2
+  json_serializable: 6.14.0
   lints: 6.1.0
-  test: 1.31.1
+  test: 1.31.2
   coverage: 1.15.1
 
 funding:

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -199,7 +199,7 @@ void main() {
           expect(result.barcode, barcode);
           expect(result.product, isNotNull);
           expect(result.product!.barcode, barcode);
-          expect(result.product!.brandsTags![0], 'kelsin');
+          expect(result.product!.brandsTags![0], 'Kelsin');
 
           // only german ingredients
           expect(result.product!.ingredientsText, isNotNull);
@@ -552,10 +552,10 @@ void main() {
         ProductResultV3 result = await getProductV3InProd(configurations);
 
         expect(result.product, isNotNull);
-        expect(result.product!.ecoscoreGrade, isNotNull);
-        expect(result.product!.ecoscoreScore, isNotNull);
-        expect(result.product!.ecoscoreData!.agribalyse, isNotNull);
-        expect(result.product!.ecoscoreData!.adjustments, isNotNull);
+        expect(result.product!.environmentalScoreGrade, isNotNull);
+        expect(result.product!.environmentalScoreScore, isNotNull);
+        expect(result.product!.environmentalScoreData!.agribalyse, isNotNull);
+        expect(result.product!.environmentalScoreData!.adjustments, isNotNull);
       });
 
       test('product fields', () async {
@@ -1576,6 +1576,84 @@ void main() {
           );
           expect(attribute.status, 'known');
           expect(attribute.match, entry.value ? 0 : 100);
+        }
+      });
+    });
+
+    group('$OpenFoodAPIClient API 3.1', () {
+      test('eco/environmental fields in API 3.0 and 3.1', () async {
+        const barcode = '3422150002180';
+
+        const versions = [ProductQueryVersion.v3, ProductQueryVersion.v3_1];
+
+        late double score;
+        late String grade;
+        late EcoscoreData data;
+
+        for (final version in versions) {
+          final configuration = ProductQueryConfiguration(
+            barcode,
+            fields: [
+              ProductField.BARCODE,
+              ProductField.SCHEMA_VERSION,
+              ProductField.ECOSCORE_SCORE,
+              ProductField.ECOSCORE_GRADE,
+              ProductField.ECOSCORE_DATA,
+            ],
+            language: OpenFoodFactsLanguage.FRENCH,
+            version: version,
+          );
+
+          final result = await getProductV3InProd(configuration);
+          final Product product = result.product!;
+
+          // the deprecated "eco" fields are similar to "environmental" fields.
+          if (version.version == 3) {
+            // here we have the "eco" fields
+            expect(product.getEnvironmentalScore(), product.ecoscoreScore);
+            expect(product.ecoscoreScore, isNotNull);
+            expect(product.environmentalScoreScore, isNull);
+
+            expect(product.getEnvironmentalGrade(), product.ecoscoreGrade);
+            expect(product.ecoscoreGrade, isNotNull);
+            expect(product.environmentalScoreGrade, isNull);
+
+            expect(product.getEnvironmentalData(), product.ecoscoreData);
+            expect(product.ecoscoreData, isNotNull);
+            expect(product.environmentalScoreData, isNull);
+
+            score = product.ecoscoreScore!;
+            grade = product.ecoscoreGrade!;
+            data = product.ecoscoreData!;
+          } else if (version.version == 3.1) {
+            // here we have the "environmental" fields
+            expect(
+              product.getEnvironmentalScore(),
+              product.environmentalScoreScore,
+            );
+            expect(product.ecoscoreScore, isNull);
+            expect(product.environmentalScoreScore, isNotNull);
+
+            expect(
+              product.getEnvironmentalGrade(),
+              product.environmentalScoreGrade,
+            );
+            expect(product.ecoscoreGrade, isNull);
+            expect(product.environmentalScoreGrade, isNotNull);
+
+            expect(
+              product.getEnvironmentalData(),
+              product.environmentalScoreData,
+            );
+            expect(product.ecoscoreData, isNull);
+            expect(product.environmentalScoreData, isNotNull);
+
+            expect(product.environmentalScoreScore, score);
+            expect(product.environmentalScoreGrade, grade);
+            expect(product.environmentalScoreData!.toData(), data.toData());
+          } else {
+            fail('Unexpected version number: ${version.version}');
+          }
         }
       });
     });

--- a/test/api_get_robotoff_test.dart
+++ b/test/api_get_robotoff_test.dart
@@ -169,19 +169,23 @@ void main() {
       timeout: Timeout(Duration(seconds: 90)),
     );
 
-    test('get 2 random questions with no specific type', () async {
-      final RobotoffQuestionResult result =
-          await RobotoffAPIClient.getQuestions(
-            OpenFoodFactsLanguage.FRENCH,
-            user: TestConstants.PROD_USER,
-            count: 2,
-            questionOrder: RobotoffQuestionOrder.random,
-          );
+    test(
+      'get 2 random questions with no specific type',
+      () async {
+        final RobotoffQuestionResult result =
+            await RobotoffAPIClient.getQuestions(
+              OpenFoodFactsLanguage.FRENCH,
+              user: TestConstants.PROD_USER,
+              count: 2,
+              questionOrder: RobotoffQuestionOrder.random,
+            );
 
-      expect(result.status, isNotNull);
-      expect(result.status, 'found');
-      expect(result.questions!.length, 2);
-    });
+        expect(result.status, isNotNull);
+        expect(result.status, 'found');
+        expect(result.questions!.length, 2);
+      },
+      timeout: Timeout(Duration(seconds: 90)),
+    );
   });
 
   group('$OpenFoodAPIClient get robotoff insights', () {

--- a/test/api_get_save_product_test.dart
+++ b/test/api_get_save_product_test.dart
@@ -29,13 +29,13 @@ void main() {
   const String germanCountry = 'Russland';
   const String englishProductName = 'Pancakes';
   const String englishIngredientsAll = 'Flour, water';
-  const List<String> englishIngredientsSplit = <String>['Flour', 'Water'];
+  const List<String> englishIngredientsSplit = <String>['flour', 'water'];
   const String germanProductName = 'Pfannkuchen';
   const String germanIngredientsAll = 'Mehl, wasser';
   const List<String> germanIngredientsSplit = <String>['Mehl', 'Wasser'];
   const String russianProductName = 'Блинчики';
   const String russianIngredientsAll = 'Мука, вода';
-  const List<String> russianIngredientsSplit = <String>['Мука', 'Вода'];
+  const List<String> russianIngredientsSplit = <String>['мука', 'Вода'];
 
   bool checkServerStatus(final Status status) {
     if (status.status == 400) {
@@ -85,7 +85,7 @@ void main() {
 
         const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.GERMAN;
         const String genericName = 'Softdrink beverage';
-        const String countries = 'Frankreich,Deutschland';
+        const String countries = 'Frankreich, Deutschland';
         const List<String> ingredientsText = <String>[
           'Wasser',
           'Kohlensäure',
@@ -766,7 +766,7 @@ void main() {
       const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.GERMAN;
       const String barcode = '111111555555';
       const String genericName = 'Softdrink beverage';
-      const String labels = 'MyTestLabel';
+      const String labels = 'de:MyTestLabel';
       const String quantity = '5.5 Liter';
 
       //First add the product to the Test DB

--- a/test/api_get_suggestions_test.dart
+++ b/test/api_get_suggestions_test.dart
@@ -405,7 +405,7 @@ void main() {
         uriHelper: uriHelper,
       );
 
-      expect(result, contains('Céleri'));
+      expect(result, contains('céleri'));
 
       result = await OpenFoodAPIClient.getSuggestions(
         TagType.TRACES,
@@ -413,7 +413,7 @@ void main() {
         uriHelper: uriHelper,
       );
 
-      expect(result, contains('Celery'));
+      expect(result, contains('celery'));
 
       result = await OpenFoodAPIClient.getSuggestions(
         TagType.INGREDIENTS,
@@ -421,7 +421,7 @@ void main() {
         uriHelper: uriHelper,
       );
 
-      expect(result, contains('Absinthe'));
+      expect(result, contains('Abondance'));
     });
   });
 }

--- a/test/api_get_taxonomy_packaging_recycling_server_test.dart
+++ b/test/api_get_taxonomy_packaging_recycling_server_test.dart
@@ -15,8 +15,8 @@ void main() {
   ];
 
   const String knownTag = 'en:return-to-store';
-  const String expectedNameFrench = 'Consigné';
-  const String expectedNameEnglish = 'Return to store';
+  const String expectedNameFrench = 'consigné';
+  const String expectedNameEnglish = 'return to store';
   const Set<String> expectedChildren = <String>{
     'en:return-pet-bottle-to-store',
     'en:deposit-refunds',

--- a/test/api_search_products_test.dart
+++ b/test/api_search_products_test.dart
@@ -20,6 +20,7 @@ void main() {
 
   const ProductQueryVersion version = ProductQueryVersion.testVersion;
   const int defaultPageSize = 50;
+  const String storeCarrefour = 'carrefour';
 
   Future<SearchResult> searchProductsInTest(
     final AbstractQueryConfiguration configuration,
@@ -174,26 +175,28 @@ void main() {
       });
 
       test('search favorite products EN', () async {
+        const pageNumber = 3;
+        const pageSize = 7;
         final parameters = <Parameter>[
-          const PageNumber(page: 14),
-          const PageSize(size: 3),
+          const PageNumber(page: pageNumber),
+          const PageSize(size: pageSize),
           const SortBy(option: SortOption.EDIT),
         ];
 
         final ProductSearchQueryConfiguration configuration =
             ProductSearchQueryConfiguration(
               parametersList: parameters,
-              fields: [ProductField.ALL],
+              fields: [ProductField.BARCODE],
               language: OpenFoodFactsLanguage.ENGLISH,
               version: version,
             );
 
         final SearchResult result = await searchProductsInProd(configuration);
 
-        expect(result.page, 14);
-        expect(result.pageSize, 3);
+        expect(result.page, pageNumber);
+        expect(result.pageSize, pageSize);
         expect(result.products, isNotNull);
-        expect(result.products!.length, 3);
+        expect(result.products!.length, pageSize);
         expect(result.products![0].runtimeType, Product);
         expect(result.count, greaterThan(30000));
       });
@@ -359,9 +362,11 @@ void main() {
       );
 
       test('type bug : ingredient percent int vs String ', () async {
+        const pageNumber = 6;
+        const pageSize = 5;
         final parameters = <Parameter>[
-          const PageNumber(page: 16),
-          const PageSize(size: 5),
+          const PageNumber(page: pageNumber),
+          const PageSize(size: pageSize),
           const SortBy(option: SortOption.POPULARITY),
         ];
 
@@ -375,10 +380,10 @@ void main() {
 
         final SearchResult result = await searchProductsInProd(configuration);
 
-        expect(result.page, 16);
-        expect(result.pageSize, 5);
+        expect(result.page, pageNumber);
+        expect(result.pageSize, pageSize);
         expect(result.products, isNotNull);
-        expect(result.products!.length, 5);
+        expect(result.products!.length, pageSize);
         expect(result.products![0].runtimeType, Product);
         expect(result.count, greaterThan(30000));
       });
@@ -462,9 +467,11 @@ void main() {
       });
 
       test('search products with filter on tags', () async {
+        const pageNumber = 5;
+        const pageSize = 10;
         final parameters = <Parameter>[
-          const PageNumber(page: 5),
-          const PageSize(size: 10),
+          const PageNumber(page: pageNumber),
+          const PageSize(size: pageSize),
           const SortBy(option: SortOption.PRODUCT_NAME),
           TagFilter.fromType(
             tagFilterType: TagFilterType.CATEGORIES,
@@ -474,7 +481,7 @@ void main() {
           TagFilter.fromType(
             tagFilterType: TagFilterType.NUTRITION_GRADES,
             contains: true,
-            tagName: 'A',
+            tagName: 'a',
           ),
         ];
 
@@ -488,10 +495,10 @@ void main() {
 
         final SearchResult result = await searchProductsInProd(configuration);
 
-        expect(result.page, 5);
-        expect(result.pageSize, 10);
+        expect(result.page, pageNumber);
+        expect(result.pageSize, pageSize);
         expect(result.products, isNotNull);
-        expect(result.products!.length, 10);
+        expect(result.products!.length, pageSize);
         expect(result.products![0].runtimeType, Product);
         expect(
           result.products![0].categoriesTags,
@@ -507,20 +514,19 @@ void main() {
         const String labels = 'en:organic';
         const String origins = 'Union Européenne et Non Union Européenne';
         const String originsTags = 'en:european-union-and-non-european-union';
-        const String manufacturingPlaces = 'Allemagne';
+        const String manufacturingPlaces = 'allemagne';
         const String purchasePlaces = 'france';
         const String stores = 'franprix';
         const String countries = 'en:france';
         const String allergens = 'en:gluten';
         const String traces = 'en:nuts';
-        const String nutritionGrades = 'A';
+        const String nutritionGrades = 'a';
         const String states = 'en:nutrition-facts-completed';
         const String ingredients = 'en:cereal';
         const int novaGroup = 3;
         const String languages = 'ar';
         const String creator = 'sebleouf';
         const String editors = 'foodrepo';
-        const String lang = 'fr';
 
         final parameters = <Parameter>[
           TagFilter.fromType(
@@ -587,7 +593,6 @@ void main() {
             tagFilterType: TagFilterType.EDITORS,
             tagName: editors,
           ),
-          TagFilter.fromType(tagFilterType: TagFilterType.LANG, tagName: lang),
         ];
 
         final ProductSearchQueryConfiguration configuration =
@@ -606,17 +611,16 @@ void main() {
           expect(product.brands!, brands);
           expect(product.categoriesTags, contains(categories));
           expect(product.labelsTags, contains(labels));
-          expect(product.storesTags, contains(stores));
+          expect(product.storesTags, contains('Franprix'));
           expect(product.countriesTags, contains(countries));
           expect(product.allergens!.ids, contains(allergens));
           expect(product.tracesTags, contains(traces));
-          expect(product.nutriscore!.toUpperCase(), nutritionGrades);
+          expect(product.nutriscore, nutritionGrades);
           expect(product.statesTags, contains(states));
           expect(product.ingredientsTags, contains(ingredients));
-          expect(product.lang.code, lang);
           expect(product.novaGroup, novaGroup);
           expect(product.origins, origins);
-          expect(product.manufacturingPlaces, manufacturingPlaces);
+          expect(product.manufacturingPlaces, 'Allemagne');
           expect(product.creator, creator);
         }
       });
@@ -872,7 +876,7 @@ void main() {
                 ),
                 TagFilter.fromType(
                   tagFilterType: TagFilterType.STORES,
-                  tagName: 'Carrefour',
+                  tagName: storeCarrefour,
                 ),
                 PageSize(size: defaultPageSize),
               ],
@@ -1198,10 +1202,12 @@ void main() {
 
       Future<void> checkTypeCount(
         final OpenFoodFactsCountry country,
-        final String store,
         final int minimalExpectedCount,
       ) async {
-        final int count = await getCountForAllLanguages(country, store);
+        final int count = await getCountForAllLanguages(
+          country,
+          storeCarrefour,
+        );
         expect(count, greaterThanOrEqualTo(minimalExpectedCount));
       }
 
@@ -1209,9 +1215,8 @@ void main() {
         'in France',
         () async => checkTypeCount(
           OpenFoodFactsCountry.FRANCE,
-          'Carrefour',
-          // 2023-08-12: was 14778
-          10000,
+          // 2026-08-12: was 21036
+          15000,
         ),
       );
 
@@ -1219,9 +1224,8 @@ void main() {
         'in Italy',
         () async => checkTypeCount(
           OpenFoodFactsCountry.ITALY,
-          'Carrefour',
-          // 2023-07-09: was 2394
-          1500,
+          // 2026-07-09: was 3377
+          2000,
         ),
       );
 
@@ -1229,9 +1233,8 @@ void main() {
         'in Spain',
         () async => checkTypeCount(
           OpenFoodFactsCountry.SPAIN,
-          'El Corte Inglès',
-          // 2023-07-09: was 608
-          500,
+          // 2026-07-09: was 8681
+          5000,
         ),
       );
     },
@@ -1728,6 +1731,101 @@ void main() {
       }
       expect(countWith, greaterThan(0));
       expect(countWithout, greaterThan(0));
+    });
+  });
+
+  group('$OpenFoodAPIClient API 3.1', () {
+    test('eco/environmental fields in API 3.0 and 3.1', () async {
+      const versions = [ProductQueryVersion.v3, ProductQueryVersion.v3_1];
+
+      final List<double> scores = [];
+      final List<String> grades = [];
+      final List<EcoscoreData> datas = [];
+      final List<String> barcodes = [];
+
+      const int pageSize = 20;
+
+      for (final version in versions) {
+        final configuration = ProductSearchQueryConfiguration(
+          parametersList: [
+            SortBy(option: SortOption.ECOSCORE),
+            PageSize(size: pageSize),
+          ],
+          fields: [
+            ProductField.BARCODE,
+            ProductField.SCHEMA_VERSION,
+            ProductField.ECOSCORE_SCORE,
+            ProductField.ECOSCORE_GRADE,
+            ProductField.ECOSCORE_DATA,
+          ],
+          language: OpenFoodFactsLanguage.FRENCH,
+          version: version,
+        );
+
+        final result = await searchProductsInTest(configuration);
+        expect(result.pageSize, pageSize);
+        expect(result.products, isNotNull);
+        expect(result.products!, hasLength(pageSize));
+
+        int index = -1;
+        for (final Product product in result.products!) {
+          index++;
+
+          // the deprecated "eco" fields are similar to "environmental" fields.
+          if (version.version == 3) {
+            // here we have the "eco" fields
+            expect(product.getEnvironmentalScore(), product.ecoscoreScore);
+            expect(product.ecoscoreScore, isNotNull);
+            expect(product.environmentalScoreScore, isNull);
+
+            expect(product.getEnvironmentalGrade(), product.ecoscoreGrade);
+            expect(product.ecoscoreGrade, isNotNull);
+            expect(product.environmentalScoreGrade, isNull);
+
+            expect(product.getEnvironmentalData(), product.ecoscoreData);
+            expect(product.ecoscoreData, isNotNull);
+            expect(product.environmentalScoreData, isNull);
+
+            scores.add(product.ecoscoreScore!);
+            grades.add(product.ecoscoreGrade!);
+            datas.add(product.ecoscoreData!);
+            barcodes.add(product.barcode!);
+          } else if (version.version == 3.1) {
+            // here we have the "environmental" fields
+            expect(
+              product.getEnvironmentalScore(),
+              product.environmentalScoreScore,
+            );
+            expect(product.ecoscoreScore, isNull);
+            expect(product.environmentalScoreScore, isNotNull);
+
+            expect(
+              product.getEnvironmentalGrade(),
+              product.environmentalScoreGrade,
+            );
+            expect(product.ecoscoreGrade, isNull);
+            expect(product.environmentalScoreGrade, isNotNull);
+
+            expect(
+              product.getEnvironmentalData(),
+              product.environmentalScoreData,
+            );
+            expect(product.ecoscoreData, isNull);
+            expect(product.environmentalScoreData, isNotNull);
+
+            // same ordern same values for API 3 and API 3.1
+            expect(product.barcode, barcodes[index]);
+            expect(product.environmentalScoreScore, scores[index]);
+            expect(product.environmentalScoreGrade, grades[index]);
+            expect(
+              product.environmentalScoreData!.toData(),
+              datas[index].toData(),
+            );
+          } else {
+            fail('Unexpected version number: ${version.version}');
+          }
+        }
+      }
     });
   });
 }


### PR DESCRIPTION
### What
- Now we support API3.1, which is basically some renaming of ECOSCORE fields as ENVIRONMENTAL fields.

### Fixes bug(s)
- Closes: #1238

### Files
New file:
* `product_query_version.dart`: Api version for product queries (minimum forced version number: 3). Moved from `product_query_configurations.dart`.

Impacted files:
* `abstract_query_configuration.dart`: moved here the `version`
* `api_get_product_test.dart`: new tests for API3.1
* `api_get_robotoff_test.dart`: minor fix
* `api_get_save_product_test.dart`: minor fixes
* `api_get_suggestions_test.dart`: minor fix
* `api_get_taxonomy_packaging_recycling_server_test.dart`: minor fix
* `api_search_products_test.dart`: new tests for API3.1; minor fixes
* `main.dart`: minor refactoring
* `nutrient.dart`: added missing nutrients vitamin D2 and D3
* `open_food_api_client.dart`: minor refactoring
* `openfoodfacts.dart`: added new file `product_query_version.dart`
* `product.dart`: now supports API3.1 fields environmental%, identical to eco%
* `product.g.dart`: wtf
* `product_fields.dart`: now the ECO fields are supported as long as ENVIRONMENTAL fields
* `product_query_configurations.dart`: now inherits `version`
* `product_search_query_configuration.dart`: now inherits `version`
* `pubspec.yaml`: light upgrades
* `sort_by.dart`: fixed the ECOSCORE value
* `tsv_helper.dart`: minor refactoring