### PR TITLE
fix: 1271 - new super mandatory syntax

### DIFF
--- a/lib/src/model/taxonomy_additive.dart
+++ b/lib/src/model/taxonomy_additive.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -322,19 +320,12 @@ class TaxonomyAdditiveQueryConfiguration
 
   /// Configuration to get the root additives
   TaxonomyAdditiveQueryConfiguration.roots({
-    final List<OpenFoodFactsLanguage>? languages,
-    final OpenFoodFactsCountry? country,
-    final bool includeChildren = false,
-    final List<TaxonomyAdditiveField> fields = const [],
-    final List<Parameter> additionalParameters = const [],
-  }) : super.roots(
-         TagType.ADDITIVES,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.includeChildren = false,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super.roots(TagType.ADDITIVES);
 
   @override
   Map<String, TaxonomyAdditive> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_additive.dart
+++ b/lib/src/model/taxonomy_additive.dart
@@ -314,19 +314,11 @@ class TaxonomyAdditiveQueryConfiguration
   /// Configuration to get additives from their tags
   TaxonomyAdditiveQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyAdditiveField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super(
-         TagType.ADDITIVES,
-         tags,
-         languages: languages,
-         country: country,
-         includeChildren: false,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super(TagType.ADDITIVES, tags, includeChildren: false);
 
   /// Configuration to get the root additives
   TaxonomyAdditiveQueryConfiguration.roots({

--- a/lib/src/model/taxonomy_allergen.dart
+++ b/lib/src/model/taxonomy_allergen.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -80,17 +78,11 @@ class TaxonomyAllergenQueryConfiguration
 
   /// Configuration to get ALL the allergens.
   TaxonomyAllergenQueryConfiguration.all({
-    final List<OpenFoodFactsLanguage>? languages,
-    final OpenFoodFactsCountry? country,
-    final List<TaxonomyAllergenField> fields = const [],
-    final List<Parameter> additionalParameters = const [],
-  }) : super.roots(
-         TagType.ALLERGENS,
-         languages: languages,
-         country: country,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super.roots(TagType.ALLERGENS);
 
   @override
   Map<String, TaxonomyAllergen> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_allergen.dart
+++ b/lib/src/model/taxonomy_allergen.dart
@@ -72,18 +72,11 @@ class TaxonomyAllergenQueryConfiguration
   /// Configuration to get the allergens that match the [tags].
   TaxonomyAllergenQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyAllergenField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super(
-         TagType.ALLERGENS,
-         tags,
-         languages: languages,
-         country: country,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super(TagType.ALLERGENS, tags);
 
   /// Configuration to get ALL the allergens.
   TaxonomyAllergenQueryConfiguration.all({

--- a/lib/src/model/taxonomy_category.dart
+++ b/lib/src/model/taxonomy_category.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -308,19 +306,12 @@ class TaxonomyCategoryQueryConfiguration
   }) : super(TagType.CATEGORIES, tags);
 
   TaxonomyCategoryQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    bool includeChildren = false,
-    List<TaxonomyCategoryField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super.roots(
-         TagType.CATEGORIES,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.includeChildren = false,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super.roots(TagType.CATEGORIES);
 
   @override
   Map<String, TaxonomyCategory> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_category.dart
+++ b/lib/src/model/taxonomy_category.dart
@@ -300,20 +300,12 @@ class TaxonomyCategoryQueryConfiguration
         TaxonomyQueryConfiguration<TaxonomyCategory, TaxonomyCategoryField> {
   TaxonomyCategoryQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    bool includeChildren = false,
-    List<TaxonomyCategoryField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super(
-         TagType.CATEGORIES,
-         tags,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.includeChildren = false,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super(TagType.CATEGORIES, tags);
 
   TaxonomyCategoryQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages,

--- a/lib/src/model/taxonomy_country.dart
+++ b/lib/src/model/taxonomy_country.dart
@@ -100,19 +100,11 @@ class TaxonomyCountryQueryConfiguration
   /// Configuration to get the countries that match the [tags].
   TaxonomyCountryQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyCountryField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super(
-         TagType.COUNTRIES,
-         tags,
-         languages: languages,
-         country: country,
-         includeChildren: false,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super(TagType.COUNTRIES, tags, includeChildren: false);
 
   /// Configuration to get ALL the countries.
   TaxonomyCountryQueryConfiguration.all({

--- a/lib/src/model/taxonomy_country.dart
+++ b/lib/src/model/taxonomy_country.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -108,17 +106,11 @@ class TaxonomyCountryQueryConfiguration
 
   /// Configuration to get ALL the countries.
   TaxonomyCountryQueryConfiguration.all({
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyCountryField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super.roots(
-         TagType.COUNTRIES,
-         languages: languages,
-         country: country,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super.roots(TagType.COUNTRIES);
 
   @override
   Map<String, TaxonomyCountry> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_ingredient.dart
+++ b/lib/src/model/taxonomy_ingredient.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -444,19 +442,12 @@ class TaxonomyIngredientQueryConfiguration
   }) : super(TagType.INGREDIENTS, tags);
 
   TaxonomyIngredientQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyIngredientField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-    bool includeChildren = false,
-  }) : super.roots(
-         TagType.INGREDIENTS,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+    super.includeChildren = false,
+  }) : super.roots(TagType.INGREDIENTS);
 
   @override
   Map<String, TaxonomyIngredient> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_ingredient.dart
+++ b/lib/src/model/taxonomy_ingredient.dart
@@ -436,20 +436,12 @@ class TaxonomyIngredientQueryConfiguration
         > {
   TaxonomyIngredientQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyIngredientField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-    bool includeChildren = false,
-  }) : super(
-         TagType.INGREDIENTS,
-         tags,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+    super.includeChildren = false,
+  }) : super(TagType.INGREDIENTS, tags);
 
   TaxonomyIngredientQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages,

--- a/lib/src/model/taxonomy_label.dart
+++ b/lib/src/model/taxonomy_label.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -259,18 +257,11 @@ class TaxonomyLabelQueryConfiguration
   }) : super(TagType.LABELS, tags, includeChildren: false);
 
   TaxonomyLabelQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyLabelField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super.roots(
-         TagType.LABELS,
-         languages: languages,
-         country: country,
-         includeChildren: false,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super.roots(TagType.LABELS, includeChildren: false);
 
   @override
   Map<String, TaxonomyLabel> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_label.dart
+++ b/lib/src/model/taxonomy_label.dart
@@ -252,19 +252,11 @@ class TaxonomyLabelQueryConfiguration
     extends TaxonomyQueryConfiguration<TaxonomyLabel, TaxonomyLabelField> {
   TaxonomyLabelQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyLabelField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super(
-         TagType.LABELS,
-         tags,
-         languages: languages,
-         country: country,
-         includeChildren: false,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super(TagType.LABELS, tags, includeChildren: false);
 
   TaxonomyLabelQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages,

--- a/lib/src/model/taxonomy_language.dart
+++ b/lib/src/model/taxonomy_language.dart
@@ -85,18 +85,11 @@ class TaxonomyLanguageQueryConfiguration
   /// Configuration to get the languages that match the [tags].
   TaxonomyLanguageQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyLanguageField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super(
-         TagType.LANGUAGES,
-         tags,
-         languages: languages,
-         country: country,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super(TagType.LANGUAGES, tags);
 
   /// Configuration to get ALL the languages.
   TaxonomyLanguageQueryConfiguration.all({

--- a/lib/src/model/taxonomy_language.dart
+++ b/lib/src/model/taxonomy_language.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -93,17 +91,11 @@ class TaxonomyLanguageQueryConfiguration
 
   /// Configuration to get ALL the languages.
   TaxonomyLanguageQueryConfiguration.all({
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyLanguageField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super.roots(
-         TagType.LANGUAGES,
-         languages: languages,
-         country: country,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super.roots(TagType.LANGUAGES);
 
   @override
   Map<String, TaxonomyLanguage> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_nova.dart
+++ b/lib/src/model/taxonomy_nova.dart
@@ -1,7 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -64,17 +63,13 @@ class TaxonomyNova extends JsonObject {
 /// Configuration for nova API query.
 class TaxonomyNovaQueryConfiguration
     extends TaxonomyQueryConfiguration<TaxonomyNova, TaxonomyNovaField> {
-  TaxonomyNovaQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-  }) : super.roots(
-         TagType.NOVA,
-         languages: languages,
-         country: country,
-         includeChildren: false,
-         fields: const [],
-         additionalParameters: const [],
-       );
+  TaxonomyNovaQueryConfiguration.roots({super.languages, super.country})
+    : super.roots(
+        TagType.NOVA,
+        includeChildren: false,
+        fields: const [],
+        additionalParameters: const [],
+      );
 
   @override
   Map<String, TaxonomyNova> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_origin.dart
+++ b/lib/src/model/taxonomy_origin.dart
@@ -81,20 +81,12 @@ class TaxonomyOriginQueryConfiguration
   /// Configuration to get the origins that match the [tags].
   TaxonomyOriginQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyOriginField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-    bool includeChildren = false,
-  }) : super(
-         TagType.ORIGINS,
-         tags,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+    super.includeChildren = false,
+  }) : super(TagType.ORIGINS, tags);
 
   TaxonomyOriginQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages,

--- a/lib/src/model/taxonomy_origin.dart
+++ b/lib/src/model/taxonomy_origin.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -89,19 +87,12 @@ class TaxonomyOriginQueryConfiguration
   }) : super(TagType.ORIGINS, tags);
 
   TaxonomyOriginQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyOriginField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-    bool includeChildren = false,
-  }) : super.roots(
-         TagType.ORIGINS,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+    super.includeChildren = false,
+  }) : super.roots(TagType.ORIGINS);
 
   @override
   Map<String, TaxonomyOrigin> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_packaging.dart
+++ b/lib/src/model/taxonomy_packaging.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -91,17 +89,11 @@ class TaxonomyPackagingQueryConfiguration
 
   /// Configuration to get the root packagings.
   TaxonomyPackagingQueryConfiguration.roots({
-    final List<OpenFoodFactsLanguage>? languages,
-    final OpenFoodFactsCountry? country,
-    final List<TaxonomyPackagingField> fields = const [],
-    final List<Parameter> additionalParameters = const [],
-  }) : super.roots(
-         TagType.PACKAGING,
-         languages: languages,
-         country: country,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super.roots(TagType.PACKAGING);
 
   @override
   Map<String, TaxonomyPackaging> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_packaging.dart
+++ b/lib/src/model/taxonomy_packaging.dart
@@ -83,18 +83,11 @@ class TaxonomyPackagingQueryConfiguration
   /// Configuration to get the packagings that match the [tags].
   TaxonomyPackagingQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyPackagingField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-  }) : super(
-         TagType.PACKAGING,
-         tags,
-         languages: languages,
-         country: country,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+  }) : super(TagType.PACKAGING, tags);
 
   /// Configuration to get the root packagings.
   TaxonomyPackagingQueryConfiguration.roots({

--- a/lib/src/model/taxonomy_packaging_material.dart
+++ b/lib/src/model/taxonomy_packaging_material.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -83,19 +81,12 @@ class TaxonomyPackagingMaterialQueryConfiguration
   }) : super(TagType.PACKAGING_MATERIALS, tags);
 
   TaxonomyPackagingMaterialQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyPackagingMaterialField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-    bool includeChildren = false,
-  }) : super.roots(
-         TagType.PACKAGING_MATERIALS,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+    super.includeChildren = false,
+  }) : super.roots(TagType.PACKAGING_MATERIALS);
 
   @override
   Map<String, TaxonomyPackagingMaterial> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_packaging_material.dart
+++ b/lib/src/model/taxonomy_packaging_material.dart
@@ -75,20 +75,12 @@ class TaxonomyPackagingMaterialQueryConfiguration
   /// Configuration to get the packaging materials that match the [tags].
   TaxonomyPackagingMaterialQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyPackagingMaterialField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-    bool includeChildren = false,
-  }) : super(
-         TagType.PACKAGING_MATERIALS,
-         tags,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+    super.includeChildren = false,
+  }) : super(TagType.PACKAGING_MATERIALS, tags);
 
   TaxonomyPackagingMaterialQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages,

