### PR TITLE
feat: 1244 - support of API 3.2

### DIFF
--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -156,14 +156,25 @@ class Product extends JsonObject {
 
   @JsonKey(name: 'brands')
   String? brands;
+
   @JsonKey(name: 'brands_tags')
+  /// From API 3.2, entries are prefixed with the language-less "xx:" prefix.
   List<String>? brandsTags;
+
   @JsonKey(
     name: 'brands_tags_in_languages',
     toJson: LanguageHelper.toJsonStringsListMap,
     fromJson: LanguageHelper.fromJsonStringsListMap,
   )
   Map<OpenFoodFactsLanguage, List<String>>? brandsTagsInLanguages;
+  @JsonKey(name: 'brands_hierarchy')
+  List<String>? brandsHierarchy;
+  @JsonKey(
+    name: 'brands_lc',
+    toJson: LanguageHelper.toJson,
+    fromJson: LanguageHelper.fromJson,
+  )
+  OpenFoodFactsLanguage? brandsLanguage;
 
   @JsonKey(name: 'countries')
   String? countries;

--- a/lib/src/model/product.g.dart
+++ b/lib/src/model/product.g.dart
@@ -130,6 +130,10 @@ Product _$ProductFromJson(Map<String, dynamic> json) =>
       ..brandsTagsInLanguages = LanguageHelper.fromJsonStringsListMap(
         json['brands_tags_in_languages'],
       )
+      ..brandsHierarchy = (json['brands_hierarchy'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList()
+      ..brandsLanguage = LanguageHelper.fromJson(json['brands_lc'] as String?)
       ..imagesFreshnessInLanguages = Product._fromJsonFreshness(
         json['imagesFreshnessInLanguages'],
       )
@@ -262,6 +266,8 @@ Map<String, dynamic> _$ProductToJson(Product instance) => <String, dynamic>{
   'brands_tags_in_languages': ?LanguageHelper.toJsonStringsListMap(
     instance.brandsTagsInLanguages,
   ),
+  'brands_hierarchy': ?instance.brandsHierarchy,
+  'brands_lc': LanguageHelper.toJson(instance.brandsLanguage),
   'countries': ?instance.countries,
   'countries_tags': ?instance.countriesTags,
   'countries_tags_in_languages': ?LanguageHelper.toJsonStringsListMap(

--- a/lib/src/utils/product_fields.dart
+++ b/lib/src/utils/product_fields.dart
@@ -53,6 +53,8 @@ enum ProductField implements OffTagged {
     inLanguagesProductField: ProductField.BRANDS_TAGS_IN_LANGUAGES,
   ),
   BRANDS_TAGS_IN_LANGUAGES(offTag: 'brands_tags_', isInLanguages: true),
+  BRANDS_HIERARCHY(offTag: 'brands_hierarchy'),
+  BRANDS_LC(offTag: 'brands_lc'),
   COUNTRIES(offTag: 'countries'),
   COUNTRIES_TAGS(
     offTag: 'countries_tags',

--- a/lib/src/utils/product_query_version.dart
+++ b/lib/src/utils/product_query_version.dart
@@ -5,7 +5,7 @@ import 'package:meta/meta.dart';
 /// cf. https://openfoodfacts.github.io/openfoodfacts-server/api/ref-api-and-product-schema-change-log/
 class ProductQueryVersion {
   const ProductQueryVersion(final num version)
-      : version = version < 3 ? 3 : version;
+    : version = version < 3 ? 3 : version;
 
   final num version;
 
@@ -32,9 +32,8 @@ class ProductQueryVersion {
   @visibleForTesting
   static const ProductQueryVersion testVersion = latestVersion;
 
-  int? get schemaVersion =>
-      switch (version) {
-        3.1 => 1000,
-        _ => null,
-      };
+  int? get schemaVersion => switch (version) {
+    3.1 => 1000,
+    _ => null,
+  };
 }

--- a/lib/src/utils/product_query_version.dart
+++ b/lib/src/utils/product_query_version.dart
@@ -5,7 +5,7 @@ import 'package:meta/meta.dart';
 /// cf. https://openfoodfacts.github.io/openfoodfacts-server/api/ref-api-and-product-schema-change-log/
 class ProductQueryVersion {
   const ProductQueryVersion(final num version)
-    : version = version < 3 ? 3 : version;
+      : version = version < 3 ? 3 : version;
 
   final num version;
 
@@ -13,9 +13,13 @@ class ProductQueryVersion {
   @Deprecated('Use ProductQueryVersion.latestVersion instead')
   static const ProductQueryVersion v3 = ProductQueryVersion(3);
 
+  // TODO: deprecated from 2026-07-20; remove when old enough
+  @Deprecated('Use ProductQueryVersion.latestVersion instead')
   static const ProductQueryVersion v3_1 = ProductQueryVersion(3.1);
 
-  static const ProductQueryVersion latestVersion = v3_1;
+  static const ProductQueryVersion v3_2 = ProductQueryVersion(3.2);
+
+  static const ProductQueryVersion latestVersion = v3_2;
 
   String getPath(final String barcode) =>
       '/api/v$version/product/${Uri.encodeComponent(barcode)}/';
@@ -28,8 +32,9 @@ class ProductQueryVersion {
   @visibleForTesting
   static const ProductQueryVersion testVersion = latestVersion;
 
-  int? get schemaVersion => switch (version) {
-    3.1 => 1000,
-    _ => null,
-  };
+  int? get schemaVersion =>
+      switch (version) {
+        3.1 => 1000,
+        _ => null,
+      };
 }

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -199,7 +199,7 @@ void main() {
           expect(result.barcode, barcode);
           expect(result.product, isNotNull);
           expect(result.product!.barcode, barcode);
-          expect(result.product!.brandsTags![0], 'Kelsin');
+          expect(result.product!.brandsTags![0], 'xx:Kelsin');
 
           // only german ingredients
           expect(result.product!.ingredientsText, isNotNull);
@@ -1651,6 +1651,75 @@ void main() {
             expect(product.environmentalScoreScore, score);
             expect(product.environmentalScoreGrade, grade);
             expect(product.environmentalScoreData!.toData(), data.toData());
+          } else {
+            fail('Unexpected version number: ${version.version}');
+          }
+        }
+      });
+    });
+
+    group('$OpenFoodAPIClient API 3.2', () {
+      test('brand fields in API 3.1 and 3.2', () async {
+        const barcode = '3560071051334';
+        const language = OpenFoodFactsLanguage.FRENCH;
+
+        const versions = [ProductQueryVersion.v3_1, ProductQueryVersion.v3_2];
+
+        late String brands;
+        late List<String> brandsTags;
+        late Map<OpenFoodFactsLanguage, List<String>> brandsTagsInLanguages;
+
+        for (final version in versions) {
+          final configuration = ProductQueryConfiguration(
+            barcode,
+            fields: [
+              ProductField.BARCODE,
+              ProductField.SCHEMA_VERSION,
+              ProductField.BRANDS,
+              ProductField.BRANDS_TAGS,
+              ProductField.BRANDS_TAGS_IN_LANGUAGES,
+              ProductField.BRANDS_HIERARCHY,
+              ProductField.BRANDS_LC,
+            ],
+            language: language,
+            version: version,
+          );
+
+          final result = await getProductV3InProd(configuration);
+          final Product product = result.product!;
+
+          expect(product.brands, isNotNull);
+          expect(product.brandsTags, isNotNull);
+          expect(product.brandsTags, isNotEmpty);
+          expect(product.brandsTagsInLanguages, isNotNull);
+          expect(product.brandsTagsInLanguages![language], isNotNull);
+          expect(product.brandsTagsInLanguages![language], isNotEmpty);
+
+          if (version.version == 3.1) {
+            expect(product.brandsHierarchy, isNull);
+            expect(product.brandsLanguage, OpenFoodFactsLanguage.UNDEFINED);
+
+            brands = product.brands!;
+            brandsTags = product.brandsTags!;
+            brandsTagsInLanguages = product.brandsTagsInLanguages!;
+          } else if (version.version == 3.2) {
+            expect(product.brandsHierarchy, isNotNull);
+            expect(product.brandsLanguage, isNotNull);
+            expect(
+              product.brandsLanguage,
+              isNot(OpenFoodFactsLanguage.UNDEFINED),
+            );
+
+            expect(product.brands, brands);
+            expect(product.brandsTagsInLanguages, brandsTagsInLanguages);
+
+            expect(product.brandsTags!.length, brandsTags.length);
+            for (int i = 0; i < brandsTags.length; i++) {
+              final String before = brandsTags[i];
+              final String after = product.brandsTags![i];
+              final String prefixed = 'xx:$before';
+              expect(prefixed, after);
+            }
           } else {
             fail('Unexpected version number: ${version.version}');
           }

--- a/test/api_get_save_product_test.dart
+++ b/test/api_get_save_product_test.dart
@@ -940,7 +940,7 @@ void main() {
           language: OpenFoodFactsLanguage.FRENCH,
           country: OpenFoodFactsCountry.FRANCE,
           fields: [ProductField.NUTRIMENTS],
-          version: ProductQueryVersion.v3,
+          version: ProductQueryVersion.latestVersion,
         ),
         uriHelper: uriHelper,
       );

--- a/test/api_search_products_test.dart
+++ b/test/api_search_products_test.dart
@@ -1828,4 +1828,81 @@ void main() {
       }
     });
   });
+
+  group('$OpenFoodAPIClient API 3.2', () {
+    test('eco/environmental fields in API 3.0 and 3.1', () async {
+      const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
+      const versions = [ProductQueryVersion.v3_1, ProductQueryVersion.v3_2];
+
+      final List<String> brands = [];
+      final List<List<String>> brandsTags = [];
+      final List<Map<OpenFoodFactsLanguage, List<String>>>
+      brandsTagsInLanguages = [];
+
+      const int pageSize = 20;
+
+      for (final version in versions) {
+        final configuration = ProductSearchQueryConfiguration(
+          parametersList: [PageSize(size: pageSize)],
+          fields: [
+            ProductField.BARCODE,
+            ProductField.SCHEMA_VERSION,
+            ProductField.BRANDS,
+            ProductField.BRANDS_TAGS,
+            ProductField.BRANDS_TAGS_IN_LANGUAGES,
+            ProductField.BRANDS_HIERARCHY,
+            ProductField.BRANDS_LC,
+          ],
+          language: language,
+          version: version,
+        );
+
+        final result = await searchProductsInTest(configuration);
+        expect(result.pageSize, pageSize);
+        expect(result.products, isNotNull);
+        expect(result.products!, hasLength(pageSize));
+
+        int index = -1;
+        for (final Product product in result.products!) {
+          index++;
+
+          expect(product.brands, isNotNull);
+          expect(product.brandsTags, isNotNull);
+          expect(product.brandsTags, isNotEmpty);
+          expect(product.brandsTagsInLanguages, isNotNull);
+          expect(product.brandsTagsInLanguages![language], isNotNull);
+          expect(product.brandsTagsInLanguages![language], isNotEmpty);
+
+          if (version.version == 3.1) {
+            expect(product.brandsHierarchy, isNull);
+            expect(product.brandsLanguage, OpenFoodFactsLanguage.UNDEFINED);
+
+            brands.add(product.brands!);
+            brandsTags.add(product.brandsTags!);
+            brandsTagsInLanguages.add(product.brandsTagsInLanguages!);
+          } else if (version.version == 3.2) {
+            expect(product.brandsHierarchy, isNotNull);
+            expect(product.brandsLanguage, isNotNull);
+            expect(
+              product.brandsLanguage,
+              isNot(OpenFoodFactsLanguage.UNDEFINED),
+            );
+
+            expect(product.brands, brands[index]);
+            expect(product.brandsTagsInLanguages, brandsTagsInLanguages[index]);
+
+            expect(product.brandsTags!.length, brandsTags[index].length);
+            for (int i = 0; i < brandsTags[index].length; i++) {
+              final String before = brandsTags[index][i];
+              final String after = product.brandsTags![i];
+              final String prefixed = 'xx:$before';
+              expect(prefixed, after);
+            }
+          } else {
+            fail('Unexpected version number: ${version.version}');
+          }
+        }
+      }
+    });
+  });
 }

--- a/test/api_search_products_test.dart
+++ b/test/api_search_products_test.dart
@@ -1830,7 +1830,7 @@ void main() {
   });
 
   group('$OpenFoodAPIClient API 3.2', () {
-    test('eco/environmental fields in API 3.0 and 3.1', () async {
+    test('brand fields in API 3.1 and 3.2', () async {
       const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
       const versions = [ProductQueryVersion.v3_1, ProductQueryVersion.v3_2];
 

--- a/test/api_search_test.dart
+++ b/test/api_search_test.dart
@@ -18,16 +18,43 @@ void main() {
       expect(result.options!.length, lessThanOrEqualTo(maxSize));
     }
 
+    Future<AutocompleteSearchResult?> autocomplete({
+      required String query,
+      required final List<TaxonomyName> taxonomyNames,
+      required final OpenFoodFactsLanguage language,
+      final Fuzziness fuzziness = Fuzziness.none,
+    }) async {
+      try {
+        final AutocompleteSearchResult result =
+            await OpenFoodSearchAPIClient.autocomplete(
+              query: query,
+              taxonomyNames: taxonomyNames,
+              language: language,
+              size: maxSize,
+              fuzziness: fuzziness,
+              uriHelper: uriHelperFoodProd,
+            );
+        basicTest(result);
+        return result;
+      } on HttpStatusException catch (e) {
+        if (e.statusCode >= 500) {
+          print('Server error: $e');
+          return null;
+        }
+        rethrow;
+      }
+    }
+
     test('category with existing matches', () async {
       const TaxonomyName taxonomyName = TaxonomyName.category;
-      final AutocompleteSearchResult result =
-          await OpenFoodSearchAPIClient.autocomplete(
-            query: 'pizza',
-            taxonomyNames: <TaxonomyName>[taxonomyName],
-            language: language,
-            size: maxSize,
-          );
-      basicTest(result);
+      final AutocompleteSearchResult? result = await autocomplete(
+        query: 'pizza',
+        taxonomyNames: <TaxonomyName>[taxonomyName],
+        language: language,
+      );
+      if (result == null) {
+        return;
+      }
       expect(result.options, hasLength(maxSize));
       for (final AutocompleteSingleResult item in result.options!) {
         expect(item.id, contains(':'));
@@ -37,14 +64,14 @@ void main() {
 
     test('category with non existing matches', () async {
       const TaxonomyName taxonomyName = TaxonomyName.category;
-      final AutocompleteSearchResult result =
-          await OpenFoodSearchAPIClient.autocomplete(
-            query: 'pifsehjfsjkvnskjvbehjszza',
-            taxonomyNames: <TaxonomyName>[taxonomyName],
-            language: language,
-            size: maxSize,
-          );
-      basicTest(result);
+      final AutocompleteSearchResult? result = await autocomplete(
+        query: 'pifsehjfsjkvnskjvbehjszza',
+        taxonomyNames: <TaxonomyName>[taxonomyName],
+        language: language,
+      );
+      if (result == null) {
+        return;
+      }
       expect(result.options, isEmpty);
     });
 
@@ -57,17 +84,17 @@ void main() {
         'Frense': Fuzziness.two,
       };
       for (final String inputValue in inputs.keys) {
-        final AutocompleteSearchResult result =
-            await OpenFoodSearchAPIClient.autocomplete(
-              // possibly with a typo
-              query: inputValue,
-              taxonomyNames: <TaxonomyName>[taxonomyName],
-              language: language,
-              size: maxSize,
-              // supposed to fix the typo (if relevant)
-              fuzziness: inputs[inputValue]!,
-            );
-        basicTest(result);
+        final AutocompleteSearchResult? result = await autocomplete(
+          // possibly with a typo
+          query: inputValue,
+          taxonomyNames: <TaxonomyName>[taxonomyName],
+          language: language,
+          // supposed to fix the typo (if relevant)
+          fuzziness: inputs[inputValue]!,
+        );
+        if (result == null) {
+          return;
+        }
         expect(result.options, isNotEmpty);
         bool found = false;
         for (final AutocompleteSingleResult item in result.options!) {
@@ -87,15 +114,15 @@ void main() {
       final String expectedValue, {
       final OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH,
     }) async {
-      final AutocompleteSearchResult result =
-          await OpenFoodSearchAPIClient.autocomplete(
-            query: query,
-            taxonomyNames: <TaxonomyName>[taxonomyName],
-            language: language,
-            size: maxSize,
-            fuzziness: Fuzziness.none,
-          );
-      basicTest(result);
+      final AutocompleteSearchResult? result = await autocomplete(
+        query: query,
+        taxonomyNames: <TaxonomyName>[taxonomyName],
+        language: language,
+        fuzziness: Fuzziness.none,
+      );
+      if (result == null) {
+        return;
+      }
       expect(result.options, isNotEmpty);
       bool found = false;
       for (final AutocompleteSingleResult item in result.options!) {
@@ -170,6 +197,6 @@ void main() {
         'Carrefour',
         language: OpenFoodFactsLanguage.ENGLISH,
       );
-    });
+    }, timeout: Timeout(Duration(seconds: 90)));
   });
 }


### PR DESCRIPTION
### What
Support of API 3.2:
* added product fields brandsHierarchy and brandsLanguage
* brandsTags are now prefixed by 'xx:'

### Fixes bug(s)
- Closes: #1244

### Impacted files
* `api_get_product_test.dart`: added an API 3.2 test
* `api_get_save_product_test.dart`: minor refactoring
* `api_search_products_test.dart`: added an API 3.2 test
* `api_search_test.dart`: unrelated code strengthening
* `product.dart`: added fields brandsHierarchy and brandsLanguage
* `product.g.dart`: generated
* `product_fields.dart`: added fields BRANDS_HIERARCHY and BRANDS_LC
* `product_query_version.dart`: new version 3.2 as latest version