### PR TITLE
feat: 1250 - API 3.3 support

### DIFF
--- a/lib/src/model/product.dart
+++ b/lib/src/model/product.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 
 import '../interface/json_object.dart';
 import '../utils/json_helper.dart';
@@ -246,13 +247,13 @@ class Product extends JsonObject {
   List<ProductImage>? images;
 
   /// "Raw" (uploaded) images: for example "picture 12" resized to "400" size.
-  List<ProductImage>? getRawImages() => _getImageSubset(false);
+  List<ProductImage>? getRawImages() => getImageSubset(false, images);
 
   /// "Main" images: the selected images for certain criteria.
   ///
   /// For example the "front" picture in "French"
   /// Images may be returned in multiple sizes
-  List<ProductImage>? getMainImages() => _getImageSubset(true);
+  List<ProductImage>? getMainImages() => getImageSubset(true, images);
 
   bool? isImageLocked(
     final ImageField imageField,
@@ -309,13 +310,17 @@ class Product extends JsonObject {
     return null;
   }
 
-  List<ProductImage>? _getImageSubset(final bool isMain) {
+  @visibleForTesting
+  static List<ProductImage>? getImageSubset(
+    final bool isSelectedOrUploaded,
+    final List<ProductImage>? images,
+  ) {
     if (images == null) {
       return null;
     }
     final List<ProductImage> result = <ProductImage>[];
-    for (final ProductImage productImage in images!) {
-      if (productImage.isMain == isMain) {
+    for (final ProductImage productImage in images) {
+      if (productImage.isMain == isSelectedOrUploaded) {
         result.add(productImage);
       }
     }

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -137,22 +137,42 @@ class OpenFoodAPIClient {
       // For the moment there are limited fields concerned.
       throw Exception('At least one V3 field must be populated.');
     }
-    const String productTag = 'product';
-    parameterMap[productTag] = {};
     if (packagings != null) {
-      parameterMap[productTag][ProductField.PACKAGINGS.offTag] = packagings;
+      parameterMap[ProductField.PACKAGINGS.offTag] = packagings;
     }
     if (packagingsComplete != null) {
-      parameterMap[productTag][ProductField.PACKAGINGS_COMPLETE.offTag] =
+      parameterMap[ProductField.PACKAGINGS_COMPLETE.offTag] =
           packagingsComplete;
     }
+    final Map<String, dynamic> extraParameters = <String, dynamic>{};
     if (language != null) {
-      parameterMap['lc'] = language.offTag;
-      parameterMap['tags_lc'] = language.offTag;
+      extraParameters['lc'] = language.offTag;
+      extraParameters['tags_lc'] = language.offTag;
     }
     if (country != null) {
-      parameterMap['cc'] = country.offTag;
+      extraParameters['cc'] = country.offTag;
     }
+
+    return patchProductV3(
+      barcode: barcode,
+      productParameters: parameterMap,
+      extraParameters: extraParameters,
+      user: user,
+      uriHelper: uriHelper,
+    );
+  }
+
+  static Future<ProductResultV3> patchProductV3({
+    required final String barcode,
+    required final Map<String, dynamic> productParameters,
+    required final User user,
+    final Map<String, dynamic> extraParameters = const <String, dynamic>{},
+    final UriProductHelper uriHelper = uriHelperFoodProd,
+  }) async {
+    final Map<String, dynamic> parameterMap = <String, dynamic>{};
+    parameterMap.addAll(user.toData());
+    parameterMap.addAll(extraParameters);
+    parameterMap['product'] = productParameters;
 
     var productUri = uriHelper.getPatchUri(
       path: '/api/v3/product/${Uri.encodeComponent(barcode)}',
@@ -1325,45 +1345,24 @@ class OpenFoodAPIClient {
   /// the image as selected for this product x imagefield x language anymore.
   /// Throws an exception if not successful.
   /// Will work OK even when there was no previous selected product image.
-  static Future<void> unselectProductImage({
+  static Future<ProductResultV3> unselectProductImage({
     required final String barcode,
     required final ImageField imageField,
     required final OpenFoodFactsLanguage language,
     required final User user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
-  }) async {
-    final String id = '${imageField.offTag}_${language.offTag}';
-    final Uri uri = uriHelper.getPostUri(path: 'cgi/product_image_unselect.pl');
-    final Map<String, String> queryParameters = <String, String>{
-      'code': barcode,
-      'id': id,
-    };
-
-    final Response response = await HttpHelper().doPostRequest(
-      uri,
-      queryParameters,
-      user,
-      uriHelper: uriHelper,
-      addCredentialsToBody: true,
-    );
-    _checkResponse(response);
-    final Map<String, dynamic> json =
-        HttpHelper().jsonDecode(response.body) as Map<String, dynamic>;
-    final String status = json['status'];
-    if (status != 'status ok') {
-      throw Exception('Status not ok ($status)');
-    }
-    final int statusCode = json['status_code'];
-    if (statusCode != 0) {
-      throw Exception('Status Code not ok ($statusCode)');
-    }
-    final String imagefield = json['imagefield'];
-    if (imagefield != id) {
-      throw Exception(
-        'Different imagefield: expected "$id", actual "$imageField"',
-      );
-    }
-  }
+  }) async => patchProductV3(
+    barcode: barcode,
+    productParameters: {
+      'images': {
+        'selected': {
+          imageField.offTag: {language.offTag: null},
+        },
+      },
+    },
+    user: user,
+    uriHelper: uriHelper,
+  );
 
   /// Returns the name of each country localized in [language].
   static Future<Map<OpenFoodFactsCountry, String>> getLocalizedCountryNames(

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -132,7 +132,6 @@ class OpenFoodAPIClient {
     final OpenFoodFactsLanguage? language,
   }) async {
     final Map<String, dynamic> parameterMap = <String, dynamic>{};
-    parameterMap.addAll(user.toData());
     if (packagings == null && packagingsComplete == null) {
       // For the moment there are limited fields concerned.
       throw Exception('At least one V3 field must be populated.');

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -131,17 +131,16 @@ class OpenFoodAPIClient {
     final OpenFoodFactsCountry? country,
     final OpenFoodFactsLanguage? language,
   }) async {
-    final Map<String, dynamic> parameterMap = <String, dynamic>{};
-    if (packagings == null && packagingsComplete == null) {
-      // For the moment there are limited fields concerned.
-      throw Exception('At least one V3 field must be populated.');
-    }
+    final Map<String, dynamic> productParameters = <String, dynamic>{};
     if (packagings != null) {
-      parameterMap[ProductField.PACKAGINGS.offTag] = packagings;
+      productParameters[ProductField.PACKAGINGS.offTag] = packagings;
     }
     if (packagingsComplete != null) {
-      parameterMap[ProductField.PACKAGINGS_COMPLETE.offTag] =
+      productParameters[ProductField.PACKAGINGS_COMPLETE.offTag] =
           packagingsComplete;
+    }
+    if (productParameters.isEmpty) {
+      throw Exception('At least one V3 field must be populated.');
     }
     final Map<String, dynamic> extraParameters = <String, dynamic>{};
     if (language != null) {
@@ -154,7 +153,7 @@ class OpenFoodAPIClient {
 
     return patchProductV3(
       barcode: barcode,
-      productParameters: parameterMap,
+      productParameters: productParameters,
       extraParameters: extraParameters,
       user: user,
       uriHelper: uriHelper,

--- a/lib/src/utils/json_helper.dart
+++ b/lib/src/utils/json_helper.dart
@@ -9,7 +9,9 @@ import '../utils/language_helper.dart';
 class JsonHelper {
   /// Returns [ProductImage]s from a product JSON map for "Selected images"
   static List<ProductImage>? selectedImagesFromJson(Map? json) {
-    if (json == null) return null;
+    if (json == null) {
+      return null;
+    }
 
     var imageList = <ProductImage>[];
     for (var field in ImageField.values) {
@@ -96,91 +98,93 @@ class JsonHelper {
   static const String _ALL_IMAGES_TAG_SIZES = 'sizes';
   static const String _ALL_IMAGES_TAG_URL = 'url';
 
+  // from API 3.3
+  static const _ALL_IMAGES_TAG_3_3_UPLOADED = 'uploaded';
+  static const _ALL_IMAGES_TAG_3_3_SELECTED = 'selected';
+  static const _ALL_IMAGES_TAG_3_3_GENERATION = 'generation';
+
   /// Returns [ProductImage]s from a JSON map for "Images".
-  static List<ProductImage>? allImagesFromJson(
-    Map? json, {
-    final bool onlyMain = false,
-  }) {
-    if (json == null) return null;
+  static List<ProductImage>? allImagesFromJson(Map? json) {
+    if (json == null) {
+      return null;
+    }
 
     var imageList = <ProductImage>[];
 
-    for (final String key in json.keys) {
-      ImageField? field;
-      OpenFoodFactsLanguage? lang;
-      final int? imageId = int.tryParse(key);
-      if (imageId != null) {
-        // the key is an int: it's a "raw" image
-        if (onlyMain) {
-          continue;
-        }
-      } else {
-        // we expect field + '_' + language: it's a "main" image
-        final List<String> values = key.split('_');
-        if (values.length != 2) {
-          continue;
-        }
-        final String fieldString = values[0];
-        field = ImageField.fromOffTag(fieldString);
-        if (field == null) {
-          continue;
-        }
-        final String languageString = values[1];
-        lang = OpenFoodFactsLanguage.fromOffTag(languageString);
-        if (lang == null) {
-          continue;
-        }
-      }
-
-      final Map<String, dynamic> fieldObject = json[key];
-
+    void addUploadedImages({
+      required int imageId,
+      required Map<String, dynamic> fieldObject,
+    }) {
       // get the sizes object
       final Map<String, dynamic>? sizesObject =
           fieldObject[_ALL_IMAGES_TAG_SIZES] as Map<String, dynamic>?;
       if (sizesObject == null) {
-        continue;
+        return;
       }
 
-      if (imageId != null) {
-        final DateTime? uploaded = timestampToDate(
-          fieldObject[_ALL_IMAGES_TAG_UPLOADED],
-        );
-        final String? contributor = fieldObject[_ALL_IMAGES_TAG_UPLOADER];
-        // get each number object (e.g. 200)
-        for (var size in ImageSize.values) {
-          var number = size.number;
-          var numberObject = sizesObject[number] as Map<String, dynamic>?;
-          if (numberObject == null) {
-            continue;
-          }
-          imageList.add(
-            ProductImage.raw(
-              size: size,
-              imgid: imageId.toString(),
-              width: JsonObject.parseInt(numberObject[_ALL_IMAGES_TAG_WIDTH]),
-              height: JsonObject.parseInt(numberObject[_ALL_IMAGES_TAG_HEIGHT]),
-              url: numberObject[_ALL_IMAGES_TAG_URL],
-              uploaded: uploaded,
-              contributor: contributor,
-            ),
-          );
+      final DateTime? uploaded = timestampToDate(
+        fieldObject[_ALL_IMAGES_TAG_UPLOADED],
+      );
+      final String? contributor = fieldObject[_ALL_IMAGES_TAG_UPLOADER];
+      // get each number object (e.g. 200)
+      for (var size in ImageSize.values) {
+        var number = size.number;
+        var numberObject = sizesObject[number] as Map<String, dynamic>?;
+        if (numberObject == null) {
+          continue;
         }
-        continue;
+        imageList.add(
+          ProductImage.raw(
+            size: size,
+            imgid: imageId.toString(),
+            width: JsonObject.parseInt(numberObject[_ALL_IMAGES_TAG_WIDTH]),
+            height: JsonObject.parseInt(numberObject[_ALL_IMAGES_TAG_HEIGHT]),
+            url: numberObject[_ALL_IMAGES_TAG_URL],
+            uploaded: uploaded,
+            contributor: contributor,
+          ),
+        );
+      }
+    }
+
+    void addSelectedImages({
+      required ImageField field,
+      required OpenFoodFactsLanguage lang,
+      required Map<String, dynamic> fieldObject,
+      required bool pre3_3Mode,
+    }) {
+      // get the sizes object
+      final Map<String, dynamic>? sizesObject =
+          fieldObject[_ALL_IMAGES_TAG_SIZES] as Map<String, dynamic>?;
+      if (sizesObject == null) {
+        return;
       }
 
       final int? rev = JsonObject.parseInt(
         fieldObject[_ALL_IMAGES_TAG_REVISION],
       );
       final String imgid = fieldObject[_ALL_IMAGES_TAG_IMAGE_ID].toString();
-      final ImageAngle? angle = ImageAngleExtension.fromInt(
-        JsonObject.parseInt(fieldObject[_ALL_IMAGES_TAG_ANGLE]),
-      );
-      final String? coordinatesImageSize =
-          fieldObject[_ALL_IMAGES_TAG_COORDINATES]?.toString();
-      final int? x1 = JsonObject.parseInt(fieldObject[_ALL_IMAGES_TAG_X1]);
-      final int? y1 = JsonObject.parseInt(fieldObject[_ALL_IMAGES_TAG_Y1]);
-      final int? x2 = JsonObject.parseInt(fieldObject[_ALL_IMAGES_TAG_X2]);
-      final int? y2 = JsonObject.parseInt(fieldObject[_ALL_IMAGES_TAG_Y2]);
+
+      ImageAngle? angle;
+      String? coordinatesImageSize;
+      int? x1;
+      int? y1;
+      int? x2;
+      int? y2;
+      final Map<String, dynamic>? generation = pre3_3Mode
+          ? fieldObject
+          : fieldObject[_ALL_IMAGES_TAG_3_3_GENERATION];
+      if (generation != null) {
+        angle = ImageAngleExtension.fromInt(
+          JsonObject.parseInt(generation[_ALL_IMAGES_TAG_ANGLE]),
+        );
+        coordinatesImageSize = generation[_ALL_IMAGES_TAG_COORDINATES]
+            ?.toString();
+        x1 = JsonObject.parseInt(generation[_ALL_IMAGES_TAG_X1]);
+        y1 = JsonObject.parseInt(generation[_ALL_IMAGES_TAG_Y1]);
+        x2 = JsonObject.parseInt(generation[_ALL_IMAGES_TAG_X2]);
+        y2 = JsonObject.parseInt(generation[_ALL_IMAGES_TAG_Y2]);
+      }
 
       // get each number object (e.g. 200)
       for (var size in ImageSize.values) {
@@ -189,41 +193,102 @@ class JsonHelper {
         if (numberObject == null) {
           continue;
         }
-        final int? width = JsonObject.parseInt(
-          numberObject[_ALL_IMAGES_TAG_WIDTH],
+        imageList.add(
+          ProductImage(
+            field: field,
+            size: size,
+            language: lang,
+            rev: rev,
+            imgid: imgid,
+            angle: angle,
+            coordinatesImageSize: coordinatesImageSize,
+            x1: x1,
+            y1: y1,
+            x2: x2,
+            y2: y2,
+            width: JsonObject.parseInt(numberObject[_ALL_IMAGES_TAG_WIDTH]),
+            height: JsonObject.parseInt(numberObject[_ALL_IMAGES_TAG_HEIGHT]),
+            url: numberObject[_ALL_IMAGES_TAG_URL],
+          ),
         );
-        final int? height = JsonObject.parseInt(
-          numberObject[_ALL_IMAGES_TAG_HEIGHT],
-        );
-        final String? url = numberObject[_ALL_IMAGES_TAG_URL];
-
-        var image = ProductImage(
-          field: field!,
-          size: size,
-          language: lang!,
-          rev: rev,
-          imgid: imgid,
-          angle: angle,
-          coordinatesImageSize: coordinatesImageSize,
-          x1: x1,
-          y1: y1,
-          x2: x2,
-          y2: y2,
-          width: width,
-          height: height,
-          url: url,
-        );
-        imageList.add(image);
       }
+    }
+
+    for (final String key in json.keys) {
+      final Map<String, dynamic> fieldObject = json[key];
+
+      if (key == _ALL_IMAGES_TAG_3_3_UPLOADED) {
+        // here, only raw images are expected
+        for (final MapEntry<String, dynamic> entry in fieldObject.entries) {
+          final int? imageId = int.tryParse(entry.key);
+          if (imageId != null) {
+            addUploadedImages(imageId: imageId, fieldObject: entry.value);
+          }
+        }
+        continue;
+      }
+
+      if (key == _ALL_IMAGES_TAG_3_3_SELECTED) {
+        for (final MapEntry<String, dynamic> entry1 in fieldObject.entries) {
+          final ImageField? field = ImageField.fromOffTag(entry1.key);
+          if (field == null) {
+            continue;
+          }
+          for (final MapEntry<String, dynamic> entry2 in entry1.value.entries) {
+            final OpenFoodFactsLanguage? lang =
+                OpenFoodFactsLanguage.fromOffTag(entry2.key);
+            if (lang == null) {
+              continue;
+            }
+            addSelectedImages(
+              field: field,
+              lang: lang,
+              fieldObject: entry2.value,
+              pre3_3Mode: false,
+            );
+          }
+        }
+        continue;
+      }
+
+      final int? imageId = int.tryParse(key);
+      if (imageId != null) {
+        // the key is an int: it's a "raw" image
+        addUploadedImages(imageId: imageId, fieldObject: fieldObject);
+        continue;
+      }
+
+      // we expect field + '_' + language: it's a "main" image
+      ImageField? field;
+      OpenFoodFactsLanguage? lang;
+      final List<String> values = key.split('_');
+      if (values.length != 2) {
+        continue;
+      }
+      final String fieldString = values[0];
+      field = ImageField.fromOffTag(fieldString);
+      if (field == null) {
+        continue;
+      }
+      final String languageString = values[1];
+      lang = OpenFoodFactsLanguage.fromOffTag(languageString);
+      if (lang == null) {
+        continue;
+      }
+      addSelectedImages(
+        field: field,
+        lang: lang,
+        fieldObject: fieldObject,
+        pre3_3Mode: true,
+      );
     }
 
     return imageList;
   }
 
   static Map<String, dynamic> allImagesToJson(
-    final List<ProductImage>? images, {
-    final bool onlyMain = false,
-  }) {
+    final List<ProductImage>? images,
+  ) {
     final Map<String, dynamic> result = <String, dynamic>{};
     if (images == null || images.isEmpty) {
       return result;
@@ -238,9 +303,6 @@ class JsonHelper {
         key = '${productImage.field!.offTag}_${productImage.language!.offTag}';
       } else {
         // it's a "raw" image
-        if (onlyMain) {
-          continue;
-        }
         key = productImage.imgid!.toString();
       }
       List<ProductImage>? items = sorted[key];
@@ -264,17 +326,12 @@ class JsonHelper {
         if (productImage.size == null) {
           continue;
         }
-        final Map<String, Object> size = <String, Object>{};
-        if (productImage.width != null) {
-          size[_ALL_IMAGES_TAG_WIDTH] = productImage.width!;
-        }
-        if (productImage.height != null) {
-          size[_ALL_IMAGES_TAG_HEIGHT] = productImage.height!;
-        }
-        if (productImage.url != null) {
-          size[_ALL_IMAGES_TAG_URL] = productImage.url!;
-        }
-        item[_ALL_IMAGES_TAG_SIZES]![productImage.size!.number] = size;
+        item[_ALL_IMAGES_TAG_SIZES]![productImage.size!.number] =
+            <String, Object>{
+              _ALL_IMAGES_TAG_WIDTH: ?productImage.width,
+              _ALL_IMAGES_TAG_HEIGHT: ?productImage.height,
+              _ALL_IMAGES_TAG_URL: ?productImage.url,
+            };
         if (first) {
           first = false;
           if (!productImage.isMain) {

--- a/lib/src/utils/product_query_version.dart
+++ b/lib/src/utils/product_query_version.dart
@@ -17,9 +17,13 @@ class ProductQueryVersion {
   @Deprecated('Use ProductQueryVersion.latestVersion instead')
   static const ProductQueryVersion v3_1 = ProductQueryVersion(3.1);
 
+  // TODO: deprecated from 2026-07-26; remove when old enough
+  @Deprecated('Use ProductQueryVersion.latestVersion instead')
   static const ProductQueryVersion v3_2 = ProductQueryVersion(3.2);
 
-  static const ProductQueryVersion latestVersion = v3_2;
+  static const ProductQueryVersion v3_3 = ProductQueryVersion(3.3);
+
+  static const ProductQueryVersion latestVersion = v3_3;
 
   String getPath(final String barcode) =>
       '/api/v$version/product/${Uri.encodeComponent(barcode)}/';

--- a/test/api_add_product_image_test.dart
+++ b/test/api_add_product_image_test.dart
@@ -250,41 +250,103 @@ void main() {
         Duration(seconds: 90),
       ),
     );
+  }, skip: 'TEST env is not reliable');
 
-    test(
-      'image unselect',
-      () async {
-        const ImageField unselectedImageField = ImageField.INGREDIENTS;
-        await OpenFoodAPIClient.unselectProductImage(
-          barcode: barcode,
-          user: user,
-          imageField: unselectedImageField,
-          language: language,
-          uriHelper: uriHelper,
-        );
+  group('$OpenFoodAPIClient select/unselect images', () {
+    test('select/unselect', () async {
+      const String barcode = '3019081238643';
+      const ImageField imageField = ImageField.INGREDIENTS;
+      const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.CATALAN;
 
+      Future<Product> reload() async {
         final ProductResultV3 productResult =
             await OpenFoodAPIClient.getProductV3(
               ProductQueryConfiguration(
                 barcode,
-                fields: <ProductField>[ProductField.SELECTED_IMAGE],
+                fields: <ProductField>[
+                  ProductField.SELECTED_IMAGE,
+                  ProductField.IMAGES,
+                ],
                 version: version,
               ),
               uriHelper: uriHelper,
             );
-        expect(productResult.product, isNotNull);
-        expect(productResult.product!.selectedImages, isNotNull);
-        for (final ProductImage productImage
-            in productResult.product!.selectedImages!) {
-          if (productImage.language == language) {
-            expect(productImage.field, isNot(unselectedImageField));
+        return productResult.product!;
+      }
+
+      bool find(final Product product) {
+        for (final item in product.selectedImages!) {
+          if (item.field == imageField && item.language == language) {
+            return true;
           }
         }
-      },
-      timeout: Timeout(
-        // this guy is rather slow
-        Duration(seconds: 90),
-      ),
-    );
-  }, skip: 'TEST env is not reliable');
+        return false;
+      }
+
+      int findImageId(final Product product) {
+        for (final item in product.images!) {
+          if (item.imgid != null) {
+            return int.parse(item.imgid!);
+          }
+        }
+        fail("Couldn't find any image id");
+      }
+
+      ProductImage? findProductImage(final Product product) {
+        for (final item in product.images!) {
+          if (item.field == imageField && item.language == language) {
+            return item;
+          }
+        }
+        return null;
+      }
+
+      Future<void> unselect() async {
+        final ProductResultV3 res =
+            await OpenFoodAPIClient.unselectProductImage(
+              barcode: barcode,
+              user: user,
+              imageField: imageField,
+              language: language,
+              uriHelper: uriHelper,
+            );
+        expect(res.status, ProductResultV3.statusSuccess);
+
+        final Product product = await reload();
+        expect(find(product), isFalse);
+        expect(findProductImage(product), isNull);
+      }
+
+      final Product product = await reload();
+      final int imageId = findImageId(product);
+      final bool found = find(product);
+
+      Future<void> select() async {
+        final String? imageUrl = await OpenFoodAPIClient.setProductImageAngle(
+          barcode: barcode,
+          imageField: imageField,
+          language: language,
+          imgid: '$imageId',
+          angle: ImageAngle.NOON,
+          user: user,
+          uriHelper: uriHelper,
+        );
+        expect(imageUrl, isNotNull);
+        final Product product = await reload();
+        expect(find(product), isTrue);
+        final ProductImage productImage = findProductImage(product)!;
+        expect(productImage.imgid, '$imageId');
+      }
+
+      if (found) {
+        await unselect();
+        await select();
+        await unselect();
+      } else {
+        await select();
+        await unselect();
+        await select();
+      }
+    }, timeout: Timeout(Duration(seconds: 120)));
+  });
 }

--- a/test/api_get_product_test.dart
+++ b/test/api_get_product_test.dart
@@ -1726,5 +1726,61 @@ void main() {
         }
       });
     });
+
+    group('$OpenFoodAPIClient API 3.3', () {
+      test('images fields in API 3.2 and 3.3', () async {
+        const barcode = '3019081238643';
+        const language = OpenFoodFactsLanguage.FRENCH;
+
+        const versions = [ProductQueryVersion.v3_2, ProductQueryVersion.v3_3];
+
+        late List<ProductImage> previousImages;
+
+        for (final version in versions) {
+          final configuration = ProductQueryConfiguration(
+            barcode,
+            fields: [ProductField.IMAGES],
+            language: language,
+            version: version,
+          );
+
+          final result = await getProductV3InProd(configuration);
+          final Product product = result.product!;
+
+          expect(product.images, isNotNull);
+          expect(product.images, isNotEmpty);
+
+          if (version.version == 3.2) {
+            previousImages = product.images!;
+          } else if (version.version == 3.3) {
+            var images = product.images!;
+
+            expect(images, unorderedEquals(previousImages));
+            expect(
+              Product.getImageSubset(true, images)!,
+              unorderedEquals(Product.getImageSubset(true, previousImages)!),
+            );
+            expect(
+              Product.getImageSubset(false, images)!,
+              unorderedEquals(Product.getImageSubset(false, previousImages)!),
+            );
+
+            final recodedProduct = Product.fromJson(product.toJson());
+            images = recodedProduct.images!;
+            expect(images, unorderedEquals(previousImages));
+            expect(
+              Product.getImageSubset(true, images)!,
+              unorderedEquals(Product.getImageSubset(true, previousImages)!),
+            );
+            expect(
+              Product.getImageSubset(false, images)!,
+              unorderedEquals(Product.getImageSubset(false, previousImages)!),
+            );
+          } else {
+            fail('Unexpected version number: ${version.version}');
+          }
+        }
+      });
+    });
   });
 }

--- a/test/api_get_save_product_test.dart
+++ b/test/api_get_save_product_test.dart
@@ -37,13 +37,34 @@ void main() {
   const String russianIngredientsAll = 'Мука, вода';
   const List<String> russianIngredientsSplit = <String>['мука', 'Вода'];
 
-  bool checkServerStatus(final Status status) {
-    if (status.status == 400) {
+  Future<Status?> saveProduct(
+    final Product product, {
+    final OpenFoodFactsLanguage? language,
+  }) async {
+    try {
+      final Status status = await OpenFoodAPIClient.saveProduct(
+        TestConstants.TEST_USER,
+        product,
+        language: language,
+        uriHelper: uriHelper,
+      );
+      return status;
+    } on HttpStatusException catch (e) {
+      if (e.statusCode >= 500) {
+        print('Server error: $e');
+        return null;
+      }
+      rethrow;
+    }
+  }
+
+  bool checkServerStatus(final Status? status) {
+    if (status == null) {
       // grumpy server: let's not fail
       return false;
     }
-    if (status.status >= 500) {
-      // grumpy server, but another way: let's not fail either
+    if (status.status == 400) {
+      // grumpy server: let's not fail
       return false;
     }
     expect(status.status, 1);
@@ -118,12 +139,10 @@ void main() {
           additives: Additives(['en:e150d, en:e950'], ['E150d, E950']),
         );
 
-        await OpenFoodAPIClient.saveProduct(
-          TestConstants.TEST_USER,
-          inputProduct,
-          uriHelper: uriHelper,
-          language: language,
-        );
+        final saved = await saveProduct(inputProduct, language: language);
+        if (saved == null) {
+          return;
+        }
 
         final SendImage fontImage = SendImage(
           lang: language,
@@ -204,12 +223,13 @@ void main() {
             countries: englishCountry,
           );
 
-          await OpenFoodAPIClient.saveProduct(
-            TestConstants.TEST_USER,
+          final saved = await saveProduct(
             englishInputProduct,
-            uriHelper: uriHelper,
             language: OpenFoodFactsLanguage.ENGLISH,
           );
+          if (saved == null) {
+            return;
+          }
 
           final fields = [
             ProductField.NAME,
@@ -346,18 +366,21 @@ void main() {
             },
           );
 
-          await OpenFoodAPIClient.saveProduct(
-            TestConstants.TEST_USER,
+          var saved = await saveProduct(
             englishInputProduct,
-            uriHelper: uriHelper,
             language: OpenFoodFactsLanguage.ENGLISH,
           );
-          await OpenFoodAPIClient.saveProduct(
-            TestConstants.TEST_USER,
+          if (saved == null) {
+            return;
+          }
+
+          saved = await saveProduct(
             russianInputProduct,
-            uriHelper: uriHelper,
             language: OpenFoodFactsLanguage.RUSSIAN,
           );
+          if (saved == null) {
+            return;
+          }
 
           const fields = [
             ProductField.NAME,
@@ -494,11 +517,10 @@ void main() {
           countries: englishCountry,
         );
 
-        await OpenFoodAPIClient.saveProduct(
-          TestConstants.TEST_USER,
-          inputProduct,
-          uriHelper: uriHelper,
-        );
+        final saved = await saveProduct(inputProduct);
+        if (saved == null) {
+          return;
+        }
 
         final fields = [
           ProductField.NAME,
@@ -604,11 +626,10 @@ void main() {
           },
         );
 
-        await OpenFoodAPIClient.saveProduct(
-          TestConstants.TEST_USER,
-          inputProduct,
-          uriHelper: uriHelper,
-        );
+        final saved = await saveProduct(inputProduct);
+        if (saved == null) {
+          return;
+        }
 
         // Request all available languages for the fields which allow it
         final fields = [
@@ -666,11 +687,10 @@ void main() {
             },
           );
 
-          await OpenFoodAPIClient.saveProduct(
-            TestConstants.TEST_USER,
-            inputProduct,
-            uriHelper: uriHelper,
-          );
+          final saved = await saveProduct(inputProduct);
+          if (saved == null) {
+            return;
+          }
 
           // Request both 'all-langs' and 'in-langs' fields types
           final fields = [
@@ -729,12 +749,10 @@ void main() {
           brands: brands,
         );
 
-        await OpenFoodAPIClient.saveProduct(
-          TestConstants.TEST_USER,
-          product,
-          uriHelper: uriHelper,
-          language: language,
-        );
+        final saved = await saveProduct(product, language: language);
+        if (saved == null) {
+          return;
+        }
 
         final ProductQueryConfiguration configurations =
             ProductQueryConfiguration(
@@ -779,12 +797,10 @@ void main() {
         quantity: quantity,
       );
 
-      await OpenFoodAPIClient.saveProduct(
-        TestConstants.TEST_USER,
-        product,
-        uriHelper: uriHelper,
-        language: language,
-      );
+      final saved = await saveProduct(product, language: language);
+      if (saved == null) {
+        return;
+      }
 
       final ProductQueryConfiguration configurations =
           ProductQueryConfiguration(
@@ -821,8 +837,7 @@ void main() {
 
     Future<bool> uploadProduct({required bool noNutritionData}) async {
       const perSize = PerSize.oneHundredGrams;
-      final Status status = await OpenFoodAPIClient.saveProduct(
-        TestConstants.TEST_USER,
+      final Status? status = await saveProduct(
         Product(
           barcode: barcode,
           nutrimentDataPer: perSize.offTag,
@@ -831,7 +846,6 @@ void main() {
               ? (Nutriments.empty()..setValue(Nutrient.salt, perSize, 10.0))
               : null,
         ),
-        uriHelper: uriHelper,
       );
       if (!checkServerStatus(status)) {
         return false;
@@ -920,8 +934,7 @@ void main() {
       }
       inputNutriments.setValue(nutrient, perSize, ++value, modifier: modifier);
 
-      final Status savedStatus = await OpenFoodAPIClient.saveProduct(
-        TestConstants.TEST_USER,
+      final Status? savedStatus = await saveProduct(
         Product(
           barcode: barcode,
           nutriments: inputNutriments,
@@ -930,7 +943,6 @@ void main() {
           servingQuantity: 250,
           noNutritionData: false,
         ),
-        uriHelper: uriHelper,
       );
       if (!checkServerStatus(savedStatus)) {
         return;

--- a/test/api_get_save_product_test.dart
+++ b/test/api_get_save_product_test.dart
@@ -287,8 +287,6 @@ void main() {
 
           expect(russianProduct.productNameInLanguages, isNull);
 
-          expect(russianProduct.ingredientsTextInLanguages, isNull);
-
           expect(russianProduct.ingredientsTags, equals(ingredientsTags));
           expect(
             russianProduct.ingredientsTagsInLanguages,

--- a/test/api_get_save_product_test.dart
+++ b/test/api_get_save_product_test.dart
@@ -42,6 +42,10 @@ void main() {
       // grumpy server: let's not fail
       return false;
     }
+    if (status.status >= 500) {
+      // grumpy server, but another way: let's not fail either
+      return false;
+    }
     expect(status.status, 1);
     expect(status.statusVerbose, 'fields saved');
     return true;

--- a/test/api_save_product_v3_test.dart
+++ b/test/api_save_product_v3_test.dart
@@ -10,6 +10,33 @@ void main() {
 
   const ProductQueryVersion version = ProductQueryVersion.testVersion;
 
+  Future<ProductResultV3?> temporarySaveProductV3(
+    final String barcode, {
+    final List<ProductPackaging>? packagings,
+    final bool? packagingsComplete,
+    final OpenFoodFactsCountry? country,
+    final OpenFoodFactsLanguage? language,
+  }) async {
+    try {
+      final result = await OpenFoodAPIClient.temporarySaveProductV3(
+        TestConstants.TEST_USER,
+        barcode,
+        packagings: packagings,
+        packagingsComplete: packagingsComplete,
+        uriHelper: uriHelper,
+        country: country,
+        language: language,
+      );
+      return result;
+    } on HttpStatusException catch (e) {
+      if (e.statusCode >= 500) {
+        print('Server error: $e');
+        return null;
+      }
+      rethrow;
+    }
+  }
+
   group('$OpenFoodAPIClient save product V3', () {
     const String barcode = '7300400481588';
     const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
@@ -33,15 +60,15 @@ void main() {
             ..quantityPerUnit = quantityPerUnit
             ..weightMeasured = weightMeasured,
         ];
-        final ProductResultV3 status =
-            await OpenFoodAPIClient.temporarySaveProductV3(
-              TestConstants.TEST_USER,
-              barcode,
-              uriHelper: uriHelper,
-              country: country,
-              language: language,
-              packagings: inputPackagings,
-            );
+        final ProductResultV3? status = await temporarySaveProductV3(
+          barcode,
+          country: country,
+          language: language,
+          packagings: inputPackagings,
+        );
+        if (status == null) {
+          return;
+        }
 
         expect(status.status, ProductResultV3.statusWarning);
         expect(status.errors, isEmpty);
@@ -82,15 +109,15 @@ void main() {
     test('save packagings_complete', () async {
       final List<bool> values = [false, true, false];
       for (final bool value in values) {
-        final ProductResultV3 writeStatus =
-            await OpenFoodAPIClient.temporarySaveProductV3(
-              TestConstants.TEST_USER,
-              barcode,
-              uriHelper: uriHelper,
-              country: country,
-              language: language,
-              packagingsComplete: value,
-            );
+        final ProductResultV3? writeStatus = await temporarySaveProductV3(
+          barcode,
+          country: country,
+          language: language,
+          packagingsComplete: value,
+        );
+        if (writeStatus == null) {
+          return;
+        }
 
         expect(writeStatus.status, ProductResultV3.statusSuccess);
         expect(writeStatus.errors, isEmpty);
@@ -135,15 +162,15 @@ void main() {
           ..numberOfUnits = numberOfUnits
           ..weightMeasured = weightMeasured,
       ];
-      final ProductResultV3 status =
-          await OpenFoodAPIClient.temporarySaveProductV3(
-            TestConstants.TEST_USER,
-            barcode,
-            uriHelper: uriHelper,
-            country: country,
-            language: language,
-            packagings: inputPackagings,
-          );
+      final ProductResultV3? status = await temporarySaveProductV3(
+        barcode,
+        country: country,
+        language: language,
+        packagings: inputPackagings,
+      );
+      if (status == null) {
+        return;
+      }
 
       expect(status.status, ProductResultV3.statusWarning);
       expect(status.errors, isEmpty);

--- a/test/api_save_product_v3_test.dart
+++ b/test/api_save_product_v3_test.dart
@@ -10,14 +10,14 @@ void main() {
 
   const ProductQueryVersion version = ProductQueryVersion.testVersion;
 
-  group(
-    '$OpenFoodAPIClient save product V3',
-    () {
-      const String barcode = '7300400481588';
-      const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
-      const OpenFoodFactsCountry country = OpenFoodFactsCountry.FRANCE;
+  group('$OpenFoodAPIClient save product V3', () {
+    const String barcode = '7300400481588';
+    const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
+    const OpenFoodFactsCountry country = OpenFoodFactsCountry.FRANCE;
 
-      test('save packagings with unknown recycling', () async {
+    test(
+      'save packagings with unknown recycling',
+      () async {
         // Here we put an unknown recycling label, and we expect related warnings.
         const String unknownRecycling = 'recyKKlage';
         const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
@@ -75,125 +75,118 @@ void main() {
         expect(answer.field, isNotNull);
         expect(answer.field!.id, 'recycling');
         expect(answer.field!.value, '${language.offTag}:$unknownRecycling');
-      });
+      },
+      timeout: Timeout(Duration(seconds: 180)),
+    );
 
-      test('save packagings_complete', () async {
-        final List<bool> values = [false, true, false];
-        for (final bool value in values) {
-          final ProductResultV3 writeStatus =
-              await OpenFoodAPIClient.temporarySaveProductV3(
-                TestConstants.TEST_USER,
-                barcode,
-                uriHelper: uriHelper,
-                country: country,
-                language: language,
-                packagingsComplete: value,
-              );
-
-          expect(writeStatus.status, ProductResultV3.statusSuccess);
-          expect(writeStatus.errors, isEmpty);
-          expect(
-            writeStatus.result,
-            isNull,
-          ); // result is null for UPDATE queries
-          expect(writeStatus.barcode, barcode);
-          expect(writeStatus.product, isNotNull);
-          expect(writeStatus.product!.packagingsComplete, value);
-
-          // checking again...
-          final ProductResultV3 readStatus =
-              await OpenFoodAPIClient.getProductV3(
-                ProductQueryConfiguration(
-                  barcode,
-                  language: language,
-                  country: country,
-                  version: version,
-                  fields: [
-                    ProductField.BARCODE,
-                    ProductField.PACKAGINGS_COMPLETE,
-                  ],
-                ),
-                user: TestConstants.TEST_USER,
-                uriHelper: uriHelper,
-              );
-
-          expect(readStatus.status, ProductResultV3.statusSuccess);
-          expect(readStatus.errors, isEmpty);
-          expect(readStatus.result, isNotNull);
-          expect(readStatus.result!.id, ProductResultV3.resultProductFound);
-          expect(readStatus.barcode, barcode);
-          expect(readStatus.product, isNotNull);
-          expect(readStatus.product!.packagingsComplete, value);
-        }
-      }, timeout: Timeout(Duration(seconds: 180)));
-
-      test('reproducing issue 1038', () async {
-        // Check it's ok if we get numbers instead of String? as warning/error values.
-        const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
-        const int numberOfUnits = -12;
-        const double weightMeasured = -250;
-        final List<ProductPackaging> inputPackagings = [
-          ProductPackaging()
-            ..shape = (LocalizedTag()..lcName = 'bouteille')
-            ..material = (LocalizedTag()..lcName = 'verre')
-            ..recycling = (LocalizedTag()..lcName = 'bac de tri')
-            ..numberOfUnits = numberOfUnits
-            ..weightMeasured = weightMeasured,
-        ];
-        final ProductResultV3 status =
+    test('save packagings_complete', () async {
+      final List<bool> values = [false, true, false];
+      for (final bool value in values) {
+        final ProductResultV3 writeStatus =
             await OpenFoodAPIClient.temporarySaveProductV3(
               TestConstants.TEST_USER,
               barcode,
               uriHelper: uriHelper,
               country: country,
               language: language,
-              packagings: inputPackagings,
+              packagingsComplete: value,
             );
 
-        expect(status.status, ProductResultV3.statusWarning);
-        expect(status.errors, isEmpty);
-        expect(status.result, isNull); // result is null for UPDATE queries
-        expect(status.barcode, barcode);
-        expect(status.product, isNotNull);
+        expect(writeStatus.status, ProductResultV3.statusSuccess);
+        expect(writeStatus.errors, isEmpty);
+        expect(writeStatus.result, isNull); // result is null for UPDATE queries
+        expect(writeStatus.barcode, barcode);
+        expect(writeStatus.product, isNotNull);
+        expect(writeStatus.product!.packagingsComplete, value);
 
-        expect(status.product!.packagings, isNotNull);
-        final List<ProductPackaging> packagings = status.product!.packagings!;
-        expect(packagings, hasLength(1));
-        final ProductPackaging packaging = packagings.first;
-        // we send crap data, we get "corrected" results.
-        expect(packaging.numberOfUnits, isNull);
-        expect(packaging.weightMeasured, isNull);
+        // checking again...
+        final ProductResultV3 readStatus = await OpenFoodAPIClient.getProductV3(
+          ProductQueryConfiguration(
+            barcode,
+            language: language,
+            country: country,
+            version: version,
+            fields: [ProductField.BARCODE, ProductField.PACKAGINGS_COMPLETE],
+          ),
+          user: TestConstants.TEST_USER,
+          uriHelper: uriHelper,
+        );
 
-        expect(status.warnings, isNotEmpty);
-        expect(status.warnings, hasLength(2));
+        expect(readStatus.status, ProductResultV3.statusSuccess);
+        expect(readStatus.errors, isEmpty);
+        expect(readStatus.result, isNotNull);
+        expect(readStatus.result!.id, ProductResultV3.resultProductFound);
+        expect(readStatus.barcode, barcode);
+        expect(readStatus.product, isNotNull);
+        expect(readStatus.product!.packagingsComplete, value);
+      }
+    }, timeout: Timeout(Duration(seconds: 180)));
 
-        for (final ProductResultFieldAnswer answer in status.warnings!) {
-          expect(answer.field, isNotNull);
-          expect(answer.impact, isNotNull);
-          expect(answer.message, isNotNull);
-          if (answer.field!.id == 'number_of_units') {
-            expect(answer.field!.value, numberOfUnits.toString());
-            expect(answer.impact!.id, 'field_ignored');
-            expect(answer.impact!.name, isNotNull);
-            expect(answer.impact!.lcName, isNotNull);
-            expect(answer.message!.id, 'invalid_type_must_be_integer');
-            expect(answer.message!.name, isNotNull);
-            expect(answer.message!.lcName, isNotNull);
-          } else if (answer.field!.id == 'weight_measured') {
-            expect(answer.field!.value, weightMeasured.toString());
-            expect(answer.field!.valuedConverted, isNull);
-            expect(answer.impact!.id, 'field_ignored');
-            expect(answer.impact!.name, isNotNull);
-            expect(answer.impact!.lcName, isNotNull);
-            expect(answer.message!.id, 'invalid_type_must_be_number');
-            expect(answer.message!.name, isNotNull);
-            expect(answer.message!.lcName, isNotNull);
-          } else {
-            fail('Unexpected field id: ${answer.field!.id}');
-          }
+    test('reproducing issue 1038', () async {
+      // Check it's ok if we get numbers instead of String? as warning/error values.
+      const OpenFoodFactsLanguage language = OpenFoodFactsLanguage.FRENCH;
+      const int numberOfUnits = -12;
+      const double weightMeasured = -250;
+      final List<ProductPackaging> inputPackagings = [
+        ProductPackaging()
+          ..shape = (LocalizedTag()..lcName = 'bouteille')
+          ..material = (LocalizedTag()..lcName = 'verre')
+          ..recycling = (LocalizedTag()..lcName = 'bac de tri')
+          ..numberOfUnits = numberOfUnits
+          ..weightMeasured = weightMeasured,
+      ];
+      final ProductResultV3 status =
+          await OpenFoodAPIClient.temporarySaveProductV3(
+            TestConstants.TEST_USER,
+            barcode,
+            uriHelper: uriHelper,
+            country: country,
+            language: language,
+            packagings: inputPackagings,
+          );
+
+      expect(status.status, ProductResultV3.statusWarning);
+      expect(status.errors, isEmpty);
+      expect(status.result, isNull); // result is null for UPDATE queries
+      expect(status.barcode, barcode);
+      expect(status.product, isNotNull);
+
+      expect(status.product!.packagings, isNotNull);
+      final List<ProductPackaging> packagings = status.product!.packagings!;
+      expect(packagings, hasLength(1));
+      final ProductPackaging packaging = packagings.first;
+      // we send crap data, we get "corrected" results.
+      expect(packaging.numberOfUnits, isNull);
+      expect(packaging.weightMeasured, isNull);
+
+      expect(status.warnings, isNotEmpty);
+      expect(status.warnings, hasLength(2));
+
+      for (final ProductResultFieldAnswer answer in status.warnings!) {
+        expect(answer.field, isNotNull);
+        expect(answer.impact, isNotNull);
+        expect(answer.message, isNotNull);
+        if (answer.field!.id == 'number_of_units') {
+          expect(answer.field!.value, numberOfUnits.toString());
+          expect(answer.impact!.id, 'field_ignored');
+          expect(answer.impact!.name, isNotNull);
+          expect(answer.impact!.lcName, isNotNull);
+          expect(answer.message!.id, 'invalid_type_must_be_integer');
+          expect(answer.message!.name, isNotNull);
+          expect(answer.message!.lcName, isNotNull);
+        } else if (answer.field!.id == 'weight_measured') {
+          expect(answer.field!.value, weightMeasured.toString());
+          expect(answer.field!.valuedConverted, isNull);
+          expect(answer.impact!.id, 'field_ignored');
+          expect(answer.impact!.name, isNotNull);
+          expect(answer.impact!.lcName, isNotNull);
+          expect(answer.message!.id, 'invalid_type_must_be_number');
+          expect(answer.message!.name, isNotNull);
+          expect(answer.message!.lcName, isNotNull);
+        } else {
+          fail('Unexpected field id: ${answer.field!.id}');
         }
-      }, timeout: Timeout(Duration(seconds: 180)));
-    },
-    skip: 'frequent 504 Gateway Time-out in TEST',
-  );
+      }
+    }, timeout: Timeout(Duration(seconds: 180)));
+  });
 }

--- a/test/api_save_product_v3_test.dart
+++ b/test/api_save_product_v3_test.dart
@@ -8,8 +8,6 @@ void main() {
   OpenFoodAPIConfiguration.userAgent = TestConstants.TEST_USER_AGENT;
   const UriProductHelper uriHelper = uriHelperFoodTest;
 
-  const ProductQueryVersion version = ProductQueryVersion.testVersion;
-
   Future<ProductResultV3?> temporarySaveProductV3(
     final String barcode, {
     final List<ProductPackaging>? packagings,
@@ -109,43 +107,22 @@ void main() {
     test('save packagings_complete', () async {
       final List<bool> values = [false, true, false];
       for (final bool value in values) {
-        final ProductResultV3? writeStatus = await temporarySaveProductV3(
+        final ProductResultV3? status = await temporarySaveProductV3(
           barcode,
           country: country,
           language: language,
           packagingsComplete: value,
         );
-        if (writeStatus == null) {
+        if (status == null) {
           return;
         }
 
-        expect(writeStatus.status, ProductResultV3.statusSuccess);
-        expect(writeStatus.errors, isEmpty);
-        expect(writeStatus.result, isNull); // result is null for UPDATE queries
-        expect(writeStatus.barcode, barcode);
-        expect(writeStatus.product, isNotNull);
-        expect(writeStatus.product!.packagingsComplete, value);
-
-        // checking again...
-        final ProductResultV3 readStatus = await OpenFoodAPIClient.getProductV3(
-          ProductQueryConfiguration(
-            barcode,
-            language: language,
-            country: country,
-            version: version,
-            fields: [ProductField.BARCODE, ProductField.PACKAGINGS_COMPLETE],
-          ),
-          user: TestConstants.TEST_USER,
-          uriHelper: uriHelper,
-        );
-
-        expect(readStatus.status, ProductResultV3.statusSuccess);
-        expect(readStatus.errors, isEmpty);
-        expect(readStatus.result, isNotNull);
-        expect(readStatus.result!.id, ProductResultV3.resultProductFound);
-        expect(readStatus.barcode, barcode);
-        expect(readStatus.product, isNotNull);
-        expect(readStatus.product!.packagingsComplete, value);
+        expect(status.status, ProductResultV3.statusSuccess);
+        expect(status.errors, isEmpty);
+        expect(status.result, isNull); // result is null for UPDATE queries
+        expect(status.barcode, barcode);
+        expect(status.product, isNotNull);
+        expect(status.product!.packagingsComplete, value);
       }
     }, timeout: Timeout(Duration(seconds: 180)));
 

--- a/test/api_search_products_test.dart
+++ b/test/api_search_products_test.dart
@@ -516,7 +516,7 @@ void main() {
         const String originsTags = 'en:european-union-and-non-european-union';
         const String manufacturingPlaces = 'allemagne';
         const String purchasePlaces = 'france';
-        const String stores = 'franprix';
+        const String stores = 'leclerc';
         const String countries = 'en:france';
         const String allergens = 'en:gluten';
         const String traces = 'en:nuts';
@@ -524,8 +524,8 @@ void main() {
         const String states = 'en:nutrition-facts-completed';
         const String ingredients = 'en:cereal';
         const int novaGroup = 3;
-        const String languages = 'ar';
-        const String creator = 'sebleouf';
+        const String languages = 'fr';
+        const String creator = 'openfoodfacts-contributors';
         const String editors = 'foodrepo';
 
         final parameters = <Parameter>[
@@ -611,7 +611,7 @@ void main() {
           expect(product.brands!, brands);
           expect(product.categoriesTags, contains(categories));
           expect(product.labelsTags, contains(labels));
-          expect(product.storesTags, contains('Franprix'));
+          expect(product.storesTags, contains('Leclerc'));
           expect(product.countriesTags, contains(countries));
           expect(product.allergens!.ids, contains(allergens));
           expect(product.tracesTags, contains(traces));


### PR DESCRIPTION
### What
API 3.3 support:
* now we support both 3.3 and pre-3.3 image structure
* `unselectProductImage` now uses the 3.3 method

### Fixes bug(s)
- Closes: #1250

### Impacted files
* `api_add_product_image_test.dart`: added a test for image select/unselect
* `api_get_product_test.dart`: added a test specific to 3.3 images
* `api_get_save_product_test.dart`: minor unrelated fix
* `api_save_product_v3_test.dart`: unrelated minor fix
* `api_search_products_test.dart`: minor unrelated fix
* `json_helper.dart`: now managing both 3.3 and pre 3.3 image formats
* `open_food_api_client.dart`: `unselectProductImage` now uses the 3.3 method; related refactoring
* `product.dart`: minor refactoring
* `product_query_version.dart`: new 3.3 version