--- a/lib/src/model/taxonomy_packaging_recycling.dart
+++ b/lib/src/model/taxonomy_packaging_recycling.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -101,19 +99,12 @@ class TaxonomyPackagingRecyclingQueryConfiguration
   }) : super(TagType.PACKAGING_RECYCLING, tags);
 
   TaxonomyPackagingRecyclingQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyPackagingRecyclingField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-    bool includeChildren = false,
-  }) : super.roots(
-         TagType.PACKAGING_RECYCLING,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+    super.includeChildren = false,
+  }) : super.roots(TagType.PACKAGING_RECYCLING);
 
   @override
   Map<String, TaxonomyPackagingRecycling> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_packaging_recycling.dart
+++ b/lib/src/model/taxonomy_packaging_recycling.dart
@@ -93,20 +93,12 @@ class TaxonomyPackagingRecyclingQueryConfiguration
   /// Configuration to get the packaging recycling that match the [tags].
   TaxonomyPackagingRecyclingQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyPackagingRecyclingField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-    bool includeChildren = false,
-  }) : super(
-         TagType.PACKAGING_RECYCLING,
-         tags,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+    super.includeChildren = false,
+  }) : super(TagType.PACKAGING_RECYCLING, tags);
 
   TaxonomyPackagingRecyclingQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages,

