### PR TITLE
feat: 1252 - API 3.4 support

### DIFF
--- a/lib/openfoodfacts.dart
+++ b/lib/openfoodfacts.dart
@@ -152,6 +152,7 @@ export 'src/search/fuzziness.dart';
 export 'src/search/taxonomy_name.dart';
 export 'src/search/taxonomy_name_autocompleter.dart';
 export 'src/utils/abstract_query_configuration.dart';
+export 'src/utils/api_version.dart';
 export 'src/utils/autocomplete_manager.dart';
 export 'src/utils/autocompleter.dart';
 export 'src/utils/barcodes_validator.dart';

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -36,6 +36,7 @@ import 'model/taxonomy_packaging_shape.dart';
 import 'model/user.dart';
 import 'prices/maybe_error.dart';
 import 'utils/abstract_query_configuration.dart';
+import 'utils/api_version.dart';
 import 'utils/country_helper.dart';
 import 'utils/http_helper.dart';
 import 'utils/language_helper.dart';
@@ -166,6 +167,7 @@ class OpenFoodAPIClient {
     required final User user,
     final Map<String, dynamic> extraParameters = const <String, dynamic>{},
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ProductQueryVersion version = ProductQueryVersion.latestVersion,
   }) async {
     final Map<String, dynamic> parameterMap = <String, dynamic>{};
     parameterMap.addAll(user.toData());
@@ -173,7 +175,7 @@ class OpenFoodAPIClient {
     parameterMap['product'] = productParameters;
 
     var productUri = uriHelper.getPatchUri(
-      path: '/api/v3/product/${Uri.encodeComponent(barcode)}',
+      path: version.getApiPath('product/${Uri.encodeComponent(barcode)}'),
     );
 
     final Response response = await HttpHelper().doPatchRequest(
@@ -515,8 +517,9 @@ class OpenFoodAPIClient {
     TaxonomyQueryConfiguration<T, F> configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) async {
-    final Uri uri = configuration.getPostUri(uriHelper);
+    final Uri uri = configuration.getPostUri(uriHelper, version: version);
     final Response response = await HttpHelper().doPostRequest(
       uri,
       configuration.getParametersMap(),
@@ -793,6 +796,7 @@ class OpenFoodAPIClient {
     final String? shape,
     final int limit = 25,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ProductQueryVersion version = ProductQueryVersion.latestVersion,
     final User? user,
   }) async {
     final Map<String, String> queryParameters = <String, String>{
@@ -805,7 +809,7 @@ class OpenFoodAPIClient {
       'limit': limit.toString(),
     };
     final Uri uri = uriHelper.getUri(
-      path: '/api/v3/taxonomy_suggestions',
+      path: version.getApiPath('taxonomy_suggestions'),
       queryParameters: queryParameters,
     );
     final Response response = await HttpHelper().doGetRequest(
@@ -845,6 +849,7 @@ class OpenFoodAPIClient {
     required final List<String> localizedNames,
     required final OpenFoodFactsLanguage language,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ProductQueryVersion version = ProductQueryVersion.latestVersion,
   }) async {
     final List<String> input = _cleanTags(localizedNames);
     if (input.isEmpty) {
@@ -856,7 +861,7 @@ class OpenFoodAPIClient {
       'local_tags_list': input.join(','),
     };
     final Uri uri = uriHelper.getUri(
-      path: '/api/v3/taxonomy_canonicalize_tags',
+      path: version.getApiPath('taxonomy_canonicalize_tags'),
       queryParameters: queryParameters,
     );
     final Response response = await HttpHelper().doGetRequest(
@@ -901,6 +906,7 @@ class OpenFoodAPIClient {
     required final List<String> canonicalTags,
     required final OpenFoodFactsLanguage language,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ProductQueryVersion version = ProductQueryVersion.latestVersion,
   }) async {
     final List<String> input = _cleanTags(canonicalTags);
     if (input.isEmpty) {
@@ -912,7 +918,7 @@ class OpenFoodAPIClient {
       'canonical_tags_list': input.join(','),
     };
     final Uri uri = uriHelper.getUri(
-      path: '/api/v3/taxonomy_display_tags',
+      path: version.getApiPath('taxonomy_display_tags'),
       queryParameters: queryParameters,
     );
     final Response response = await HttpHelper().doGetRequest(
@@ -1394,11 +1400,11 @@ class OpenFoodAPIClient {
   /// Returns the list of all external source metadata.
   static Future<MaybeError<List<ExternalSourceMetadata>>>
   getExternalSourceMetadatas({
-    final ProductQueryVersion version = ProductQueryVersion.v3,
+    final ProductQueryVersion version = ProductQueryVersion.latestVersion,
     final UriProductHelper uriHelper = uriHelperFoodProd,
   }) async {
     final Response response = await HttpHelper().doGetRequest(
-      uriHelper.getUri(path: 'api/v${version.version}/external_sources'),
+      uriHelper.getUri(path: version.getApiPath('external_sources')),
       uriHelper: uriHelper,
     );
     if (response.statusCode != 200) {

--- a/lib/src/open_food_api_client.dart
+++ b/lib/src/open_food_api_client.dart
@@ -553,10 +553,12 @@ class OpenFoodAPIClient {
     TaxonomyPackagingShapeQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyPackagingShape, TaxonomyPackagingShapeField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyPackagingMaterial>?>
@@ -564,10 +566,12 @@ class OpenFoodAPIClient {
     TaxonomyPackagingMaterialQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyPackagingMaterial, TaxonomyPackagingMaterialField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyPackagingRecycling>?>
@@ -575,111 +579,133 @@ class OpenFoodAPIClient {
     TaxonomyPackagingRecyclingQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) =>
       getTaxonomy<TaxonomyPackagingRecycling, TaxonomyPackagingRecyclingField>(
         configuration,
         user: user,
         uriHelper: uriHelper,
+        version: version,
       );
 
   static Future<Map<String, TaxonomyNova>?> getTaxonomyNova(
     TaxonomyNovaQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyNova, TaxonomyNovaField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyCategory>?> getTaxonomyCategories(
     TaxonomyCategoryQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyCategory, TaxonomyCategoryField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyAdditive>?> getTaxonomyAdditives(
     TaxonomyAdditiveQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyAdditive, TaxonomyAdditiveField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyAllergen>?> getTaxonomyAllergens(
     TaxonomyAllergenQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyAllergen, TaxonomyAllergenField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyCountry>?> getTaxonomyCountries(
     TaxonomyCountryQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyCountry, TaxonomyCountryField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyIngredient>?> getTaxonomyIngredients(
     TaxonomyIngredientQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyIngredient, TaxonomyIngredientField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyLabel>?> getTaxonomyLabels(
     TaxonomyLabelQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyLabel, TaxonomyLabelField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyLanguage>?> getTaxonomyLanguages(
     TaxonomyLanguageQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyLanguage, TaxonomyLanguageField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyPackaging>?> getTaxonomyPackagings(
     final TaxonomyPackagingQueryConfiguration configuration, {
     final User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyPackaging, TaxonomyPackagingField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static Future<Map<String, TaxonomyOrigin>?> getTaxonomyOrigins(
     TaxonomyOriginQueryConfiguration configuration, {
     User? user,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = TaxonomyQueryConfiguration.defaultVersion,
   }) => getTaxonomy<TaxonomyOrigin, TaxonomyOriginField>(
     configuration,
     user: user,
     uriHelper: uriHelper,
+    version: version,
   );
 
   static void _removeImages(

--- a/lib/src/open_prices_api_client.dart
+++ b/lib/src/open_prices_api_client.dart
@@ -29,6 +29,7 @@ import 'prices/session.dart';
 import 'prices/update_price_parameters.dart';
 import 'prices/update_proof_parameters.dart';
 import 'prices/create_proof_parameters.dart';
+import 'utils/api_version.dart';
 import 'utils/http_helper.dart';
 import 'utils/open_food_api_configuration.dart';
 import 'utils/uri_helper.dart';
@@ -39,6 +40,8 @@ import 'utils/uri_reader.dart';
 /// cf. https://prices.openfoodfacts.org/api/docs
 class OpenPricesAPIClient {
   OpenPricesAPIClient._();
+
+  static const ApiVersion defaultVersion = ApiVersion(1);
 
   /// Status when the server is running (cf. [getStatus]).
   static const String statusRunning = 'running';
@@ -62,12 +65,26 @@ class OpenPricesAPIClient {
     addUserAgentParameters: addUserAgentParameters,
   );
 
+  static Uri getApiUri(
+    final String subpath, {
+    final Map<String, dynamic>? queryParameters,
+    required final UriProductHelper uriHelper,
+    required final ApiVersion version,
+  }) => getUri(
+    path: version.getApiPath(subpath),
+    queryParameters: queryParameters,
+    uriHelper: uriHelper,
+  );
+
   static Future<MaybeError<PriceUser>> getUser(
     final String username, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = OpenPricesAPIClient.getUri(
-      path: '/api/v1/users/${Uri.encodeComponent(username)}',
+    final Uri uri = getApiUri(
+      'users/${Uri.encodeComponent(username)}',
+      uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -87,12 +104,14 @@ class OpenPricesAPIClient {
   static Future<MaybeError<GetPricesResult>> getPrices(
     final GetPricesParameters parameters, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     final String? bearerToken,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/prices',
+    final Uri uri = getApiUri(
+      'prices',
       queryParameters: parameters.getQueryParameters(),
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -116,10 +135,12 @@ class OpenPricesAPIClient {
   static Future<MaybeError<Price>> getPrice(
     final int priceId, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/prices/$priceId',
+    final Uri uri = getApiUri(
+      'prices/$priceId',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -140,11 +161,12 @@ class OpenPricesAPIClient {
     required final int locationOSMId,
     required final LocationOSMType locationOSMType,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(
-      path:
-          '/api/v1/locations/osm/${Uri.encodeComponent(locationOSMType.offTag)}/$locationOSMId',
+    final Uri uri = getApiUri(
+      'locations/osm/${Uri.encodeComponent(locationOSMType.offTag)}/$locationOSMId',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -164,12 +186,14 @@ class OpenPricesAPIClient {
   static Future<MaybeError<GetLocationsResult>> getLocations(
     final GetLocationsParameters parameters, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     final String? bearerToken,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/locations',
+    final Uri uri = getApiUri(
+      'locations',
       queryParameters: parameters.getQueryParameters(),
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -192,10 +216,12 @@ class OpenPricesAPIClient {
   static Future<MaybeError<Location>> getLocation(
     final int locationId, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/locations/$locationId',
+    final Uri uri = getApiUri(
+      'locations/$locationId',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -215,11 +241,13 @@ class OpenPricesAPIClient {
   static Future<MaybeError<GetChallengesResult>> getChallenges(
     final GetChallengesParameters parameters, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/challenges',
+    final Uri uri = getApiUri(
+      'challenges',
       queryParameters: parameters.getQueryParameters(),
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -241,10 +269,12 @@ class OpenPricesAPIClient {
   static Future<MaybeError<Challenge>> getChallenge(
     final int challengeId, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/challenges/$challengeId',
+    final Uri uri = getApiUri(
+      'challenges/$challengeId',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -264,12 +294,14 @@ class OpenPricesAPIClient {
   static Future<MaybeError<GetPriceProductsResult>> getPriceProducts(
     final GetPriceProductsParameters parameters, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     final String? bearerToken,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/products',
+    final Uri uri = getApiUri(
+      'products',
       queryParameters: parameters.getQueryParameters(),
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -292,10 +324,12 @@ class OpenPricesAPIClient {
   static Future<MaybeError<PriceProduct>> getPriceProductById(
     final int productId, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/products/$productId',
+    final Uri uri = getApiUri(
+      'products/$productId',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -317,10 +351,12 @@ class OpenPricesAPIClient {
   static Future<MaybeError<PriceProduct>> getPriceProductByCode(
     final String productCode, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/products/code/${Uri.encodeComponent(productCode)}',
+    final Uri uri = getApiUri(
+      'products/code/${Uri.encodeComponent(productCode)}',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -345,8 +381,9 @@ class OpenPricesAPIClient {
   /// cf. https://prices.openfoodfacts.org/api/docs#/default/status_endpoint_api_v1_status_get
   static Future<MaybeError<String>> getStatus({
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(path: '/api/v1/status', uriHelper: uriHelper);
+    final Uri uri = getApiUri('status', uriHelper: uriHelper, version: version);
     final Response response = await HttpHelper().doGetRequest(
       uri,
       uriHelper: uriHelper,
@@ -375,10 +412,12 @@ class OpenPricesAPIClient {
     required final String password,
     final bool setCookie = false,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/auth${setCookie ? '?set_cookie=1' : ''}',
+    final Uri uri = getApiUri(
+      'auth${setCookie ? '?set_cookie=1' : ''}',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await post(
       uri,
@@ -398,9 +437,14 @@ class OpenPricesAPIClient {
   /// Returns the session details related to this [bearerToken].
   static Future<MaybeError<Session>> getUserSession({
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     required final String bearerToken,
   }) async {
-    final Uri uri = getUri(path: '/api/v1/session', uriHelper: uriHelper);
+    final Uri uri = getApiUri(
+      'session',
+      uriHelper: uriHelper,
+      version: version,
+    );
     final Response response = await HttpHelper().doGetRequest(
       uri,
       uriHelper: uriHelper,
@@ -422,9 +466,14 @@ class OpenPricesAPIClient {
   /// Returns true if successful.
   static Future<MaybeError<bool>> deleteUserSession({
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     required final String bearerToken,
   }) async {
-    final Uri uri = getUri(path: '/api/v1/session', uriHelper: uriHelper);
+    final Uri uri = getApiUri(
+      'session',
+      uriHelper: uriHelper,
+      version: version,
+    );
     final Response response = await HttpHelper().doDeleteRequest(
       uri,
       uriHelper: uriHelper,
@@ -445,8 +494,9 @@ class OpenPricesAPIClient {
     required final Price price,
     required final String bearerToken,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(path: '/api/v1/prices', uriHelper: uriHelper);
+    final Uri uri = getApiUri('prices', uriHelper: uriHelper, version: version);
     final Map<String, dynamic> body = <String, dynamic>{
       'price': price.price,
       'currency': price.currency.name,
@@ -498,11 +548,13 @@ class OpenPricesAPIClient {
     final int priceId, {
     required final UpdatePriceParameters parameters,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     required final String bearerToken,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/prices/$priceId',
+    final Uri uri = getApiUri(
+      'prices/$priceId',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doPatchRequest(
       uri,
@@ -524,11 +576,13 @@ class OpenPricesAPIClient {
   static Future<MaybeError<bool>> deletePrice({
     required final int priceId,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     required final String bearerToken,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/prices/$priceId',
+    final Uri uri = getApiUri(
+      'prices/$priceId',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doDeleteRequest(
       uri,
@@ -545,12 +599,14 @@ class OpenPricesAPIClient {
   static Future<MaybeError<GetProofsResult>> getProofs(
     final GetProofsParameters parameters, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     required final String bearerToken,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/proofs',
+    final Uri uri = getApiUri(
+      'proofs',
       queryParameters: parameters.getQueryParameters(),
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -582,8 +638,13 @@ class OpenPricesAPIClient {
     required final CreateProofParameters createProofParameters,
     required final String bearerToken,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(path: '/api/v1/proofs/upload', uriHelper: uriHelper);
+    final Uri uri = getApiUri(
+      'proofs/upload',
+      uriHelper: uriHelper,
+      version: version,
+    );
 
     final MultipartRequest request = MultipartRequest('POST', uri);
     request.headers.addAll({
@@ -628,11 +689,13 @@ class OpenPricesAPIClient {
   static Future<MaybeError<Proof>> getProof(
     final int proofId, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     required final String bearerToken,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/proofs/$proofId',
+    final Uri uri = getApiUri(
+      'proofs/$proofId',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -658,11 +721,13 @@ class OpenPricesAPIClient {
     final int proofId, {
     required final UpdateProofParameters parameters,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     required final String bearerToken,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/proofs/$proofId',
+    final Uri uri = getApiUri(
+      'proofs/$proofId',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doPatchRequest(
       uri,
@@ -687,11 +752,13 @@ class OpenPricesAPIClient {
   static Future<MaybeError<bool>> deleteProof({
     required final int proofId,
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     required final String bearerToken,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/proofs/$proofId',
+    final Uri uri = getApiUri(
+      'proofs/$proofId',
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doDeleteRequest(
       uri,
@@ -707,12 +774,14 @@ class OpenPricesAPIClient {
   static Future<MaybeError<GetUsersResult>> getUsers(
     final GetUsersParameters parameters, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
     final String? bearerToken,
   }) async {
-    final Uri uri = getUri(
-      path: '/api/v1/users',
+    final Uri uri = getApiUri(
+      'users',
       queryParameters: parameters.getQueryParameters(),
       uriHelper: uriHelper,
+      version: version,
     );
     final Response response = await HttpHelper().doGetRequest(
       uri,
@@ -735,8 +804,9 @@ class OpenPricesAPIClient {
   /// Returns the total stats.
   static Future<MaybeError<PriceTotalStats>> getStats({
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    final Uri uri = getUri(path: '/api/v1/stats', uriHelper: uriHelper);
+    final Uri uri = getApiUri('stats', uriHelper: uriHelper, version: version);
     final Response response = await HttpHelper().doGetRequest(
       uri,
       uriHelper: uriHelper,

--- a/lib/src/personalized_search/available_attribute_groups.dart
+++ b/lib/src/personalized_search/available_attribute_groups.dart
@@ -1,6 +1,7 @@
 import '../model/attribute_group.dart';
 import '../utils/http_helper.dart';
 import '../utils/open_food_api_configuration.dart';
+import '../utils/product_query_version.dart';
 import '../utils/uri_helper.dart';
 
 /// Referential of attribute groups, with loader.
@@ -53,8 +54,9 @@ class AvailableAttributeGroups {
   static Uri getUri(
     final String languageCode, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ProductQueryVersion version = ProductQueryVersion.latestVersion,
   }) => uriHelper.getUri(
-    path: '/api/v3.4/attribute_groups',
+    path: version.getApiPath('attribute_groups'),
     queryParameters: {'lc': languageCode},
   );
 }

--- a/lib/src/personalized_search/available_preference_importances.dart
+++ b/lib/src/personalized_search/available_preference_importances.dart
@@ -1,6 +1,7 @@
 import 'preference_importance.dart';
 import '../utils/http_helper.dart';
 import '../utils/open_food_api_configuration.dart';
+import '../utils/product_query_version.dart';
 import '../utils/uri_helper.dart';
 
 /// Referential of preference importance, with loader.
@@ -63,6 +64,7 @@ class AvailablePreferenceImportances {
   }
 
   List<String>? _importanceIds;
+
   List<String>? get importanceIds => _importanceIds;
   Map<String, PreferenceImportance>? _preferenceImportances;
   Map<String, int>? _importancesReverseIds;
@@ -72,8 +74,9 @@ class AvailablePreferenceImportances {
   static Uri getUri(
     final String languageCode, {
     final UriProductHelper uriHelper = uriHelperFoodProd,
+    final ProductQueryVersion version = ProductQueryVersion.latestVersion,
   }) => uriHelper.getUri(
-    path: '/api/v3.4/preferences',
+    path: version.getApiPath('preferences'),
     queryParameters: {'lc': languageCode},
   );
 

--- a/lib/src/robot_off_api_client.dart
+++ b/lib/src/robot_off_api_client.dart
@@ -8,6 +8,7 @@ import 'model/robotoff_question_order.dart';
 import 'model/robotoff_nutrient_extraction.dart';
 import 'model/status.dart';
 import 'model/user.dart';
+import 'utils/api_version.dart';
 import 'utils/country_helper.dart';
 import 'utils/http_helper.dart';
 import 'utils/http_status_exception.dart';
@@ -19,6 +20,18 @@ import 'utils/uri_helper.dart';
 class RobotoffAPIClient {
   RobotoffAPIClient._();
 
+  static const ApiVersion defaultVersion = ApiVersion(1);
+
+  static Uri getApiUri(
+    final String subpath, {
+    final Map<String, dynamic>? queryParameters,
+    required final UriHelper uriHelper,
+    required final ApiVersion version,
+  }) => uriHelper.getUri(
+    path: version.getApiPath(subpath),
+    queryParameters: queryParameters,
+  );
+
   static Future<InsightsResult> getRandomInsights({
     InsightType? type,
     Iterable<OpenFoodFactsCountry>? countries,
@@ -26,6 +39,7 @@ class RobotoffAPIClient {
     ServerType? serverType,
     int? count,
     final UriHelper uriHelper = uriHelperRobotoffProd,
+    final ApiVersion version = defaultVersion,
   }) async {
     final Map<String, String> parameters = {
       if (type != null) 'type': type.offTag,
@@ -36,9 +50,11 @@ class RobotoffAPIClient {
       if (serverType != null) 'server_type': serverType.offTag,
     };
 
-    var insightUri = uriHelper.getUri(
-      path: 'api/v1/insights/random/',
+    final insightUri = getApiUri(
+      'insights/random',
       queryParameters: parameters,
+      uriHelper: uriHelper,
+      version: version,
     );
 
     Response response = await HttpHelper().doGetRequest(
@@ -57,14 +73,17 @@ class RobotoffAPIClient {
     String barcode, {
     ServerType? serverType,
     final UriHelper uriHelper = uriHelperRobotoffProd,
+    final ApiVersion version = defaultVersion,
   }) async {
     final Map<String, String> parameters = <String, String>{
       if (serverType != null) 'server_type': serverType.offTag,
     };
 
-    var insightsUri = uriHelper.getUri(
-      path: 'api/v1/insights/${Uri.encodeComponent(barcode)}',
+    final insightsUri = getApiUri(
+      'insights/${Uri.encodeComponent(barcode)}',
       queryParameters: parameters,
+      uriHelper: uriHelper,
+      version: version,
     );
 
     Response response = await HttpHelper().doGetRequest(
@@ -85,6 +104,7 @@ class RobotoffAPIClient {
     int? count,
     ServerType? serverType,
     final UriHelper uriHelper = uriHelperRobotoffProd,
+    final ApiVersion version = defaultVersion,
     List<InsightType>? insightTypes,
   }) async {
     final Map<String, String> parameters = <String, String>{
@@ -97,9 +117,11 @@ class RobotoffAPIClient {
             .join(','),
     };
 
-    var robotoffQuestionUri = uriHelper.getUri(
-      path: 'api/v1/questions/${Uri.encodeComponent(barcode)}',
+    final robotoffQuestionUri = getApiUri(
+      'questions/${Uri.encodeComponent(barcode)}',
       queryParameters: parameters,
+      uriHelper: uriHelper,
+      version: version,
     );
 
     Response response = await HttpHelper().doGetRequest(
@@ -136,6 +158,7 @@ class RobotoffAPIClient {
     ServerType? serverType,
     String? valueTag,
     final UriHelper uriHelper = uriHelperRobotoffProd,
+    final ApiVersion version = defaultVersion,
   }) async {
     final List<String> insightValues = [];
     if (insightTypes != null) {
@@ -158,9 +181,11 @@ class RobotoffAPIClient {
       'value_tag': ?valueTag,
     };
 
-    var robotoffQuestionUri = uriHelper.getUri(
-      path: 'api/v1/questions',
+    final robotoffQuestionUri = getApiUri(
+      'questions',
       queryParameters: parameters,
+      uriHelper: uriHelper,
+      version: version,
     );
 
     final Response response = await HttpHelper().doGetRequest(
@@ -190,8 +215,13 @@ class RobotoffAPIClient {
     String? deviceId,
     bool update = true,
     final UriHelper uriHelper = uriHelperRobotoffProd,
+    final ApiVersion version = defaultVersion,
   }) async {
-    var insightUri = uriHelper.getUri(path: 'api/v1/insights/annotate');
+    final insightUri = getApiUri(
+      'insights/annotate',
+      uriHelper: uriHelper,
+      version: version,
+    );
 
     final Map<String, String> annotationData = {
       'annotation': annotation.value.toString(),
@@ -217,15 +247,18 @@ class RobotoffAPIClient {
   static Future<RobotoffNutrientExtractionResult> getNutrientExtraction(
     final String barcode, {
     final UriHelper uriHelper = uriHelperRobotoffProd,
+    final ApiVersion version = defaultVersion,
   }) async {
     final Map<String, String> parameters = <String, String>{
       'barcode': barcode,
       'insight_types': 'nutrient_extraction',
     };
 
-    final Uri uri = uriHelper.getUri(
-      path: '/api/v1/insights',
+    final Uri uri = getApiUri(
+      'insights',
       queryParameters: parameters,
+      uriHelper: uriHelper,
+      version: version,
     );
 
     final response = await HttpHelper().doGetRequest(uri, uriHelper: uriHelper);

--- a/lib/src/utils/api_version.dart
+++ b/lib/src/utils/api_version.dart
@@ -1,0 +1,8 @@
+/// Api version.
+class ApiVersion {
+  const ApiVersion(this.version);
+
+  final num version;
+
+  String getApiPath(final String subpath) => 'api/v$version/$subpath';
+}

--- a/lib/src/utils/product_query_configurations.dart
+++ b/lib/src/utils/product_query_configurations.dart
@@ -50,7 +50,8 @@ class ProductQueryConfiguration extends AbstractQueryConfiguration {
   bool matchesV3() => true;
 
   @override
-  String getUriPath() => version.getPath(barcode);
+  String getUriPath() =>
+      version.getApiPath('product/${Uri.encodeComponent(barcode)}');
 
   @override
   Future<Response> getResponse(

--- a/lib/src/utils/product_query_version.dart
+++ b/lib/src/utils/product_query_version.dart
@@ -1,13 +1,13 @@
 import 'package:meta/meta.dart';
 
+import 'api_version.dart';
+
 /// Api version for product queries (minimum forced version number: 3).
 ///
 /// cf. https://openfoodfacts.github.io/openfoodfacts-server/api/ref-api-and-product-schema-change-log/
-class ProductQueryVersion {
+class ProductQueryVersion extends ApiVersion {
   const ProductQueryVersion(final num version)
-    : version = version < 3 ? 3 : version;
-
-  final num version;
+    : super(version < 3 ? 3 : version);
 
   // TODO: deprecated from 2026-06-25; remove when old enough
   @Deprecated('Use ProductQueryVersion.latestVersion instead')
@@ -21,12 +21,18 @@ class ProductQueryVersion {
   @Deprecated('Use ProductQueryVersion.latestVersion instead')
   static const ProductQueryVersion v3_2 = ProductQueryVersion(3.2);
 
+  // TODO: deprecated from 2026-07-27; remove when old enough
+  @Deprecated('Use ProductQueryVersion.latestVersion instead')
   static const ProductQueryVersion v3_3 = ProductQueryVersion(3.3);
 
-  static const ProductQueryVersion latestVersion = v3_3;
+  static const ProductQueryVersion v3_4 = ProductQueryVersion(3.4);
 
+  static const ProductQueryVersion latestVersion = v3_4;
+
+  // TODO: deprecated from 2026-07-27; remove when old enough
+  @Deprecated('Source of confusion. Use getApiPath instead.')
   String getPath(final String barcode) =>
-      '/api/v$version/product/${Uri.encodeComponent(barcode)}/';
+      getApiPath('product/${Uri.encodeComponent(barcode)}/');
 
   // TODO: deprecated from 2026-07-09; remove when old enough
   @Deprecated('Minimum version is now 3')
@@ -38,6 +44,9 @@ class ProductQueryVersion {
 
   int? get schemaVersion => switch (version) {
     3.1 => 1000,
+    3.2 => 1001,
+    3.3 => 1002,
+    3.4 => 1002,
     _ => null,
   };
 }

--- a/lib/src/utils/taxonomy_query_configuration.dart
+++ b/lib/src/utils/taxonomy_query_configuration.dart
@@ -1,5 +1,6 @@
 import '../interface/json_object.dart';
 import '../interface/parameter.dart';
+import 'api_version.dart';
 import 'country_helper.dart';
 import 'language_helper.dart';
 import 'tag_type.dart';
@@ -86,6 +87,8 @@ abstract class TaxonomyQueryConfiguration<
            OpenFoodAPIConfiguration.globalLanguages ??
            const <OpenFoodFactsLanguage>[];
 
+  static const ApiVersion defaultVersion = ApiVersion(2);
+
   /// Returns the corresponding API URI parameter map, including
   /// [additionalParameters].
   Map<String, String> getParametersMap() {
@@ -124,8 +127,10 @@ abstract class TaxonomyQueryConfiguration<
     return result;
   }
 
-  Uri getPostUri(final UriProductHelper uriHelper) =>
-      uriHelper.getPostUri(path: 'api/v2/taxonomy');
+  Uri getPostUri(
+    final UriProductHelper uriHelper, {
+    final ApiVersion version = defaultVersion,
+  }) => uriHelper.getPostUri(path: version.getApiPath('taxonomy'));
 
   /// Returns the set of fields to ignore if specified in the [fields] parameter.
   ///


### PR DESCRIPTION
### What
Actually, we already used specifically version 3.4 for its added value: product attribute parameters.
No big change on that part: we use 3.4 implicitly everywhere, not just for product attribute parameters.
But that was a good opportunity to refactor around the api versions, including price, robotoff and taxonomy.

### Fixes bug(s)
- Closes: #1252

### Files
New file:
* `api_version.dart`: Api version.

Impacted files:
* `available_attribute_groups.dart`: now using an API version
* `available_preference_importances.dart`: now using an API version
* `open_food_api_client.dart`: minor refactoring
* `open_prices_api_client.dart`: now using an API version
* `openfoodfacts.dart`: added new file `api_version.dart`
* `product_query_configurations.dart`: minor refactoring
* `product_query_version.dart`: now extending new class `ApiVersion`; upgrade to API 3.4
* `robot_off_api_client.dart`: now using an API version
* `taxonomy_query_configuration.dart`: now using an API version