--- a/lib/src/model/taxonomy_packaging_shape.dart
+++ b/lib/src/model/taxonomy_packaging_shape.dart
@@ -1,8 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'off_tagged.dart';
 import '../interface/json_object.dart';
-import '../interface/parameter.dart';
-import '../utils/country_helper.dart';
 import '../utils/language_helper.dart';
 import '../utils/taxonomy_query_configuration.dart';
 import '../utils/tag_type.dart';
@@ -83,19 +81,12 @@ class TaxonomyPackagingShapeQueryConfiguration
   }) : super(TagType.PACKAGING_SHAPES, tags);
 
   TaxonomyPackagingShapeQueryConfiguration.roots({
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyPackagingShapeField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-    bool includeChildren = false,
-  }) : super.roots(
-         TagType.PACKAGING_SHAPES,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+    super.includeChildren = false,
+  }) : super.roots(TagType.PACKAGING_SHAPES);
 
   @override
   Map<String, TaxonomyPackagingShape> convertResults(dynamic jsonData) {

--- a/lib/src/model/taxonomy_packaging_shape.dart
+++ b/lib/src/model/taxonomy_packaging_shape.dart
@@ -75,20 +75,12 @@ class TaxonomyPackagingShapeQueryConfiguration
   /// Configuration to get the packaging shapes that match the [tags].
   TaxonomyPackagingShapeQueryConfiguration({
     required List<String> tags,
-    List<OpenFoodFactsLanguage>? languages,
-    OpenFoodFactsCountry? country,
-    List<TaxonomyPackagingShapeField> fields = const [],
-    List<Parameter> additionalParameters = const [],
-    bool includeChildren = false,
-  }) : super(
-         TagType.PACKAGING_SHAPES,
-         tags,
-         languages: languages,
-         country: country,
-         includeChildren: includeChildren,
-         fields: fields,
-         additionalParameters: additionalParameters,
-       );
+    super.languages,
+    super.country,
+    super.fields = const [],
+    super.additionalParameters = const [],
+    super.includeChildren = false,
+  }) : super(TagType.PACKAGING_SHAPES, tags);
 
   TaxonomyPackagingShapeQueryConfiguration.roots({
     List<OpenFoodFactsLanguage>? languages,


### PR DESCRIPTION
### What
- The recent "super.field" syntax is now mandatory.

### Fixes bug(s)
- Fixes: #1271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified taxonomy query configuration constructors by using Dart’s superclass parameter forwarding.
  * Preserved existing parameter types, defaults, supported options, and query behavior.
  * No changes to serialization or user-visible functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->